### PR TITLE
feat(hub): implement hub registry for components and targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ SRC = \
 	$(NAME)-running.c \
 	$(NAME)-window-list.c \
 	$(NAME)-clients.c \
+	$(NAME)-hub.c \
 	$(NAME)-xcb-ewmh.c \
 	$(NAME)-xcb-events.c \
 	$(NAME)-states.c \
@@ -34,7 +35,8 @@ SRC = \
 OBJ = ${SRC:.c=.o}
 
 TEST_SRC = \
-	test-$(NAME)-window-list.c
+	test-$(NAME)-window-list.c \
+	test-$(NAME)-hub.c
 
 TEST_OBJ = ${TEST_SRC:.c=.o}
 

--- a/docs/GRILL-ME-PROMPT.md
+++ b/docs/GRILL-ME-PROMPT.md
@@ -1,0 +1,388 @@
+# wm/ — Grill-Me Session Prompt
+
+*Generated: 2026-04-28*
+*Purpose: Align understanding and make key design decisions before implementation*
+
+---
+
+## Context: What We Have
+
+### The Vision
+
+A new window manager (`./wm/`) built from scratch in C using XCB, with:
+- **State machine architecture** at its core (not ad-hoc if/else)
+- **Event-driven design** — state changes emit events, plugins subscribe
+- **Plugin/extension system** — add features without modifying core code
+- **No patch conflicts** — extensions that don't know about each other can coexist
+- Reference: The architecture is inspired by XState (JS) but for C
+
+**The core problem we're solving:** In dwm, patches modify the same source code. Apply patch A then patch B and they conflict. We want extensions that "just work" by subscribing to events, not by patching code.
+
+---
+
+## What We Did Today
+
+### 1. Analyzed dwm (`./dwm/`) — 23 documented functions
+
+Documents in `./dwm/docs/`:
+- `globals.md` — all global variables and Client/Monitor structs
+- `focus.md`, `manage.md`, `view.md`, `tag.md`, `setmfact.md`, `setcfact.md`
+- `tile.md`, `monocle.md`, `togglefloating.md`, `setfullscreen.md`
+- `resizeclient.md`, `resizemouse.md`, `movemouse.md`
+- `showhide.md`, `restack.md`, `attach.md`, `unmanage.md`
+- `setlayout.md`, `clientmessage.md`, `configurerequest.md`
+- `state-machines-architecture.md` — 12 state machines identified:
+  1. MonitorManager — multi-monitor state
+  2. ClientLifecycle — window creation/destruction
+  3. ClientFocus — keyboard focus
+  4. TagViewState — tag selection
+  5. LayoutState — layout selection
+  6. ClientFloatingState — tile vs float
+  7. ClientFullscreenState — fullscreen mode
+  8. TilingState — mfact, nmaster, cfact
+  9. BarState — bar visibility
+  10. ClientUrgencyState — urgency hints
+  11. ScratchpadState — scratchpad visibility
+  12. MouseDragState — mouse drag operations
+
+### 2. Reviewed existing wm/ codebase
+
+Files in `./wm/`:
+- `wm-states.c/h` — Basic state machine with 3 states: IDLE, WINDOW_MOVE, WINDOW_RESIZE
+  - Has `StateTransition` table (defined in `config.def.h`)
+  - Has `Context` struct holding event data
+  - `handle_state_event()` dispatches to state handlers
+- `wm-window-list.c/h` — Linked list with sentinel pattern for window tracking
+  - `window_insert()`, `window_remove()`, `window_find()`
+  - `wnd_node_t` struct with: window, title, parent, x/y/w/h, border_width, stack_mode, mapped
+- `wm-xcb.c` — XCB connection, `handle_xcb_events()` event loop
+- `wm-xcb-events.c/h` — 19 event handlers (create, destroy, map, button, key, motion, etc.)
+- `wm-clients.c/h` — `client_configure()`, `client_show()`, `client_hide()`
+- `wm-xcb-ewmh.c/h` — EWMH setup
+- `config.def.h` — State transition table
+- `Makefile`, `Dockerfile` — Build setup
+
+### 3. Designed 13 Extensions (in `./wm/docs/extensions/`)
+
+Each extension doc contains:
+- Overview, DWM reference, state machine events, hook points, configuration, keybindings, interactions
+
+Extensions designed:
+1. **gap** — Configurable gaps between tiled windows
+2. **pertag** — Per-tag layouts, mfact, nmaster, focus
+3. **floatpos** — Rule-based floating window positioning
+4. **urgency** — Sound/flashes on urgent clients
+5. **scratchpad** — Hidden windows with quick toggle
+6. **bstack** — Bottom-stack tiling layout
+7. **cfact** — Per-client relative sizing
+8. **actualfullscreen** — Fullscreen with bar visible
+9. **resizecorners** — Corner-drag resize
+10. **focus-adjacent** — Tag wrap-around navigation
+11. **ewmh-desktop** — EWMH atoms for external tools
+12. **bar-style** — Bar sizing/position config
+13. **attach-policy** — Client insertion policy
+
+### 4. Created Handoff Document
+
+`./wm/docs/PRE-WORK_CHECKLIST.md` — everything needed to continue:
+- Architecture docs still needed
+- Decisions to make
+- Implementation order
+- Quick wins
+
+---
+
+## Key Concepts We've Discussed
+
+### Event-Driven Architecture
+
+```
+┌─────────────────────────────────────────────────┐
+│                    Event Bus                     │
+│   (plugins subscribe, state machines emit)      │
+└─────────────────────────────────────────────────┘
+           ▲                      │
+           │                      │ emit events
+           │                      ▼
+┌─────────────────────────────────────────────────┐
+│              State Machine (Core)                │
+│  - Only thing that can mutate state             │
+│  - Guards validate transitions                   │
+│  - Actions execute mutations                      │
+│  - Emits events (never calls plugins directly)  │
+└─────────────────────────────────────────────────┘
+           ▲
+           │ dispatch commands
+           │
+┌─────────────────────────────────────────────────┐
+│                 Input (keys, mouse)              │
+│  KeyPress/Mouse → Command → State Machine        │
+└─────────────────────────────────────────────────┘
+```
+
+### Plugin Pattern
+
+Plugins:
+- Subscribe to events via the event bus
+- Emit commands to the state machine
+- **Never modify the state machine**
+- **Never modify other plugins**
+
+Example: Gap plugin
+```c
+// Subscribes to EVT_LAYOUT_CHANGED
+// Sets mon->gap_size = config.gap_size
+// Does NOT modify tile() function
+```
+
+### State Machine Framework (Conceptual)
+
+```c
+typedef struct StateMachine StateMachine;
+
+StateMachine* sm_create(const char* name, void* context);
+
+// States and transitions
+void sm_define_state(StateMachine* sm, State* state);
+void sm_define_transition(StateMachine* sm, Transition t);
+
+// Hooks for plugins
+void sm_add_hook(StateMachine* sm, HookPhase phase, HookFn fn, void* userdata);
+
+// Process a command
+bool sm_dispatch(StateMachine* sm, const Command* cmd);
+```
+
+---
+
+## What's Already in wm/
+
+### Current State Machine (Minimal)
+
+```c
+enum State {
+    STATE_IDLE,
+    STATE_WINDOW_MOVE,
+    STATE_WINDOW_RESIZE
+};
+
+struct StateTransition {
+    enum WindowType window_target_type;
+    enum EventType event_type;
+    enum ModKey mod;
+    xcb_button_t btn;
+    xcb_keycode_t key;
+    enum State prev_state;
+    enum State next_state;
+};
+
+struct Context {
+    enum State state;
+    void (*state_funcs[NUM_STATES])(struct Context* ctx);
+    // ... event data
+};
+```
+
+### Current Window List
+
+```c
+typedef struct wnd_node_t {
+    struct wnd_node_t* next;
+    struct wnd_node_t* prev;
+    char* title;
+    xcb_window_t parent;
+    xcb_window_t window;
+    int16_t x, y;
+    uint16_t width, height;
+    uint16_t border_width;
+    enum xcb_stack_mode_t stack_mode;
+    uint8_t mapped;
+} wnd_node_t;
+```
+
+---
+
+## What We Need to Decide
+
+### 1. Architecture Questions
+
+- **One SM per domain or one global SM?**
+  - Per-domain: Client SM, Focus SM, TagView SM, etc. (like dwm's 12 state machines)
+  - One global: Single state machine handling all events
+  - Concern: How do per-monitor SMs coordinate? What is `selmon`?
+
+- **Event naming convention?**
+  - `EVT_CLIENT_MANAGED` (caps, underscore)
+  - `client.managed` (lowercase, dot)
+  - `ClientEvent.Managed` ( CamelCase)
+
+- **Event ownership — who emits what?**
+  - State machines emit events after transitions
+  - Event handlers emit events before calling SM
+  - Both?
+
+- **Event data — copy on emit or shared?**
+  - Copy: safer, more allocations
+  - Shared: faster, must ensure not freed while in use
+
+### 2. Plugin System Questions
+
+- **Static or dynamic loading?**
+  - Static: compile-time plugin registry, simpler
+  - Dynamic: dlopen .so files, can reload without restart
+
+- **Hook placement — in SM or centralized?**
+  - In SM: `sm->pre_guards[]`, `sm->post_actions[]`
+  - Centralized: global hook registry
+
+- **Configuration — how do plugins store config?**
+  - Plugin struct has `void* data`
+  - Config parsed at load time
+  - Runtime config via commands?
+
+### 3. Domain Model Questions
+
+- **Tag representation?**
+  - Bitmask (like dwm): `uint32_t tags` where bit N = tag N
+  - Enum (safer): `enum Tag { TAG_1, TAG_2, ... }`
+  - Bitmask allows multi-tag views, enum is clearer
+
+- **Multi-tag views?**
+  - dwm supports viewing multiple tags at once (via `toggleview`)
+  - Should wm support this?
+
+- **selmon — global or per-context?**
+  - Global `selmon` (like dwm)
+  - Passed through context everywhere
+  - Multiple selected monitors?
+
+### 4. Implementation Questions
+
+- **Minimum viable wm?**
+  - What must work before any extensions?
+  - Window tracking, basic tiling, basic focus, basic tags?
+
+- **XCB vs Xlib?**
+  - Already using XCB (good)
+  - Stick with XCB for all new code
+
+---
+
+## The Big Questions for the Grill
+
+### About the Core Architecture
+
+1. **Should we have one StateMachine per domain (Client, Focus, Tag, Layout) or one monolithic SM?**
+   - Pro of per-domain: isolation, easier to reason about
+   - Con of per-domain: coordination, shared state
+   - Pro of monolithic: simpler, one place to look
+   - Con of monolithic: grows unwieldy
+
+2. **How do monitors fit into the SM architecture?**
+   - Is there a MonitorStateMachine?
+   - Do we have one SM per monitor?
+   - Is `selmon` global or threaded through context?
+
+3. **What is the minimal set of events needed to support all 13 extensions?**
+   - Can we start with fewer and add later?
+   - What's truly core vs extension-specific?
+
+### About Extensions
+
+4. **Which extensions should be "built-in" vs "loadable plugins"?**
+   - ewmh-desktop might need to be built-in (required for panels)
+   - pertag might be built-in (foundation for workflows)
+   - gap could be a plugin
+
+5. **Should extensions be able to modify state machine behavior (guards, transitions) or only react?**
+   - Current design: extensions can only react, not modify
+   - Is this too restrictive?
+   - What if we need extensions to add transitions?
+
+### About the Implementation
+
+6. **What's the minimum wm we can ship that demonstrates the architecture?**
+   - Just Client lifecycle + Events?
+   - Add tag system?
+   - Add basic tile layout?
+
+7. **How do we handle the transition from "everything in one file" to "modular"?**
+   - Current `wm-states.c` is ~200 lines
+   - We want `sm/`, `events/`, `domain/`, `plugins/` directories
+   - When do we refactor?
+
+---
+
+## Documents That Exist
+
+```
+wm/
+├── docs/
+│   ├── PRE-WORK_CHECKLIST.md    # Handoff context
+│   └── extensions/
+│       ├── README.md            # Extension index
+│       ├── gap.md                # 13 extension docs
+│       ├── pertag.md
+│       ├── floatpos.md
+│       ├── urgency.md
+│       ├── scratchpad.md
+│       ├── bstack.md
+│       ├── cfact.md
+│       ├── actualfullscreen.md
+│       ├── resizecorners.md
+│       ├── focus-adjacent.md
+│       ├── ewmh-desktop.md
+│       ├── bar-style.md
+│       └── attach-policy.md
+└── (source files)
+
+dwm/
+├── docs/
+│   ├── README.md                # Function doc index
+│   ├── globals.md               # Client/Monitor structs
+│   ├── state-machines-architecture.md  # 12-SM design
+│   ├── focus.md, manage.md, view.md, ...  # 23 function docs
+│   └── (many more function docs)
+└── (source files)
+```
+
+---
+
+## What's Been Resolved ✅
+
+The grill-me session on 2026-04-28 resolved all pending questions:
+
+### Architecture
+
+| Decision | Choice | Document |
+|----------|--------|----------|
+| SM granularity | Per-domain per-target | `architecture/decisions.md` |
+| SM lives on | Target (not component) | `architecture/decisions.md` |
+| SM allocation | Lazy | `architecture/decisions.md` |
+| Two writer types | Raw + Request | `architecture/decisions.md` |
+| Requests | Fire-and-forget async | `architecture/decisions.md` |
+| Component ownership | SM templates, not SMs | `architecture/decisions.md` |
+| Component filtering | accepted_targets[] | `architecture/decisions.md` |
+| Target resolution | In hub | `architecture/decisions.md` |
+| Target adoption | Eager at creation | `architecture/decisions.md` |
+| Hot-plugging | Supported | `architecture/decisions.md` |
+
+### Key Concepts Resolved
+
+- **Target** = entity that owns SMs (Client, Monitor)
+- **State Machine** = tracks mutually exclusive state, lives on target
+- **Component** = driver (executor + listener + SM template)
+- **Hub** = central orchestrator (registry + router + event bus)
+- **Raw Writer** = authoritative state change (hardware events, no guards)
+- **Request Writer** = intent to change state (keybindings, plugins, with guards)
+
+
+---
+
+*Full decision log: `architecture/decisions.md`*
+*Full architecture docs: `docs/architecture/`*
+
+---
+
+*End of prompt*
+*Ready for grill-me session*

--- a/docs/PRE-WORK_CHECKLIST.md
+++ b/docs/PRE-WORK_CHECKLIST.md
@@ -1,0 +1,187 @@
+# wm/ Implementation — Pre-Work Checklist
+
+## Context: What We Have
+
+### From dwm/ (Reference Implementation)
+- **23 function documentation files** in `./dwm/docs/` analyzing dwm's behavior
+- **State machine architecture analysis** in `dwm/docs/state-machines-architecture.md` (26KB, 12 state machines)
+- Globals, focus, manage, view, tile, togglefloating, setmfact, setfullscreen, etc.
+
+### Extension Designs for wm/
+- **13 extension documents** in `./wm/docs/extensions/` covering:
+  - gap, pertag, floatpos, urgency, scratchpad, bstack, cfact, actualfullscreen, resizecorners, focus-adjacent, ewmh-desktop, bar-style, attach-policy
+
+### Existing wm/ Codebase
+- Basic state machine (`wm-states.c/h`) with: STATE_IDLE, STATE_WINDOW_MOVE, STATE_WINDOW_RESIZE
+- Window list with sentinel pattern (`wm-window-list.c/h`)
+- XCB event handling (`wm-xcb.c`, `wm-xcb-events.c`)
+- Client operations (`wm-clients.c/h`)
+- EWMH setup (`wm-xcb-ewmh.c/h`)
+
+---
+
+## What We Still Need to Design/Decide
+
+### 1. Core Architecture Documents (Missing)
+
+We have extension docs but no architecture docs for the core. Need to write:
+
+- [ ] **`./wm/docs/architecture/event-bus.md`** — Pub/sub system design
+  - Event types (the 20+ events listed in extension docs)
+  - Subscription API
+  - Event emission/consumption flow
+  
+- [ ] **`./wm/docs/architecture/state-machine-framework.md`** — SM core design
+  - StateMachine struct
+  - Transition table format
+  - Guard/action function signature
+  - Context management
+  
+- [ ] **`./wm/docs/architecture/plugin-system.md`** — How extensions load
+  - Plugin interface (init, hooks, data)
+  - Static vs dynamic loading
+  - Plugin registry
+
+- [ ] **`./wm/docs/architecture/hook-system.md`** — Extension points
+  - Hook phases (pre_guard, post_guard, pre_action, post_action)
+  - How hooks are called from state machines
+  - Built-in vs custom hooks
+
+- [ ] **`./wm/docs/architecture/domain-model.md`** — Core entities
+  - Client struct design
+  - Monitor struct design
+  - TagSet value object
+  - Geometry value object
+
+### 2. Extension-to-Event Mapping
+
+Need to consolidate what events each extension needs:
+
+| Event | Used By | Priority |
+|-------|---------|----------|
+| EVT_CLIENT_MANAGED | floatpos, pertag, attach-policy | Core |
+| EVT_CLIENT_UNMANAGED | pertag | Core |
+| EVT_CLIENT_SHOWN/HIDDEN | (implied by tag change) | Core |
+| EVT_CLIENT_FOCUS_GAIN/LOSE | pertag, urgency | Core |
+| EVT_CLIENT_FLOAT_ENABLED/DISABLED | floatpos | Core |
+| EVT_CLIENT_FLOAT_MOVED | floatpos | Core |
+| EVT_CLIENT_FULLSCREEN_ENTER/EXIT | actualfullscreen | Core |
+| EVT_CLIENT_URGENCY_SET/CLEAR | urgency | Core |
+| EVT_TAG_VIEW_CHANGED | pertag, ewmh-desktop, urgency, focus-adjacent, bar-style | Core |
+| EVT_LAYOUT_CHANGED | pertag, bstack, gap | Core |
+| EVT_TILING_PARAM_CHANGED | gap, cfact | Core |
+| EVT_TILING_RECALCULATE | cfact | Core |
+| EVT_BAR_SHOWN/HIDDEN | bar-style, actualfullscreen | Core |
+| EVT_BAR_DRAW | bar-style | Core |
+| EVT_RESIZE_START/UPDATE/END | resizecorners | Optional |
+| EVT_SCRATCHPAD_SHOWN/HIDDEN/SPAWNED | scratchpad | Core |
+| EVT_MONITOR_CONNECTED/DISCONNECTED | (not in ext docs yet) | Later |
+| EVT_DRAG_START/END | (mouse drag) | Core |
+
+### 3. Decisions to Make
+
+- [ ] **Event enum naming**: `EVT_CLIENT_MANAGED` or `client.managed` or `Client.Managed`?
+- [ ] **SM per-domain or single SM**: One SM per client? One global SM? Per-monitor SMs?
+- [ ] **Plugin loading**: Static (compile-time) or dynamic (dlopen)?
+- [ ] **Hook storage**: In SM struct or centralized hook registry?
+- [ ] **Memory management**: Who owns event data? Copy on emit or shared?
+- [ ] **Thread safety**: Single-threaded event loop is fine, but guard against misuse?
+
+### 4. dwm Concepts to Port
+
+From dwm docs, need to implement:
+
+| dwm Concept | wm Equivalent | Status |
+|-------------|--------------|--------|
+| Client.isfloating | client.is_floating | TODO |
+| Client.isfullscreen | client.is_fullscreen | TODO |
+| Client.tags (bitmask) | client.tags (uint32) | TODO |
+| Client.isurgent | client.is_urgent | TODO |
+| Client.scratchkey | client.scratchkey | TODO |
+| Client.cfact | client.cfact | TODO (cfact ext) |
+| Monitor.tagset[2], seltags | mon.tagset, mon.seltags | TODO |
+| Monitor.nmaster, mfact | mon.nmaster, mon.mfact | TODO |
+| Monitor.lt[2] | mon.layouts[2] | TODO |
+| Monitor.showbar | mon.showbar | TODO |
+| Monitor.clients, sel, stack | mon.clients, mon.sel, mon.stack | TODO |
+| Pertag (per-tag arrays) | pertag (pertag ext) | TODO (pertag ext) |
+| TAGMASK, LENGTH(tags) | TAGMASK, NUM_TAGS | TODO |
+
+### 5. Immediate Implementation Order (Suggested)
+
+```
+Phase 1: Core Infrastructure (Must come first)
+├── 1. Event bus (no deps)
+├── 2. Basic state machine framework (depends on events)
+├── 3. Client entity (basic struct)
+├── 4. Monitor entity (basic struct)
+├── 5. Core events (CLIENT_MANAGED, TAG_VIEW_CHANGED, etc.)
+│
+Phase 2: Basic Functionality (Uses Phase 1)
+├── 6. Window list integration with event emission
+├── 7. Client lifecycle (manage → managed, unmanage → destroyed)
+├── 8. Basic focus (focus/unfocus events)
+├── 9. Basic tag system (view tags, tagset)
+├── 10. Basic tile layout (no cfact yet)
+│
+Phase 3: Extensions (Use Phase 2)
+├── 11. ewmh-desktop (requires TAG_VIEW_CHANGED event)
+├── 12. pertag (requires tag system)
+├── 13. gap (requires tile layout)
+└── ... rest of extensions
+```
+
+### 6. Questions to Answer Tomorrow
+
+- How do we want to handle the "tag as bitmask" vs "tag as enum" distinction?
+- Should we support multi-tag views? (dwm supports via `toggleview`)
+- How does `selmon` vs per-monitor SMs work?
+- What's the minimal viable wm that can actually manage windows?
+
+---
+
+## Files to Read/Review Tomorrow
+
+1. **Existing wm code** (fresh read):
+   - `wm-states.c/h` — existing SM framework to extend
+   - `wm-window-list.c/h` — window tracking to integrate
+   - `wm-xcb-events.c` — event sources
+
+2. **Architecture docs to create**:
+   - Start with `event-bus.md` — it's the foundation
+   - Then `state-machine-framework.md`
+   - Then `domain-model.md` (Client, Monitor structs)
+
+3. **Reference from dwm**:
+   - `dwm/docs/globals.md` — for Client/Monitor field definitions
+   - `dwm/docs/manage.md` — for window lifecycle understanding
+   - `dwm/docs/state-machines-architecture.md` — for the 12-SM design
+
+---
+
+## Quick Wins (Small Things to Implement First)
+
+If we want to make progress while designing continues:
+
+1. **Add event enum to wm-states.h** — Define all events from extension docs
+2. **Add basic event emission to wm-window-list.c** — Emit on insert/remove
+3. **Add hook struct to wm-states.h** — Basic hook mechanism
+4. **Refine Client struct** — Add is_floating, is_fullscreen, tags, etc.
+
+---
+
+## Log of What We Did Today
+
+- Discussed state machine architecture for extensibility
+- Analyzed dwm's 23 documented functions
+- Created 12-state-machine design for dwm
+- Read existing wm/ codebase (wm-states.c, wm-window-list.c, wm-xcb-events.c, etc.)
+- Created 13 extension design documents in `./wm/docs/extensions/`
+- Identified need for core architecture docs
+
+---
+
+*Document created: 2026-04-28*
+*Purpose: Handoff context for next session*
+*Total extension docs: 13*
+*Total dwm function docs analyzed: 23*

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,196 @@
+# wm/ Project Overview
+
+*Last updated: 2026-04-28*
+
+---
+
+## What Is This?
+
+A new X11 window manager built in C with XCB, designed from scratch with:
+- **State machine architecture** as the core
+- **Event-driven plugin system** for extensibility
+- **No patch conflicts** — extensions subscribe to events, don't modify code
+
+Reference: dwm (`./dwm/`) — analyzed extensively for design patterns
+
+---
+
+## Documentation Index
+
+### For Implementation (Start Here)
+
+| Document | Purpose |
+|----------|---------|
+| **[GRILL-ME-PROMPT.md](GRILL-ME-PROMPT.md)** | ⭐ **START HERE TOMORROW** — Design decisions to align on |
+| **[PRE-WORK_CHECKLIST.md](PRE-WORK_CHECKLIST.md)** | Handoff context, what was discussed today |
+
+### Architecture (Core Framework)
+
+| Document | Status |
+|----------|--------|
+| **[architecture/README.md](../docs/architecture/README.md)** | ⭐ START HERE — Index to architecture docs |
+| **[architecture/overview.md](../docs/architecture/overview.md)** | ⭐ Core concepts, event/request flows, decisions |
+| **[architecture/hub.md](../docs/architecture/hub.md)** | Hub: registry, router, event bus, target resolution |
+| **[architecture/state-machine.md](../docs/architecture/state-machine.md)** | SM framework: templates, transitions, guards |
+| **[architecture/component.md](../docs/architecture/component.md)** | Component: executor, listener, SM templates |
+| **[architecture/target.md](../docs/architecture/target.md)** | Target: Client, Monitor, adoption model |
+| **[architecture/decisions.md](../docs/architecture/decisions.md)** | Decision log with rationale |
+
+### Extension Designs (Reference for Implementation)
+
+In `extensions/`:
+
+| Extension | Priority | DWM Equivalent |
+|-----------|----------|----------------|
+| [ewmh-desktop.md](extensions/ewmh-desktop.md) | High | dwm-ewmh |
+| [pertag.md](extensions/pertag.md) | High | dwmpertag |
+| [gap.md](extensions/gap.md) | High | dwm-gaps |
+| [scratchpad.md](extensions/scratchpad.md) | High | dwm-scratchpads |
+| [floatpos.md](extensions/floatpos.md) | High | dwm-floatpos |
+| [bstack.md](extensions/bstack.md) | Medium | dwm-bstack |
+| [cfact.md](extensions/cfact.md) | Medium | dwm-cfacts |
+| [urgency.md](extensions/urgency.md) | Medium | dwm-urgencyhook |
+| [actualfullscreen.md](extensions/actualfullscreen.md) | Medium | dwm-actualfullscreen |
+| [bar-style.md](extensions/bar-style.md) | Medium | dwm-bar-padding |
+| [resizecorners.md](extensions/resizecorners.md) | Low | dwm-resizecorners |
+| [focus-adjacent.md](extensions/focus-adjacent.md) | Low | dwm-focusadjacenttag |
+| [attach-policy.md](extensions/attach-policy.md) | Low | dwm-attach-aside-and-below |
+| [README.md](extensions/README.md) | Index | — |
+
+### Reference: dwm Analysis
+
+| Document | Purpose |
+|----------|---------|
+| `dwm/docs/state-machines-architecture.md` | 12-state-machine design |
+| `dwm/docs/globals.md` | Client/Monitor struct definitions |
+| `dwm/docs/manage.md` | Window lifecycle |
+| `dwm/docs/focus.md` | Focus management |
+| `dwm/docs/view.md` | Tag/view system |
+| `dwm/docs/tile.md` | Tiling algorithm |
+| `dwm/docs/setmfact.md` | Master factor |
+| `dwm/docs/setcfact.md` | Client factor |
+| `dwm/docs/togglefloating.md` | Floating state |
+| `dwm/docs/setfullscreen.md` | Fullscreen |
+| `dwm/docs/resizemouse.md` | Resize drag |
+| `dwm/docs/movemouse.md` | Move drag |
+| + 13 more function docs | Full dwm coverage |
+
+---
+
+## Current Codebase
+
+### Existing Files (./wm/)
+
+```
+wm/
+├── wm.c                          # Main entry, event loop
+├── wm.h                          # Empty (header stub)
+├── wm-states.c/h                 # Basic state machine (3 states)
+├── wm-window-list.c/h            # Window list (sentinel pattern)
+├── wm-clients.c/h                # Window operations
+├── wm-xcb.c/h                    # XCB connection
+├── wm-xcb-events.c/h             # 19 event handlers
+├── wm-xcb-ewmh.c/h               # EWMH setup
+├── wm-kbd-mouse.c                # (stub)
+├── wm-log.c/h                    # Logging
+├── wm-signals.c/h                # Signal handling
+├── wm-running.c/h               # running flag
+├── config.def.h                 # State transitions
+├── Makefile, Dockerfile
+└── (vendor/, .git/, etc.)
+```
+
+### What's Implemented
+
+- ✅ XCB connection setup
+- ✅ Event loop (`handle_xcb_events()`)
+- ✅ Basic state machine (IDLE, WINDOW_MOVE, WINDOW_RESIZE)
+- ✅ Window list (insert, remove, find)
+- ✅ Signal handling (SIGINT, SIGTERM, SIGCHLD)
+- ✅ Logging system
+- ✅ EWMH setup stub
+
+### What's Missing (for basic wm)
+
+- ❌ Client entity (with is_floating, tags, etc.)
+- ❌ Monitor entity (with tagset, mfact, layouts, etc.)
+- ❌ Event bus (pub/sub system)
+- ❌ State machine framework (for extensions)
+- ❌ Basic tiling layout
+- ❌ Basic focus management
+- ❌ Basic tag system
+- ❌ Plugin system
+
+---
+
+## Key Design Decisions (Pending)
+
+From `GRILL-ME-PROMPT.md`:
+
+1. **State machine granularity**: One per domain or one global?
+2. **Event naming convention**: `EVT_*` or `domain.event`?
+3. **Plugin loading**: Static or dynamic?
+4. **Hook placement**: In SM or centralized?
+5. **selmon design**: Global or threaded through context?
+6. **Minimum viable wm**: What works before extensions?
+
+See [GRILL-ME-PROMPT.md](GRILL-ME-PROMPT.md) for the full list of questions.
+
+---
+
+## Implementation Order (Suggested)
+
+```
+Phase 1: Core Infrastructure
+├── 1. Event bus
+├── 2. State machine framework
+├── 3. Client entity
+├── 4. Monitor entity
+└── 5. Core events
+
+Phase 2: Basic Functionality
+├── 6. Window list → event emission
+├── 7. Client lifecycle (manage/unmanage)
+├── 8. Basic focus
+├── 9. Basic tags
+└── 10. Basic tile layout
+
+Phase 3: Extensions
+├── ewmh-desktop
+├── pertag
+├── gap
+├── floatpos
+├── scratchpad
+└── ... (rest of 13)
+```
+
+---
+
+## Quick Stats
+
+| Metric | Value |
+|--------|-------|
+| Extension docs written | 13 |
+| dwm functions documented | 23 |
+| State machines designed | 12 |
+| Lines of documentation | ~3,500 |
+| Lines of existing wm code | ~1,500 |
+
+---
+
+## How to Use This Repository
+
+### To understand the design:
+1. Read `GRILL-ME-PROMPT.md` — get context
+2. Read `extensions/README.md` — see all extension ideas
+3. Read individual extension docs for details
+
+### To start implementing:
+1. Run `/skill:grill-me` on `GRILL-ME-PROMPT.md`
+2. Align on design decisions
+3. Create `architecture/` docs based on decisions
+4. Start with Phase 1: Event bus
+
+---
+
+*End of overview*

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,110 @@
+# Architecture Documentation
+
+*Status: Authoritative*
+*Last updated: 2026-04-28*
+
+This directory contains the authoritative documentation for the wm architecture, derived from the grill-me design session.
+
+---
+
+## Core Documents
+
+| Document | Purpose |
+|----------|---------|
+| **[overview.md](overview.md)** | High-level architecture, core concepts, directory structure |
+| **[hub.md](hub.md)** | Hub implementation: registry, router, event bus, target resolution |
+| **[state-machine.md](state-machine.md)** | State machine framework: templates, transitions, guards, hooks |
+| **[component.md](component.md)** | Component design: executors, listeners, SM templates, lifecycle |
+| **[target.md](target.md)** | Target design: Client, Monitor, adoption, lazy SM allocation |
+| **[decisions.md](decisions.md)** | Decision log with rationale for all major choices |
+
+---
+
+## Quick Reference
+
+### Core Concepts
+
+- **Target**: Entity that owns state machines (Client, Monitor)
+- **State Machine**: Tracks mutually exclusive state with transitions and events
+- **Component**: Driver with executor (handles requests) and listener (handles events)
+- **Hub**: Central orchestrator connecting components, targets, requests, and events
+
+### Two Types of Writers
+
+- **Raw Writer**: Authoritative state change (hardware events). No guards. Always succeeds.
+- **Request Writer**: Intent to change state (keybindings, plugins). May fail guards.
+
+### Event Flow
+
+```
+X Event → Hub → Component Listener → raw_write SM → SM emits event → Event Bus → Subscribers
+```
+
+### Request Flow
+
+```
+Keybinding → Hub (resolves target) → Component Executor → XCB → on success: raw_write SM → emit event
+```
+
+---
+
+## Directory Structure
+
+```
+wm/
+├── src/
+│   ├── hub/           # Hub implementation
+│   ├── sm/            # State machine framework
+│   ├── target/        # Target infrastructure (Client, Monitor)
+│   ├── components/    # Built-in components
+│   └── listeners/     # Event listeners
+└── docs/
+    └── architecture/  # This directory
+```
+
+---
+
+## Reading Order
+
+For understanding the architecture:
+
+1. **overview.md** — get the big picture
+2. **decisions.md** — understand why decisions were made
+3. **target.md** — understand entities (Client, Monitor)
+4. **state-machine.md** — understand state tracking
+5. **component.md** — understand extensibility
+6. **hub.md** — understand central orchestration
+
+For implementation:
+
+1. Start with **hub.md** — implement the hub first
+2. Then **state-machine.md** — implement the SM framework
+3. Then **target.md** — implement Client and Monitor with adoption
+4. Then **component.md** — implement built-in components
+5. Wire up listeners
+
+---
+
+## Extension Documents
+
+Extension designs are in `../extensions/`. Each extension doc describes:
+- Overview and purpose
+- State machine events
+- Component hooks
+- Configuration
+
+See `../extensions/README.md` for the index.
+
+---
+
+## Reference: dwm Analysis
+
+The dwm analysis in `../../dwm/docs/` documents the existing implementation that inspired this design. Key documents:
+
+- `state-machines-architecture.md` — 12 state machines identified in dwm
+- `globals.md` — Client and Monitor struct definitions
+- Individual function docs for understanding dwm behavior
+
+---
+
+*End of architecture index*

--- a/docs/architecture/component.md
+++ b/docs/architecture/component.md
@@ -1,0 +1,524 @@
+# Component Design
+
+*Part of architecture documentation — Authoritative*
+*Last updated: 2026-04-28*
+
+---
+
+## Purpose
+
+A Component is a driver that can act upon targets. It is composed of:
+- **Executor** — handles requests, interacts with X server
+- **Listener** — handles external events, raw-writes to target's SM
+- **SM Template** — defines state machine for targets to adopt
+
+Components are the building blocks of the window manager. Built-in functionality (fullscreen, floating, focus) and extensions (gap, pertag, urgency) are all components.
+
+**Key design principle:** Components do NOT own state machines. They provide templates that targets adopt.
+
+---
+
+## Component Interface
+
+```c
+struct Component {
+    const char* name;           // unique identifier (for debugging/logging)
+    
+    // Target type filtering
+    TargetType* accepted_targets;  // which target types this component works with
+    uint32_t num_targets;
+    
+    // Request types this component handles
+    RequestType* requests;
+    uint32_t num_requests;
+    
+    // Event types this component emits
+    EventType* events;
+    uint32_t num_events;
+    
+    // Lifecycle hooks
+    void (*on_init)(void);                    // called once at startup
+    void (*on_shutdown)(void);                // called once at shutdown
+    
+    void (*on_adopt)(Target* t);              // called when target adopts this component
+    void (*on_unadopt)(Target* t);            // called when target unadopts this component
+    
+    // Executor: handles requests
+    void (*executor)(Request* req);
+    
+    // Listener: handles external events, raw-writes to SM
+    void (*listener)(Target* t, Event* e);
+    
+    // SM template factory
+    struct SMTemplate* (*get_sm_template)(void);
+};
+```
+
+---
+
+## XCB Handler Registration
+
+Components register their own XCB event handlers. Raw X events go directly to components, NOT through the hub.
+
+```c
+struct Component {
+    // ... existing fields ...
+    
+    // XCB handler registration
+    void (*on_xcb_event)(xcb_generic_event_t* event);
+    xcb_event_mask_t xcb_event_types[];
+};
+```
+
+**Handler registration at init:**
+```c
+void keybinding_on_init(void) {
+    xcb_handler_register(KEY_PRESS, keybinding_handler);
+    xcb_handler_register(KEY_RELEASE, keybinding_handler);
+}
+
+void keybinding_handler(xcb_generic_event_t* event) {
+    // Look up keybinding, send request to hub
+}
+```
+
+**XCB infrastructure dispatches directly:**
+```c
+void handle_xcb_events() {
+    xcb_generic_event_t* event = xcb_poll_for_event(dpy);
+    if (!event) return;
+    
+    Component* comp = xcb_handler_lookup(event->response_type);
+    if (comp && comp->on_xcb_event) {
+        comp->on_xcb_event(event);
+    }
+    free(event);
+}
+```
+
+## Lifecycle
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                         COMPONENT LIFECYCLE                          │
+│                                                                     │
+│  ┌─────────┐                                                        │
+│  │ INIT   │ ← hub_init() calls component->on_init() for all        │
+│  │         │    and xcb_handler_register() for X events            │
+│  └────┬───┘                                                        │
+│       ▼                                                           │
+│  ┌─────────┐     ┌─────────┐     ┌─────────┐     ┌─────────┐     │
+│  │ ADOPTED │ ←── │ TARGET  │ ←── │ hub_    │ ←── │ EVENT   │     │
+│  │         │     │ CREATED │     │ register│     │ LISTENER│     │
+│  └────┬───┘     └─────────┘     │ _target │     │ ADDED   │     │
+│       │                           └─────────┘     └─────────┘     │
+│       ▼                                                           │
+│  ┌─────────┐                                                        │
+│  │ ACTIVE  │ ← component handles requests/events for this target    │
+│  └────┬───┘                                                        │
+│       │                                                           │
+│       ▼                                                           │
+│  ┌─────────┐     ┌─────────┐     ┌─────────┐                     │
+│  │UNADOPTED│ ←── │ TARGET  │ ←── │ hub_    │                     │
+│  │         │     │ DESTROYED│     │ unregister_target │           │
+│  └────┬───┘     └─────────┘     └─────────┘                     │
+│       │                                                           │
+│       ▼                                                           │
+│  ┌─────────┐                                                        │
+│  │SHUTDOWN│ ← hub_shutdown() calls component->on_shutdown()       │
+│  └─────────┘                                                        │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Executor
+
+The executor handles requests. It:
+1. Receives a request with a concrete target
+2. Performs X server operations (via XCB)
+3. On success: raw-writes to the target's state machine
+4. On failure: emits an error event
+
+```c
+void fullscreen_executor(Request* req) {
+    // req->type == REQ_CLIENT_FULLSCREEN
+    // req->target is concrete client ID
+    
+    Client* c = (Client*)hub_get_target(req->target);
+    if (!c) {
+        hub_emit(EVT_ERR_TARGET_NOT_FOUND, req->target, NULL);
+        return;
+    }
+    
+    // Get or create the SM (lazy allocation)
+    StateMachine* sm = client_get_sm(c, "fullscreen");
+    
+    // Determine target state based on current state
+    uint32_t target_state = (sm_get_state(sm) == FS_FULLSCREEN)
+        ? FS_WINDOWED
+        : FS_FULLSCREEN;
+    
+    // Perform X operation (non-blocking)
+    if (target_state == FS_FULLSCREEN) {
+        xcb_void_cookie_t ck = xcb_ewmh_request_change_wm_state(
+            ewmh,
+            c->window,
+            EWMH_WM_STATE_ADD,
+            ewmh->_NET_WM_STATE_FULLSCREEN,
+            XCB_ATOM_NONE,
+            0
+        );
+        // Will handle reply/error later...
+        sm_raw_write(sm, FS_FULLSCREEN);
+    } else {
+        xcb_ewmh_request_change_wm_state(...);
+        sm_raw_write(sm, FS_WINDOWED);
+    }
+}
+```
+
+### Executor and XCB Error Handling
+
+XCB operations are non-blocking. The executor should:
+1. Send the request with a cookie
+2. Store the correlation ID
+3. Return immediately
+
+A separate XCB reply handler will:
+1. Check the cookie for success/failure
+2. If success: sm_raw_write() to the SM
+3. If failure: emit EVT_REQUEST_FAILED
+
+```c
+void fullscreen_executor(Request* req) {
+    Client* c = hub_get_target(req->target);
+    StateMachine* sm = client_get_sm(c, "fullscreen");
+    uint32_t target_state = (sm_get_state(sm) == FS_FULLSCREEN) ? FS_WINDOWED : FS_FULLSCREEN;
+    
+    // Store pending request for later reply handling
+    pending_request_t* pr = malloc(sizeof(pending_request_t));
+    pr->correlation_id = req->correlation_id;
+    pr->client_id = req->target;
+    pr->target_state = target_state;
+    pending_requests_add(pr);
+    
+    // Send XCB request
+    if (target_state == FS_FULLSCREEN) {
+        xcb_ewmh_request_change_wm_state(ewmh, c->window, EWMH_WM_STATE_ADD, ...);
+    } else {
+        xcb_ewmh_request_change_wm_state(ewmh, c->window, EWMH_WM_STATE_TOGGLE, ...);
+    }
+}
+
+// Called when XCB reply comes back
+void on_ewmh_reply(xcb_generic_reply_t* reply, void* data) {
+    pending_request_t* pr = data;
+    StateMachine* sm = client_get_sm(hub_get_target(pr->client_id), "fullscreen");
+    
+    if (reply) {
+        sm_raw_write(sm, pr->target_state);
+    } else {
+        hub_emit(EVT_REQUEST_FAILED, pr->client_id, "fullscreen failed");
+    }
+    
+    pending_requests_remove(pr);
+}
+```
+
+---
+
+## Listener (Hub Events Only)
+
+**Important distinction:**
+- **XCB events** → component owns handler, called directly via `xcb_handler_register()`
+- **Hub events (EVT_*)** → component subscribes via `hub_subscribe()`
+
+The listener in the Component struct is for hub events, not raw XCB events:
+
+```c
+void bar_listener(Target* t, Event* e) {
+    // Subscribed to hub events: EVT_TAG_CHANGED, EVT_LAYOUT_CHANGED, etc.
+    if (e->type == EVT_TAG_CHANGED) {
+        bar_redraw(t->data);
+    }
+}
+
+void bar_on_init(void) {
+    hub_subscribe(EVT_TAG_CHANGED, bar_listener, NULL);
+}
+```
+
+### Two Types of Listeners
+
+| Event Source | Mechanism | Example |
+|-------------|-----------|----------|
+| XCB raw events | `xcb_handler_register()` | keybinding_handler(KEY_PRESS) |
+| Hub events | `hub_subscribe()` | bar_listener(EVT_TAG_CHANGED) |
+
+
+---
+
+## SM Template
+
+The SM template defines what state machine the component provides. Targets adopt it and create their own SM instance.
+
+```c
+struct SMTemplate {
+    const char* name;          // must be unique (e.g., "fullscreen", "floating")
+    
+    uint32_t* states;          // array of state enum values
+    uint32_t num_states;
+    
+    Transition* transitions;    // array of valid transitions
+    uint32_t num_transitions;
+    
+    uint32_t initial_state;    // default starting state
+    
+    // Optional init function for instance data
+    void (*init_fn)(StateMachine* sm, void* instance_data);
+    
+    // Optional cleanup function
+    void (*destroy_fn)(StateMachine* sm);
+};
+
+// Example: Fullscreen template
+SMTemplate fullscreen_template = {
+    .name = "fullscreen",
+    .states = (uint32_t[]){ FS_WINDOWED, FS_FULLSCREEN },
+    .num_states = 2,
+    .transitions = fs_transitions,
+    .num_transitions = 2,
+    .initial_state = FS_WINDOWED,
+    .init_fn = fs_sm_init,
+    .destroy_fn = fs_sm_destroy,
+};
+```
+
+---
+
+## Component Example: Fullscreen
+
+```c
+// Component definition
+Component fullscreen_component = {
+    .name = "fullscreen",
+    
+    .accepted_targets = (TargetType[]){ TARGET_TYPE_CLIENT },
+    .num_targets = 1,
+    
+    .requests = (RequestType[]){ REQ_CLIENT_FULLSCREEN },
+    .num_requests = 1,
+    
+    .events = (EventType[]){
+        EVT_FULLSCREEN_ENTERED,
+        EVT_FULLSCREEN_EXITED,
+        EVT_REQUEST_FAILED,
+    },
+    .num_events = 3,
+    
+    .on_init = fullscreen_init,
+    .on_shutdown = fullscreen_shutdown,
+    .on_adopt = fullscreen_on_adopt,
+    .on_unadopt = fullscreen_on_unadopt,
+    
+    .executor = fullscreen_executor,
+    .listener = fullscreen_listener,
+    
+    .get_sm_template = fullscreen_get_template,
+};
+```
+
+### on_init
+```c
+void fullscreen_init(void) {
+    // Subscribe to XCB PropertyNotify events
+    hub_subscribe(EVT_XCB_PROPERTY_NOTIFY, fullscreen_xcb_handler, NULL);
+    // Or: register with xcb_listener system
+}
+```
+
+### on_adopt
+```c
+void fullscreen_on_adopt(Target* t) {
+    // Nothing special needed here
+    // Listener is already attached to target
+    // SM is lazily created on first use
+}
+```
+
+### get_sm_template
+```c
+SMTemplate* fullscreen_get_template(void) {
+    return &fullscreen_template;
+}
+```
+
+---
+
+## Built-in Components
+
+### Client Components
+
+| Component | Target Type | Requests | Events | SM |
+|-----------|------------|----------|--------|-----|
+| fullscreen | CLIENT | REQ_CLIENT_FULLSCREEN | EVT_FULLSCREEN_* | FullscreenSM |
+| floating | CLIENT | REQ_CLIENT_FLOAT, REQ_CLIENT_TILE | EVT_CLIENT_* | FloatingSM |
+| urgency | CLIENT | REQ_CLIENT_CLEAR_URGENT | EVT_CLIENT_URGENT | UrgencySM |
+| focus | CLIENT | REQ_CLIENT_FOCUS | EVT_CLIENT_FOCUSED | FocusSM |
+
+### Monitor Components
+
+| Component | Target Type | Requests | Events | SM |
+|-----------|------------|----------|--------|-----|
+| connection | MONITOR | (none - raw write only) | EVT_MONITOR_* | ConnectionSM |
+| resolution | MONITOR | REQ_MONITOR_SET_RESOLUTION | EVT_RESOLUTION_* | ResolutionSM |
+
+### Global Components
+
+| Component | Target Type | Requests | Events | SM |
+|-----------|------------|----------|--------|-----|
+| event-bus | (none) | (none) | all | (none) |
+| bar | MONITOR | REQ_BAR_UPDATE | (internal) | (none) |
+
+---
+
+## Plugin Components
+
+Plugins register as components and can provide:
+- Additional SM templates (new state to track)
+- New request handlers
+- New event listeners
+
+Example: gap component
+```c
+Component gap_component = {
+    .name = "gap",
+    .accepted_targets = (TargetType[]){ TARGET_TYPE_MONITOR },
+    .requests = (RequestType[]){ REQ_MONITOR_SET_GAP },
+    .events = (EventType[]){ EVT_GAP_CHANGED },
+    .get_sm_template = gap_get_template,
+    // No executor - gap affects tiling, which is a different component
+    // This component just provides the GapSM
+};
+```
+
+---
+
+## Hot-Plugging
+
+Components can be added or removed at runtime.
+
+### Register a new component
+```c
+void plugin_load(const char* name) {
+    Component* c = load_component_from_file(name);
+    hub_register_component(c);
+    c->on_init();
+    
+    // Notify all compatible targets to adopt
+    Target** targets = hub_get_targets_by_type(c->accepted_targets[0]);
+    for (int i = 0; targets[i]; i++) {
+        component_adopt(targets[i], c);
+    }
+}
+```
+
+### Unregister a component
+```c
+void plugin_unload(const char* name) {
+    Component* c = hub_get_component(name);
+    
+    // Unadopt from all targets
+    Target** targets = hub_get_all_targets();
+    for (int i = 0; targets[i]; i++) {
+        if (target_has_adopted(targets[i], c)) {
+            component_unadopt(targets[i], c);
+        }
+    }
+    
+    c->on_shutdown();
+    hub_unregister_component(name);
+}
+```
+
+---
+
+## Header: component.h
+
+```c
+#ifndef COMPONENT_H
+#define COMPONENT_H
+
+// Forward declarations
+typedef struct Component Component;
+typedef struct Target Target;
+typedef struct Request Request;
+typedef struct Event Event;
+typedef struct SMTemplate SMTemplate;
+typedef uint32_t TargetType;
+typedef uint32_t RequestType;
+typedef uint32_t EventType;
+
+struct Component {
+    const char* name;
+    
+    TargetType* accepted_targets;
+    uint32_t num_targets;
+    
+    RequestType* requests;
+    uint32_t num_requests;
+    
+    EventType* events;
+    uint32_t num_events;
+    
+    // Lifecycle
+    void (*on_init)(void);
+    void (*on_shutdown)(void);
+    void (*on_adopt)(Target* t);
+    void (*on_unadopt)(Target* t);
+    
+    // Operations
+    void (*executor)(Request* req);
+    void (*listener)(Target* t, Event* e);
+    
+    // SM template
+    SMTemplate* (*get_sm_template)(void);
+    
+    // Internal
+    void* instance_data;
+};
+
+// Component lifecycle
+void component_init(Component* c);
+void component_destroy(Component* c);
+
+// Target adoption
+void component_adopt(Component* c, Target* t);
+void component_unadopt(Component* c, Target* t);
+
+// Query
+bool component_handles_request(Component* c, RequestType type);
+bool component_emits_event(Component* c, EventType type);
+bool component_accepts_target(Component* c, TargetType type);
+
+#endif // COMPONENT_H
+```
+
+---
+
+## Testing Strategy
+
+1. **Unit tests for each component**: Send requests, verify SM transitions
+2. **Unit tests for listeners**: Send events, verify SM raw_write
+3. **Integration tests**: Full flow request → executor → SM → event emission
+4. **Hot-plug tests**: Load/unload component, verify adoption
+
+---
+
+*See also:*
+- `architecture/overview.md` — High-level architecture
+- `architecture/hub.md` — Hub routing
+- `architecture/state-machine.md` — SM framework
+- `architecture/target.md` — Target design and adoption

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -1,0 +1,339 @@
+# Decision Log
+
+*Document status: Authoritative — records design decisions and rationale*
+*Last updated: 2026-04-28*
+
+---
+
+## Purpose
+
+This document records key design decisions made during the architecture design phase, along with the reasoning behind each choice. It serves as a reference for future implementers to understand why the system is designed as it is.
+
+---
+
+## State Machine Architecture
+
+### Decision: SMs Live on Targets, Not Components
+
+**Decision:** State machines are owned by targets (Client, Monitor), not by components. Components provide SM templates.
+
+**Rationale:**
+- A client has its own FullscreenSM. Component fullscreen doesn't "have" a fullscreen SM — it provides the template.
+- This keeps the object/state boundary clean: targets exist, state machines track transitions on those targets.
+- Makes it easy to query "what is client X's fullscreen state?" by looking at the client's SM.
+
+**Alternatives considered:**
+- SM owned by component: Would mean one component, many clients = many instances needed, or global state.
+- Global SM registry: Would couple SM to a specific target, making target lookup necessary anyway.
+
+**Trade-offs:**
+- Pro: Clean object/state boundary
+- Pro: Natural unit testing (test SM in isolation)
+- Con: Targets need to manage their SMs (but this is handled by adoption model)
+
+---
+
+### Decision: Lazy SM Allocation
+
+**Decision:** State machines are allocated lazily — only when first accessed, not at target creation.
+
+**Rationale:**
+- Most targets won't use all SMs. A client might never go fullscreen.
+- Reduces memory usage.
+- Don't pay for what you don't use.
+
+**Alternatives considered:**
+- Eager allocation at target creation: Wastes memory for unused SMs.
+- Configurable per-component: Adds complexity without clear benefit.
+
+**Trade-offs:**
+- Pro: Memory efficient
+- Pro: Simple implementation
+- Con: First use has small allocation cost (acceptable)
+
+---
+
+### Decision: Mutually Exclusive States Within One SM
+
+**Decision:** Each SM tracks one domain of mutually exclusive states. A client can have multiple SMs for different domains (fullscreen, floating, urgency).
+
+**Rationale:**
+- Clear boundary between concerns: "is this client tiled or floating?" is one SM, "is it fullscreen?" is another.
+- Independent transitions: Client can go fullscreen while tiled (rare but valid) or tiled while fullscreen (also valid).
+- Matches real-world semantics: Window is TILING and URGENT simultaneously.
+
+**Example from dwm:**
+```c
+// dwm conflates these in Client struct:
+bool isfloating;    // not "floating state"
+bool isfullscreen;  // not "fullscreen state"
+// But also:
+int tags;  // bitmask, which is technically multi-state
+```
+
+**Alternatives considered:**
+- Single SM with compound state: `TILED+NOT_FULLSCREEN`, `FLOATING+FULLSCREEN`. Exponential explosion of states.
+- SM per target per domain: Already our model, just clarifying.
+
+---
+
+## Writer Types
+
+### Decision: Two Types of Writers (Raw vs Request)
+
+**Decision:** State machines accept two kinds of input:
+1. **Raw writes** — authoritative state changes (hardware, X events). No guards.
+2. **Transitions** — requested state changes (keybindings, plugins). Guards apply.
+
+**Rationale:**
+- Reality is authoritative: If X says the monitor is disconnected, the SM MUST reflect that.
+- User requests are not authoritative: Just because user presses a key doesn't mean fullscreen will succeed (window might not support it).
+- Different error handling: Raw writes always succeed; transitions might fail guards.
+
+**Alternatives considered:**
+- Unified writer with flags: `sm_write(sm, state, FORCED)`. Confusing semantics.
+- Separate SM types: `AuthoritativeSM` vs `RequestSM`. Unnecessary duplication.
+
+---
+
+### Decision: Raw Writes Always Emit Events
+
+**Decision:** When a raw write causes a state change, the SM emits the transition event, same as a transition.
+
+**Rationale:**
+- Subscribers (other components, UI) don't care how the state changed — they just care that it did.
+- Simplifies event handling: Always subscribe to state transitions, never need separate "raw state changed" events.
+
+**Trade-offs:**
+- Pro: Consistent event model
+- Con: Might emit rapid-fire events if hardware oscillates (mitigated by debouncing in listeners if needed)
+
+---
+
+### Decision: Requests Are Fire-and-Forget by Default
+
+**Decision:** When a keybinding sends a request, it doesn't wait for the result. Success/failure is communicated via events that the requester can optionally listen to.
+
+**Rationale:**
+- Matches XCB's async nature: Send request, handle reply later.
+- Keeps keybindings simple: Just dispatch and done.
+- Optional callbacks for cases that need them: Animation sequences, user feedback.
+
+**Alternatives considered:**
+- Blocking requests: Would block the event loop, unacceptable.
+- Promises/futures: Adds complexity for marginal benefit. Can be added later if needed.
+
+**Trade-offs:**
+- Pro: Simple
+- Pro: Non-blocking
+- Pro: Matches XCB paradigm
+- Con: Caller can't get immediate return value (but can listen to events)
+
+---
+
+## Components
+
+### Decision: Components Declare Accepted Target Types
+
+**Decision:** Each component declares an array of target types it accepts (e.g., `{CLIENT, MONITOR}`). Targets only adopt compatible components.
+
+**Rationale:**
+- Clean filtering: A keyboard target doesn't accidentally adopt client components.
+- Self-documenting: Component says "I work on clients and monitors, not on keyboards."
+- Extensible: New component with new target type works automatically.
+
+**Alternatives considered:**
+- Component registers for specific target IDs: Too granular, doesn't scale.
+- Global component list per target: Requires target to know all component types.
+
+---
+
+### Decision: Components Do Not Own SMs
+
+**Decision:** Components provide SM templates; targets own and create SM instances. Components handle requests and events but don't hold SM state.
+
+**Rationale:**
+- Decoupling: Component can be swapped without affecting targets.
+- Multiple targets, one component: Fullscreen component handles all clients, each client has its own SM.
+- Testing: Can test component executor without creating real targets.
+
+**Example:**
+```c
+// WRONG (old model):
+struct FullscreenComponent {
+    StateMachine* sm;  // Which SM? Which client?
+};
+
+// RIGHT (new model):
+struct FullscreenComponent {
+    // Just the executor and listener
+    void (*executor)(Request* req);
+    void (*listener)(Target* t, Event* e);
+    SMTemplate* (*get_template)(void);
+};
+```
+
+---
+
+## Target System
+
+### Decision: Targets Own Properties, Not State
+
+**Decision:** Target objects (Client, Monitor) hold properties (geometry, title, resolution). State machines track state that transitions.
+
+**Rationale:**
+- Clear boundary: Properties change arbitrarily; state changes are controlled.
+- Properties don't need guards; state does.
+- Makes it easy to see what's "just data" vs "controlled state."
+
+**Examples:**
+
+| Properties (Target) | State (State Machine) |
+|---------------------|---------------------|
+| window ID, title, class | fullscreen status |
+| x, y, width, height | tiling status |
+| output ID, resolution | connection status |
+| tagset, mfact, nmaster | layout selection |
+
+**Note:** Some properties ARE controlled by state machines (e.g., monitor resolution → ResolutionSM). But the property holds the current value; the SM tracks the domain.
+
+---
+
+### Decision: Lazy Adoption for Targets
+
+**Decision:** When a target is created, it immediately adopts all compatible components (eager adoption at creation time). SMs are allocated lazily.
+
+**Rationale:**
+- Simplicity: Don't need to track "which components have been adopted but SM not created."
+- Built-in functionality is always available: Client can fullscreen immediately.
+- Plugin adoption can be lazy (plugin-loaded later adopts to existing targets).
+
+**Alternatives considered:**
+- Fully lazy adoption: Components adopted on first request. Adds tracking complexity.
+- Config-driven adoption: User specifies what each target adopts. Too much config for v1.
+
+---
+
+### Decision: Symbolic Targets Resolved in Hub
+
+**Decision:** Symbolic targets like `TARGET_CURRENT_CLIENT` are resolved to concrete IDs in the hub before routing requests.
+
+**Rationale:**
+- Components receive concrete IDs: Don't need to know how "current" is tracked.
+- Centralized resolution: One place to change how targets are resolved.
+- Testable: Can mock resolution in tests.
+
+**Alternatives considered:**
+- Resolution in component: Each component would need to know about symbolic targets.
+- Symbolic targets passed through: Components would need to resolve, coupling them to resolution logic.
+
+---
+
+## Event System
+
+### Decision: All Events Flow Through Event Bus
+
+**Decision:** Components don't call each other directly. All communication is via:
+1. Requests → Hub → Component
+2. Events → Hub → Event Bus → Subscribers
+
+**Rationale:**
+- Decoupling: Components don't know each other's names.
+- Extensible: New component subscribes to events, doesn't modify existing components.
+- Debuggable: Easy to trace event flow.
+- Hot-pluggable: Can add/remove components without affecting others.
+
+**Alternatives considered:**
+- Direct component calls: Tight coupling, hard to extend.
+- Shared memory + polling: Inefficient for event-driven paradigm.
+
+---
+
+### Decision: Events Include Target ID
+
+**Decision:** All events include the target ID they're about, so subscribers can filter.
+
+**Rationale:**
+- Component can subscribe to "all fullscreen events" OR "fullscreen events for client X."
+- Bar component can update for specific monitors.
+- Reduces need for fine-grained event types.
+
+**Alternatives considered:**
+- Separate event types per target: Exponential explosion of event types.
+- Subscriber-side filtering: Would require more complex subscription API.
+
+---
+
+## Hot-Plugging
+
+### Decision: Components Can Be Loaded/Unloaded at Runtime
+
+**Decision:** The system supports dynamic component loading/unloading via hub_register_component() and hub_unregister_component().
+
+**Rationale:**
+- Plugin extensibility: Users can add extensions without recompiling WM.
+- Development: Can reload components during development.
+- Experimentation: Try different layouts, behaviors without restart.
+
+**Alternatives considered:**
+- Static only: Simpler, but limits extensibility.
+- Full module system: Over-engineered for v1.
+
+**Trade-offs:**
+- Pro: Extensible
+- Con: More complex hub implementation
+- Con: Memory management complexity on unload
+
+---
+
+## What We Decided NOT to Do
+
+### No Authorization System
+
+**Explicit decision:** We do NOT implement authorization, permissions, or access control in state machines.
+
+**Rationale:**
+- Minimal system: This is a window manager, not a security boundary.
+- Complexity: Authorization would add significant complexity to every transition.
+- Trust model: If you can run the WM, you own the session.
+
+**Trade-offs:**
+- Pro: Simple
+- Con: One misbehaving component can break everything (but this is true anyway)
+
+---
+
+### No Executor State Machines (for v1)
+
+**Explicit decision:** We do NOT implement state machines for executors (beyond request handling).
+
+**Rationale:**
+- Simple operations are atomic: Send XCB request, get reply. No intermediate states.
+- Complex animations are extension territory: If a plugin wants animation states, it can implement its own.
+- Keeps core simple: Just request → X → result.
+
+**Trade-offs:**
+- Pro: Simple core
+- Con: Animations require plugin work
+
+---
+
+### No Multi-Threading (for v1)
+
+**Explicit decision:** v1 is single-threaded.
+
+**Rationale:**
+- XCB is async: Events come in one at a time anyway.
+- Simplicity: No mutexes, no race conditions.
+- Complexity: Multi-threading would add significant complexity to SMs.
+
+**Future:** If multi-threaded in future, each SM would need its own lock, or use a thread-safe event bus.
+
+---
+
+*See also:*
+- `architecture/overview.md` — High-level architecture
+- `architecture/hub.md` — Hub implementation
+- `architecture/component.md` — Component design
+- `architecture/target.md` — Target design
+- `architecture/state-machine.md` — SM framework

--- a/docs/architecture/hub.md
+++ b/docs/architecture/hub.md
@@ -1,0 +1,456 @@
+# Hub Design
+
+*Part of architecture documentation — Authoritative*
+*Last updated: 2026-04-28*
+
+---
+
+## Purpose
+
+The Hub is the central orchestrator that connects all components and targets. It provides:
+- Component registration and discovery
+- Target registration and tracking
+- Request routing
+- Event distribution
+- Target resolution
+
+Components do not call each other directly. They communicate exclusively through the Hub.
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                              HUB                                    │
+│                                                                     │
+│  ┌───────────────┐  ┌───────────────┐  ┌───────────────┐           │
+│  │  REGISTRY    │  │   ROUTER      │  │  EVENT BUS    │           │
+│  │              │  │               │  │               │           │
+│  │ components[] │  │ request →     │  │ subscribe()   │           │
+│  │ targets[]    │  │ component     │  │ emit()        │           │
+│  │              │  │               │  │               │           │
+│  │ by_name      │  │ by_request_   │  │ by_event_     │           │
+│  │ by_type      │  │ type          │  │ type          │           │
+│  │              │  │               │  │               │           │
+│  │ by_target    │  │ by_target_    │  │               │           │
+│  │              │  │ id            │  │               │           │
+│  └───────────────┘  └───────────────┘  └───────────────┘           │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Registry
+
+The registry maintains:
+1. All registered components
+2. All created targets
+3. Mappings between them
+
+### Component Registration
+
+```c
+// Components register themselves at startup
+void hub_register_component(Component* comp) {
+    // Add to components[]
+    // Create index: by_name[comp->name] = comp
+    // Create index: by_request_type[comp->requests[i]] = comp
+}
+
+// Query: which component handles this request type?
+Component* hub_get_component_for_request(RequestType type) {
+    return by_request_type[type];
+}
+```
+
+### Target Registration
+
+```c
+// When a target (client, monitor) is created, it's registered
+void hub_register_target(Target* t) {
+    // Add to targets[]
+    // Create index: by_target_id[t->id] = t
+    // Create index: by_target_type[t->type] = t[]
+}
+
+// Query: get target by ID
+Target* hub_get_target(TargetID id) {
+    return by_target_id[id];
+}
+```
+
+### Compatible Components for Target Type
+
+```c
+// When target is created, it needs to adopt compatible components
+Component** hub_get_components_for_target_type(TargetType type) {
+    // Iterate components[], filter by accepted_targets[]
+    // Return array of compatible components
+}
+```
+
+---
+
+## Router
+
+The router directs requests to the appropriate component.
+
+### Request Structure
+
+```c
+struct Request {
+    RequestType type;
+    TargetID target;
+    void* userdata;        // for callbacks
+    uint64_t correlation_id;  // for async responses
+};
+
+enum RequestType {
+    REQ_CLIENT_FULLSCREEN,
+    REQ_CLIENT_TILE,
+    REQ_CLIENT_FLOAT,
+    REQ_CLIENT_CLOSE,
+    REQ_CLIENT_FOCUS,
+    
+    REQ_MONITOR_SET_LAYOUT,
+    REQ_MONITOR_TAG_VIEW,
+    REQ_MONITOR_TOGGLE_TAG,
+    
+    // ... more request types
+};
+```
+
+### Routing Logic
+
+```c
+void hub_send_request(Request* req) {
+    // 1. Resolve target if symbolic
+    req->target = hub_resolve_target(req->target);
+    
+    // 2. Find component that handles this request type
+    Component* comp = by_request_type[req->type];
+    if (!comp) {
+        // No component handles this - emit error event
+        event_emit(EVT_ERR_UNHANDLED_REQUEST, req);
+        return;
+    }
+    
+    // 3. Dispatch to component's executor
+    comp->executor(req);
+}
+```
+
+### Target Resolution
+
+```c
+TargetID hub_resolve_target(TargetID symbolic) {
+    switch (symbolic) {
+        case TARGET_CURRENT_CLIENT:
+            return focus_component_get_current_client();
+        case TARGET_CURRENT_MONITOR:
+            return monitor_component_get_current_monitor();
+        case TARGET_ALL_CLIENTS:
+        case TARGET_ALL_MONITORS:
+            return symbolic;  // special markers, handled by executor
+        default:
+            return symbolic;  // already concrete
+    }
+}
+```
+
+### Special Target Handling
+
+```c
+void hub_broadcast_request(RequestType type, void* data) {
+    // For TARGET_ALL_CLIENTS or similar
+    // Find all targets of relevant type
+    // Route request to each
+}
+```
+
+---
+
+## Event Bus
+
+The event bus handles publish/subscribe for events.
+
+### Event Structure
+
+```c
+struct Event {
+    EventType type;
+    TargetID target;     // which target this event is about
+    void* data;         // event-specific payload
+    uint64_t correlation_id;  // for matching requests to responses
+};
+
+enum EventType {
+    // State machine transition events
+    EVT_FULLSCREEN_ENTERED,
+    EVT_FULLSCREEN_EXITED,
+    EVT_CLIENT_TILED,
+    EVT_CLIENT_FLOATING,
+    
+    // Monitor events
+    EVT_MONITOR_CONNECTED,
+    EVT_MONITOR_DISCONNECTED,
+    EVT_RESOLUTION_CHANGED,
+    
+    // Client lifecycle
+    EVT_CLIENT_MANAGED,
+    EVT_CLIENT_UNMANAGED,
+    EVT_CLIENT_FOCUSED,
+    EVT_CLIENT_UNFOCUSED,
+    
+    // Request responses
+    EVT_REQUEST_SUCCESS,
+    EVT_REQUEST_FAILED,
+    
+    // ... more event types
+};
+```
+
+### Subscription API
+
+```c
+// Subscribe to an event type
+typedef void (*EventHandler)(Event* e);
+void hub_subscribe(EventType type, EventHandler handler, void* userdata);
+
+// Unsubscribe
+void hub_unsubscribe(EventType type, EventHandler handler);
+
+// Subscribe to events for a specific target
+void hub_subscribe_target(EventType type, TargetID target, EventHandler handler, void* userdata);
+```
+
+### Event Emission
+
+```c
+void event_emit(Event* e) {
+    // 1. Find all subscribers for this event type
+    // 2. For each subscriber:
+    //    - If subscribed to specific target, check target match
+    //    - Call handler(e, userdata)
+}
+
+// Convenience: emit with type and target
+void hub_emit(EventType type, TargetID target, void* data) {
+    Event e = { .type = type, .target = target, .data = data };
+    event_emit(&e);
+}
+```
+
+### Correlation for Request/Response
+
+```c
+void hub_send_request_with_correlation(Request* req, uint64_t corr_id) {
+    req->correlation_id = corr_id;
+    
+    // Requester should have subscribed to EVT_REQUEST_* with this corr_id
+    hub_subscribe(EVT_REQUEST_SUCCESS, on_request_done, req->userdata);
+    hub_subscribe(EVT_REQUEST_FAILED, on_request_done, req->userdata);
+    
+    hub_send_request(req);
+}
+
+void on_request_done(Event* e) {
+    if (e->correlation_id != my_corr_id) return;
+    // Handle response
+}
+```
+
+---
+
+## Built-in Target Types
+
+```c
+enum TargetType {
+    TARGET_TYPE_CLIENT,
+    TARGET_TYPE_MONITOR,
+    TARGET_TYPE_KEYBOARD,
+    TARGET_TYPE_TAG,
+    TARGET_TYPE_SYSTEM,  // global WM state
+};
+```
+
+---
+
+## Target Resolution Components
+
+Some components "own" the concept of certain targets and can resolve them:
+
+```c
+// FocusComponent owns TARGET_CURRENT_CLIENT
+TargetID focus_component_resolve(TargetSymbolic sym) {
+    if (sym == TARGET_CURRENT_CLIENT) {
+        return focus_sm->current_client_id;
+    }
+    return INVALID_TARGET;
+}
+```
+
+The hub stores a list of "target resolvers" and queries them in order.
+
+```c
+typedef TargetID (*TargetResolver)(TargetSymbolic sym);
+TargetResolver resolvers[] = {
+    focus_component_resolve,
+    monitor_component_resolve,
+    // ...
+};
+
+TargetID hub_resolve_target(TargetSymbolic sym) {
+    for (auto resolver : resolvers) {
+        TargetID result = resolver(sym);
+        if (result != INVALID_TARGET) return result;
+    }
+    return sym;  // if no resolver matched, treat as concrete
+}
+```
+
+---
+
+## Error Handling
+
+```c
+// Error events that the hub can emit
+enum EventType {
+    // ... existing events ...
+    
+    EVT_ERR_UNHANDLED_REQUEST,   // no component handles this request type
+    EVT_ERR_TARGET_NOT_FOUND,    // target ID doesn't exist
+    EVT_ERR_NO_CURRENT_CLIENT,  // tried to resolve but no focused client
+    EVT_ERR_NO_CURRENT_MONITOR, // tried to resolve but no selected monitor
+};
+```
+
+Components can subscribe to error events to handle them (e.g., show error in bar).
+
+---
+
+## Thread Safety Considerations
+
+For v1, single-threaded. XCB is async, but we're not doing parallel event processing.
+
+If multi-threaded in future:
+- Event bus needs mutex
+- Registry needs mutex (or RCU)
+- Each target's SM is single-threaded (one event at a time)
+
+---
+
+## Implementation Notes
+
+### Header: hub.h
+
+```c
+#ifndef HUB_H
+#define HUB_H
+
+// Forward declarations
+typedef uint64_t TargetID;
+typedef uint32_t TargetType;
+typedef uint32_t RequestType;
+typedef uint32_t EventType;
+typedef struct Component Component;
+typedef struct Target Target;
+typedef struct Request Request;
+typedef struct Event Event;
+
+// Hub initialization
+void hub_init(void);
+void hub_shutdown(void);
+
+// Component registration
+void hub_register_component(Component* comp);
+void hub_unregister_component(const char* name);
+
+// Target registration
+void hub_register_target(Target* t);
+void hub_unregister_target(TargetID id);
+Target* hub_get_target(TargetID id);
+Target** hub_get_targets_by_type(TargetType type);
+
+// Request routing
+void hub_send_request(RequestType type, TargetID target);
+void hub_send_request_data(RequestType type, TargetID target, void* data);
+
+// Target resolution
+TargetID hub_resolve_symbolic(TargetID symbolic);
+
+// Event bus
+void hub_emit(EventType type, TargetID target, void* data);
+void hub_subscribe(EventType type, void (*handler)(Event*), void* userdata);
+void hub_unsubscribe(EventType type, void (*handler)(Event*));
+void hub_subscribe_target(EventType type, TargetID target, void (*handler)(Event*), void* userdata);
+
+// Query API
+Component* hub_get_component(const char* name);
+Component** hub_get_components_for_target_type(TargetType type);
+
+#endif // HUB_H
+```
+
+---
+
+## Usage Example
+
+```c
+// Initialization
+hub_init();
+
+// Register components (each component does this at init)
+hub_register_component(&fullscreen_component);
+hub_register_component(&floating_component);
+hub_register_component(&focus_component);
+hub_register_component(&urgency_component);
+
+// When a client is created (by listener, on ManageNotify)
+Client* c = client_create(window);
+hub_register_target(&c->target);  // target adopts compatible components
+
+// Keybinding sends fullscreen request
+void keybinding_fullscreen(void) {
+    hub_send_request(REQ_CLIENT_FULLSCREEN, TARGET_CURRENT_CLIENT);
+    // Fire-and-forget
+}
+
+// Or with data
+void keybinding_move_to_tag(int tag) {
+    RequestDataTagMove d = { .tag = tag };
+    hub_send_request_data(REQ_MONITOR_TAG_VIEW, TARGET_CURRENT_MONITOR, &d);
+}
+
+// Listen for fullscreen completion
+void my_fullscreen_listener(Event* e) {
+    if (e->type == EVT_FULLSCREEN_ENTERED) {
+        // Client is now fullscreen
+    }
+}
+hub_subscribe(EVT_FULLSCREEN_ENTERED, my_fullscreen_listener, NULL);
+
+void keybinding_fullscreen_with_callback(void) {
+    uint64_t corr_id = generate_correlation_id();
+    hub_subscribe_target(EVT_REQUEST_SUCCESS, current_client(), on_fullscreen_done, NULL);
+    hub_send_request_with_correlation(REQ_CLIENT_FULLSCREEN, current_client(), corr_id);
+}
+```
+
+---
+
+## Testing Strategy
+
+1. **Unit tests for router**: Send requests, verify correct component called
+2. **Unit tests for event bus**: Subscribe/emit, verify handlers called
+3. **Unit tests for target resolution**: Symbolic → concrete resolution
+4. **Integration tests**: Full request → component → SM → event flow
+
+---
+
+*See also:*
+- `architecture/overview.md` — High-level architecture
+- `architecture/component.md` — Component interface and structure
+- `architecture/target.md` — Target design and adoption

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,417 @@
+# Architecture Overview
+
+*Document status: Authoritative — reflects design decisions from grill-me session*
+*Last updated: 2026-04-28*
+
+---
+
+## The Problem We're Solving
+
+In dwm, patches modify the same source code. Apply patch A then patch B and they conflict. We want extensions that "just work" by subscribing to events, not by patching code.
+
+The solution is an event-driven architecture with state machines at the core, where:
+1. Extensions (plugins) never modify core code
+2. Extensions subscribe to events, emit requests
+3. State machines are the only authority on state mutations
+4. Everything is decoupled via a central hub
+
+---
+
+## Core Concepts
+
+### 1. Target
+An entity that exists in the system and can be the subject of state transitions.
+
+| Target Type | Examples | Properties |
+|-------------|----------|------------|
+| CLIENT | Windows | window ID, geometry, title |
+| MONITOR | Displays | output ID, resolution, position |
+| KEYBOARD | Input devices | (future) |
+| TAG | Virtual workspace | index, name |
+
+**A target owns:**
+- Its properties (which can change but are not state-machine-tracked)
+- Adopted state machines (lazy-allocated)
+- Adopted component listeners
+
+### 2. State Machine
+A finite state machine that tracks mutually exclusive state.
+
+**Key properties:**
+- **Mutually exclusive states** — a client is either FULLSCREEN or WINDOWED, never both
+- **Guards** — conditions that must be true for a transition to be allowed
+- **Actions** — side effects that execute during transitions
+- **Events emitted on transition** — other components can subscribe
+
+**A state machine tracks:**
+- Current state
+- Available transitions from current state
+- Template (states, transitions, guards, actions)
+
+**State machines live on targets**, not on components.
+
+### 3. Component
+A driver that can act upon targets. Composed of:
+- **Executor** — handles requests, mutates external reality (X server)
+- **Listener/Raw Writer** — handles external events, raw-writes to target's SM
+- **SM Template** — defines what state machine this component provides
+
+**Key property:** Components do NOT own state machines. They provide templates that targets adopt.
+
+```c
+struct Component {
+    const char* name;
+    TargetType* accepted_targets;  // which target types this works with
+    RequestType* requests;         // requests this component can execute
+    EventType* events;            // events this component emits
+    
+    void (*on_adopt)(Target* t);      // called when adopted by target
+    void (*on_unadopt)(Target* t);    // called when unadopted
+    void (*listener_callback)(Target* t, Event* e);  // event handler
+    SM* (*get_sm_template)(void);     // returns SM template
+};
+```
+
+### 4. Hub
+The central orchestrator that connects everything.
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                              HUB                                    │
+│                                                                     │
+│  ┌─────────────┐   ┌─────────────┐   ┌─────────────┐              │
+│  │  Registry  │   │  Router    │   │  Event Bus  │              │
+│  │             │   │             │   │             │              │
+│  │ Components  │   │ Routes      │   │ All comps   │              │
+│  │ Targets     │   │ requests    │   │ emit/       │              │
+│  │             │   │ to comps    │   │ subscribe   │              │
+│  └─────────────┘   └─────────────┘   └─────────────┘              │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+**Responsibilities:**
+- Register and track components
+- Register and track targets
+- Route requests to appropriate components (by request type + target)
+- Maintain target type → target ID mappings
+- Route events to subscribed components
+- Provide target resolution (symbolic → concrete IDs)
+
+---
+
+## Two Types of Writers to State Machines
+
+### Raw Writer
+**Authority:** External reality has changed — SM MUST accept this
+
+Used by listeners that detect hardware/X protocol changes:
+- XRandR notifications (monitor connected/disconnected)
+- Client property changes
+- ConfigureNotify events
+
+```c
+// Listener (RandR) detected monitor disconnected
+void randr_on_disconnect(xcb_randr_output_t output) {
+    MonitorSM* sm = target_get_sm(monitor, COMPONENT_CONNECTION);
+    sm_raw_write(sm, MON_STATE_DISCONNECTED);  // Forced, no negotiation
+    // SM transitions and emits EVT_MONITOR_DISCONNECTED internally
+}
+```
+
+**Rules:**
+- No validation needed — reality is authoritative
+- SM transitions immediately
+- Event is emitted on transition
+
+### Request Writer
+**Authority:** Intent to change external reality — "please do this if you can"
+
+Used by keybindings, plugins, and other requesters:
+```c
+// User presses keybinding for fullscreen
+void keybinding_fullscreen(void) {
+    hub_send_request(REQ_CLIENT_FULLSCREEN, TARGET_CURRENT_CLIENT);
+    // Fire-and-forget; can listen to success/failure events
+}
+```
+
+**Rules:**
+1. Component receives request
+2. Executor tries to fulfill the request (XCB call)
+3. On success: raw write to SM, SM transitions, event emitted
+4. On failure: SM stays in current state, failure event emitted
+
+---
+
+## Target Adoption Model
+
+When a target (Client, Monitor) is created, it adopts compatible components from the registry.
+
+```c
+Client* client_create(xcb_window_t window) {
+    Client* c = malloc(sizeof(Client));
+    c->window = window;
+    c->adopted_components = NULL;
+    c->state_machines = NULL;
+    
+    // Hub matches target type to components that accept TARGET_TYPE_CLIENT
+    Component** compatible = hub_get_components_for_target(TARGET_TYPE_CLIENT);
+    
+    for (int i = 0; compatible[i]; i++) {
+        component_adopt(c, compatible[i]);
+    }
+    
+    return c;
+}
+```
+
+**Adoption does:**
+1. Attaches component's listener (filtered for this target's ID)
+2. Attaches component's SM template (not yet allocated)
+
+**Lazy state machine allocation:**
+```c
+FullscreenSM* sm = target_get_sm(client, COMPONENT_FULLSCREEN);
+// First call allocates and initializes the SM
+// SM allocated only when actually needed
+```
+
+---
+
+## XCB Event Flow (Components Own Their Handlers)
+
+**Important:** Raw XCB events go DIRECTLY to component handlers, NOT through hub. Components register XCB handlers at init.
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                       XCB Event Loop                                │
+│   - Receives raw X events from X server                             │
+│   - Routes to registered component handlers                        │
+└─────────────────────────────────────────────────────────────────────┘
+         │
+         ├──────────────────────────────────────────────────────┐
+         │                                                      │
+         ▼                                                      ▼
+┌─────────────────────────┐  ┌─────────────────────────┐  ┌─────────────────────┐
+│  Keybinding Component  │  │   Focus Component      │  │ Monitor-Manager     │
+│                         │  │                         │  │   Component         │
+│ handle_key(KEY_PRESS)   │  │ handle_enter(ENTER)     │  │ handle_randr(RANDR) │
+│         │              │  │         │              │  │         │           │
+│         ▼              │  │         ▼              │  │         ▼           │
+│ hub_send_request()     │  │ sm_raw_write()         │  │ sm_raw_write()        │
+│ (to hub for routing)   │  │ (to client->FocusSM)   │  │ (to mon->ConnSM)     │
+└─────────────────────────┘  └─────────────────────────┘  └─────────────────────┘
+```
+
+Components own their XCB handlers. Handlers live INSIDE the component, not in a central place.
+
+| Component | XCB Events It Handles |
+|-----------|---------------------|
+| keybinding | KEY_PRESS, KEY_RELEASE |
+| pointer | BUTTON_PRESS, BUTTON_RELEASE, MOTION_NOTIFY |
+| focus | ENTER_NOTIFY, FOCUS_IN, FOCUS_OUT |
+| monitor-manager | RANDR_NOTIFY |
+| client-list | CREATE_NOTIFY, DESTROY_NOTIFY, MAP_REQUEST |
+| fullscreen | PROPERTY_NOTIFY |
+| bar | EXPOSE |
+
+## SM Event Flow (Hub Event Bus)
+
+State machine transition events flow through hub's event bus:
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                    State Machine                                    │
+│   sm_raw_write() or sm_transition() causes state change            │
+│   Emits EVT_* to HUB event bus                                      │
+└─────────────────────────────────────────────────────────────────────┘
+         │
+         ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                         HUB Event Bus                                 │
+│   hub_emit(EVT_FULLSCREEN_ENTERED, client_id, data)                  │
+│   All subscribers notified                                           │
+└─────────────────────────────────────────────────────────────────────┘
+         │
+         │ Subscribers
+         ▼
+┌─────────────────────────┐  ┌─────────────────────────┐
+│   Bar Component        │  │   Tiling Component     │
+│   subscribed:           │  │   subscribed:           │
+│   EVT_FULLSCREEN_*     │  │   EVT_FULLSCREEN_*     │
+│   Action: redraw        │  │   Action: re-tile      │
+└─────────────────────────┘  └─────────────────────────┘
+```
+
+---
+
+## Request Flow
+
+```
+Keybinding / Plugin
+         │
+         ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                              HUB                                    │
+│   hub_send_request(REQ_CLIENT_FULLSCREEN, TARGET_CURRENT_CLIENT)   │
+│   Request includes: type, target (maybe symbolic)                  │
+└─────────────────────────────────────────────────────────────────────┘
+         │
+         ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                         Router                                      │
+│   Finds component that handles REQ_CLIENT_FULLSCREEN               │
+│   Resolves TARGET_CURRENT_CLIENT → concrete client ID             │
+│   Routes to component's executor                                   │
+└─────────────────────────────────────────────────────────────────────┘
+         │
+         ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                   Component Executor                                 │
+│   Executor receives (Request* req) with concrete target            │
+│   Does XCB call (non-blocking)                                     │
+│   On success: sm_raw_write(target->sm, NEW_STATE)                  │
+│   On failure: emits EVT_REQUEST_FAILED                             │
+└─────────────────────────────────────────────────────────────────────┘
+         │
+         ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                    State Machine                                    │
+│   Transitions, emits event (EVT_FULLSCREEN_ENTERED)                │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Target Resolution
+
+Targets can be specified as:
+1. **Symbolic references** — `TARGET_CURRENT_CLIENT`, `TARGET_CURRENT_MONITOR`
+2. **Concrete IDs** — actual window ID, output ID
+
+**Resolution happens in the hub** before routing to components:
+
+```c
+Target hub_resolve(Target t) {
+    switch (t) {
+        case TARGET_CURRENT_CLIENT:
+            return focus_component_get_current_client();
+        case TARGET_CURRENT_MONITOR:
+            return monitor_component_get_current_monitor();
+        default:
+            return t;  // already concrete
+    }
+}
+```
+
+Components receive concrete target IDs and don't need to know how resolution works.
+
+---
+
+## Hot-Plugging Components
+
+Components can be added or removed at runtime:
+
+```c
+// Register a new component
+hub_register_component(&urgency_component);
+
+// Existing targets can adopt it
+target_adopt(existing_client, &urgency_component);
+
+// Or: notify all compatible targets to adopt
+hub_notify_compatible_targets(COMPONENT_URGENCY);
+```
+
+---
+
+## Directory Structure
+
+```
+wm/
+├── src/
+│   ├── hub/                    # Hub implementation
+│   │   ├── hub.c/h             # Main hub logic
+│   │   ├── registry.c/h        # Component/target registry
+│   │   ├── router.c/h         # Request routing
+│   │   └── event_bus.c/h      # Event pub/sub
+│   │
+│   ├── sm/                     # State machine framework
+│   │   ├── sm.c/h             # SM core
+│   │   ├── sm_transition.c/h  # Transition logic
+│   │   └── sm_template.c/h    # Template storage
+│   │
+│   ├── target/                # Target infrastructure
+│   │   ├── target.c/h         # Base target
+│   │   ├── client.c/h         # Client target
+│   │   ├── monitor.c/h        # Monitor target
+│   │   └── target_adoption.c/h
+│   │
+│   ├── components/            # Built-in components
+│   │   ├── fullscreen.c/h
+│   │   ├── floating.c/h
+│   │   ├── focus.c/h
+│   │   ├── connection.c/h     # Monitor connection
+│   │   ├── resolution.c/h     # Monitor resolution
+│   │   └── ... (others)
+│   │
+│   ├── listeners/             # Event listeners
+│   │   ├── xcb_listener.c/h   # XCB event dispatcher
+│   │   ├── randr_listener.c/h # RandR events
+│   │   └── ... (others)
+│   │
+│   └── main.c                 # Entry point
+│
+├── docs/
+│   ├── architecture/
+│   │   ├── overview.md        # This file
+│   │   ├── hub.md            # Hub detailed design
+│   │   ├── state-machine.md  # SM framework design
+│   │   ├── component.md      # Component design
+│   │   ├── target.md         # Target design
+│   │   ├── event-flow.md     # Event/request flows
+│   │   └── decisions.md      # Decision log with rationale
+│   │
+│   └── extensions/            # Extension designs
+│
+├── config.def.h               # Configuration
+├── Makefile
+└── config.mk
+```
+
+---
+
+## Decision Log
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| SM granularity | Per-domain per-target | Small, testable; allows plugins to subscribe to specific domains |
+| SM lives on | Target | Client owns its FullscreenSM, not a global component |
+| SMs are | Mutually exclusive per SM | Client is FULLSCREEN OR WINDOWED, never both |
+| SMs include | Raw writers + request writers | Hardware events are authoritative; user requests need execution |
+| Target resolution | In hub | Components get concrete IDs; don't need to know resolution logic |
+| SM creation | Lazy | Don't allocate SM unless it's actually needed |
+| Component adoption | Based on target type | Component declares accepted_targets[] |
+| Requests | Fire-and-forget by default | Can listen to events for confirmation |
+| Executor SMs | Not needed for v1 | Simple request-reply; executor doesn't need intermediate states |
+
+---
+
+## Next Steps
+
+1. Implement the Hub (registry, router, event bus)
+2. Implement the State Machine framework
+3. Implement Target infrastructure (base, client, monitor)
+4. Implement built-in components
+5. Wire up XCB listener
+6. Basic tiling and focus
+7. Extensions
+
+---
+
+*See also:*
+- `architecture/state-machine.md` — SM framework details
+- `architecture/hub.md` — Hub implementation details
+- `architecture/component.md` — Component interface
+- `architecture/decisions.md` — Full decision log with rationale

--- a/docs/architecture/state-machine.md
+++ b/docs/architecture/state-machine.md
@@ -1,0 +1,450 @@
+# State Machine Framework
+
+*Part of architecture documentation — Authoritative*
+*Last updated: 2026-04-28*
+
+---
+
+## Purpose
+
+State machines are the **only authority on state mutations**. They track mutually exclusive state with:
+- Well-defined transitions
+- Guards to validate transitions
+- Actions on transition
+- Events emitted on state change
+
+**Key design principle:** State machines live on targets, not in components. Components provide SM templates; targets adopt and own the SMs.
+
+---
+
+## Core Concepts
+
+### State Machine Instance
+A running instance that holds:
+- Current state
+- Pointer to owner target
+- Pointer to template (defines states, transitions, guards)
+
+### SM Template
+Defines the structure:
+- List of states
+- List of transitions
+- Guards for each transition
+- Actions for each transition
+- Events emitted on each transition
+
+### Mutually Exclusive State
+Within one SM, the system is in exactly one state at a time:
+```
+ClientFullscreenSM: FULLSCREEN ←→ WINDOWED
+ClientFloatingSM: FLOATING ←→ TILED
+```
+
+These are independent SMs. A client can be simultaneously:
+- FULLSCREEN (FullscreenSM)
+- TILED (FloatingSM)
+- FOCUSED (FocusSM)
+
+---
+
+## SM Instance Structure
+
+```c
+typedef struct StateMachine {
+    const char* name;
+    
+    // Current state
+    uint32_t current_state;
+    
+    // Owner
+    Target* owner;  // the client/monitor this SM belongs to
+    
+    // Template reference
+    SMTemplate* template;
+    
+    // Hooks for plugins (optional)
+    Hook* pre_guards;      // executed before guard
+    Hook* post_actions;    // executed after action
+    
+    // Instance-specific data (from template)
+    void* data;
+} StateMachine;
+```
+
+---
+
+## SM Template Structure
+
+```c
+typedef struct SMTemplate {
+    const char* name;
+    
+    // States
+    uint32_t* states;
+    uint32_t num_states;
+    
+    // Transitions: from → to with guard + action
+    Transition {
+        uint32_t from_state;
+        uint32_t to_state;
+        const char* guard_fn;   // name of guard function
+        const char* action_fn;  // name of action function
+        EventType emit_on_transition;
+    }* transitions;
+    uint32_t num_transitions;
+    
+    // Initial state (default)
+    uint32_t initial_state;
+} SMTemplate;
+```
+
+---
+
+## State Machine Operations
+
+### Create (lazy)
+```c
+StateMachine* sm_create(Target* owner, SMTemplate* template) {
+    StateMachine* sm = malloc(sizeof(StateMachine));
+    sm->name = template->name;
+    sm->owner = owner;
+    sm->template = template;
+    sm->current_state = template->initial_state;
+    sm->pre_guards = NULL;
+    sm->post_actions = NULL;
+    sm->data = NULL;
+    
+    // Call template init function if any
+    if (template->init_fn) {
+        template->init_fn(sm);
+    }
+    
+    return sm;
+}
+```
+
+### Raw Write (for listeners/authoritative events)
+```c
+// Used by listeners when reality changes
+void sm_raw_write(StateMachine* sm, uint32_t new_state) {
+    // No guards - reality is authoritative
+    sm->current_state = new_state;
+    event_emit(sm->template->get_transition_event(sm, new_state));
+}
+```
+
+### Transition (for requests)
+```c
+bool sm_transition(StateMachine* sm, uint32_t target_state) {
+    // Find transition from current_state → target_state
+    Transition* t = sm_find_transition(sm, sm->current_state, target_state);
+    if (!t) return false;  // no valid transition
+    
+    // Run guards (if any)
+    if (t->guard_fn && !sm_run_guard(sm, t->guard_fn)) {
+        return false;  // guard rejected
+    }
+    
+    // Run pre-hooks
+    sm_run_hooks(sm, HOOK_PRE_GUARD);
+    
+    // Execute action
+    if (t->action_fn) {
+        sm_run_action(sm, t->action_fn);
+    }
+    
+    // Update state
+    sm->current_state = target_state;
+    
+    // Run post-hooks
+    sm_run_hooks(sm, HOOK_POST_ACTION);
+    
+    // Emit event
+    event_emit(t->emit_on_transition, sm->owner->id, sm->data);
+    
+    return true;
+}
+```
+
+### Query Available Transitions
+```c
+// For UI/debugging: what can I request from here?
+uint32_t* sm_get_available_transitions(StateMachine* sm, uint32_t* count) {
+    *count = 0;
+    uint32_t* states = malloc(sizeof(uint32_t) * sm->template->num_transitions);
+    
+    for (uint32_t i = 0; i < sm->template->num_transitions; i++) {
+        if (sm->template->transitions[i].from_state == sm->current_state) {
+            states[(*count)++] = sm->template->transitions[i].to_state;
+        }
+    }
+    
+    return states;  // caller frees
+}
+
+// Check if a specific transition is valid
+bool sm_can_transition(StateMachine* sm, uint32_t target_state) {
+    // Check guard (without running it)
+    // Return whether transition exists and would pass guard
+}
+```
+
+---
+
+## Built-in State Machines
+
+### Client State Machines
+
+| SM | States | Component |
+|----|--------|-----------|
+| FullscreenSM | WINDOWED ↔ FULLSCREEN | fullscreen |
+| FloatingSM | TILED ↔ FLOATING | floating |
+| UrgencySM | CALM ↔ URGENT | urgency |
+| FocusSM | UNFOCUSED ↔ FOCUSED | focus (managed clients only) |
+
+### Monitor State Machines
+
+| SM | States | Component |
+|----|--------|-----------|
+| ConnectionSM | CONNECTED ↔ DISCONNECTED | connection |
+| ResolutionSM | RES_* (one per mode) | resolution |
+| SelectedSM | SEL_1 ↔ SEL_N (selected monitor) | (system, no component) |
+
+### Global State Machines
+
+| SM | States | Component |
+|----|--------|-----------|
+| TagViewSM | TAGS_* (bitmask of visible tags) | (system) |
+| LayoutSM | LAYOUT_* (current layout per monitor) | (system) |
+
+---
+
+## Example: Fullscreen Component's SM Template
+
+```c
+// States
+enum {
+    FS_WINDOWED = 0,
+    FS_FULLSCREEN,
+};
+
+// Transitions
+static Transition fs_transitions[] = {
+    {
+        .from = FS_WINDOWED,
+        .to = FS_FULLSCREEN,
+        .guard_fn = "fs_guard_can_fullscreen",
+        .action_fn = "fs_action_enter_fullscreen",
+        .emit = EVT_FULLSCREEN_ENTERED,
+    },
+    {
+        .from = FS_FULLSCREEN,
+        .to = FS_WINDOWED,
+        .guard_fn = "fs_guard_can_unfullscreen",
+        .action_fn = "fs_action_exit_fullscreen",
+        .emit = EVT_FULLSCREEN_EXITED,
+    },
+};
+
+// Template
+SMTemplate fullscreen_template = {
+    .name = "client-fullscreen",
+    .states = (uint32_t[]){ FS_WINDOWED, FS_FULLSCREEN },
+    .num_states = 2,
+    .transitions = fs_transitions,
+    .num_transitions = 2,
+    .initial_state = FS_WINDOWED,
+};
+
+// Guard functions
+bool fs_guard_can_fullscreen(StateMachine* sm, void* data) {
+    Client* c = (Client*)sm->owner;
+    // Can always fullscreen a managed client
+    return c->managed;
+}
+
+bool fs_guard_can_unfullscreen(StateMachine* sm, void* data) {
+    return true;  // Can always unfullscreen
+}
+
+// Action functions (for transitions triggered by requests)
+void fs_action_enter_fullscreen(StateMachine* sm, void* data) {
+    // Actions are handled by executor, not here
+    // This is only for pure SM-side effects if needed
+}
+
+void fs_action_exit_fullscreen(StateMachine* sm, void* data) {
+    // Actions are handled by executor, not here
+}
+```
+
+---
+
+## Guards vs Actions
+
+**Guards:** Validate whether a transition is allowed
+- Run BEFORE the transition happens
+- Can inspect current state, target state, owner properties
+- Can reject transition (return false)
+
+**Actions:** Side effects that happen during transition
+- Run AFTER guard passes, BEFORE state update
+- Usually empty (executor handles X calls)
+- Can be used for pure in-SM effects (logging, updating other fields)
+
+---
+
+## Hooks (for Plugins)
+
+Plugins can attach hooks to run before/after SM operations:
+
+```c
+typedef enum HookPhase {
+    HOOK_PRE_GUARD,
+    HOOK_POST_GUARD,
+    HOOK_PRE_ACTION,
+    HOOK_POST_ACTION,
+    HOOK_PRE_EMIT,
+    HOOK_POST_EMIT,
+} HookPhase;
+
+typedef void (*HookFn)(StateMachine* sm, void* userdata);
+
+void sm_add_hook(StateMachine* sm, HookPhase phase, HookFn fn, void* userdata) {
+    // Add to sm->hooks[phase]
+}
+```
+
+**Use cases:**
+- Plugin wants to log all fullscreen transitions
+- Plugin wants to add a custom guard (e.g., "don't fullscreen if video is playing")
+- Plugin wants to trigger UI update on state change
+
+---
+
+## Memory Management
+
+**SM lives on target:**
+```c
+struct Client {
+    // ... properties ...
+    
+    StateMachine* sm_fullscreen;
+    StateMachine* sm_floating;
+    StateMachine* sm_urgency;
+    // ...
+};
+```
+
+**Lazy allocation:**
+```c
+StateMachine* client_get_sm(Client* c, const char* sm_name) {
+    if (strcmp(sm_name, "fullscreen") == 0) {
+        if (!c->sm_fullscreen) {
+            c->sm_fullscreen = sm_create(c, &fullscreen_template);
+        }
+        return c->sm_fullscreen;
+    }
+    // ... other SMs
+}
+```
+
+**Target destruction:**
+```c
+void client_destroy(Client* c) {
+    sm_destroy(c->sm_fullscreen);
+    sm_destroy(c->sm_floating);
+    sm_destroy(c->sm_urgency);
+    // ... free other resources
+    free(c);
+}
+```
+
+---
+
+## Thread Safety
+
+Each SM is single-threaded (one event at a time). For v1, all processing is single-threaded.
+
+If multi-threaded in future:
+- SM operations would need mutex (or per-SM locks)
+- Event emission could be lock-free if using a ring buffer
+
+---
+
+## Header: sm.h
+
+```c
+#ifndef SM_H
+#define SM_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+// Forward declarations
+typedef struct StateMachine StateMachine;
+typedef struct Target Target;
+typedef struct Event Event;
+
+// State machine instance
+struct StateMachine {
+    const char* name;
+    uint32_t current_state;
+    Target* owner;
+    
+    struct SMTemplate* template;
+    
+    struct Hook* hooks[HOOK_MAX];
+    void* data;
+};
+
+// Operations
+StateMachine* sm_create(Target* owner, struct SMTemplate* tmpl);
+void sm_destroy(StateMachine* sm);
+
+void sm_raw_write(StateMachine* sm, uint32_t new_state);
+bool sm_transition(StateMachine* sm, uint32_t target_state);
+uint32_t sm_get_state(StateMachine* sm);
+
+// Query
+bool sm_can_transition(StateMachine* sm, uint32_t target_state);
+uint32_t* sm_get_available_transitions(StateMachine* sm, uint32_t* count);
+
+// Hooks
+typedef enum HookPhase {
+    HOOK_PRE_GUARD,
+    HOOK_POST_GUARD,
+    HOOK_PRE_ACTION,
+    HOOK_POST_ACTION,
+    HOOK_PRE_EMIT,
+    HOOK_POST_EMIT,
+    HOOK_MAX,
+} HookPhase;
+
+typedef void (*HookFn)(StateMachine* sm, void* userdata);
+void sm_add_hook(StateMachine* sm, HookPhase phase, HookFn fn, void* userdata);
+void sm_remove_hook(StateMachine* sm, HookPhase phase, HookFn fn);
+
+// Template helpers
+struct SMTemplate* sm_get_template(StateMachine* sm);
+const char* sm_get_state_name(StateMachine* sm, uint32_t state);
+
+#endif // SM_H
+```
+
+---
+
+## Testing Strategy
+
+1. **Unit tests for sm_transition**: Valid/invalid transitions
+2. **Unit tests for guards**: Guard rejection/acceptance
+3. **Unit tests for hooks**: Hooks called in correct order
+4. **Unit tests for raw_write**: Forced state changes
+5. **Integration with target**: SM lifecycle tied to target lifecycle
+
+---
+
+*See also:*
+- `architecture/overview.md` — High-level architecture
+- `architecture/component.md` — How components use SMs
+- `architecture/target.md` — Target adoption of SM templates

--- a/docs/architecture/target.md
+++ b/docs/architecture/target.md
@@ -1,0 +1,658 @@
+# Target Design
+
+*Part of architecture documentation — Authoritative*
+*Last updated: 2026-04-28*
+
+---
+
+## Purpose
+
+A Target is an entity that exists in the system and can be the subject of state transitions. Targets own:
+- Their properties (geometry, title, etc.)
+- Adopted state machines (lazy-allocated)
+- Adopted component listeners
+
+Examples: CLIENT (windows), MONITOR (displays), KEYBOARD (future), TAG (virtual workspaces)
+
+---
+
+## Target Types
+
+```c
+enum TargetType {
+    TARGET_TYPE_CLIENT,      // X11 windows
+    TARGET_TYPE_MONITOR,     // Physical displays (RandR outputs)
+    TARGET_TYPE_KEYBOARD,    // Input devices (future)
+    TARGET_TYPE_TAG,         // Virtual workspaces
+    TARGET_TYPE_SYSTEM,      // Global WM state
+};
+```
+
+**Key design principle:** Each target type has different compatible components.
+
+| Target Type | Compatible Components |
+|-------------|---------------------|
+| CLIENT | fullscreen, floating, urgency, focus, ... |
+| MONITOR | connection, resolution, bar, ... |
+| KEYBOARD | (none for v1) |
+| TAG | pertag (stores per-tag state), ... |
+| SYSTEM | (global event handlers) |
+
+---
+
+## Base Target Structure
+
+```c
+struct Target {
+    // Identity
+    TargetID id;            // unique ID (window ID, output ID, etc.)
+    TargetType type;        // what kind of target
+    
+    // Adopted components
+    Component** adopted_components;
+    uint32_t num_components;
+    
+    // Adopted state machines
+    // Stored as name → SM mapping
+    StateMachine** sms;     // array of adopted SMs
+    char** sm_names;         // corresponding names
+    uint32_t num_sms;
+    
+    // Type-specific data
+    void* data;             // points to Client*, Monitor*, etc.
+};
+```
+
+---
+
+## Client Target
+
+```c
+struct Client {
+    // Base target
+    Target target;
+    
+    // X properties
+    xcb_window_t window;
+    char* title;
+    char* class_name;
+    
+    // Geometry
+    int x, y;
+    uint16_t width, height;
+    uint16_t border_width;
+    
+    // Monitor association
+    Monitor* monitor;
+    
+    // Tags
+    uint32_t tags;          // bitmask of assigned tags
+    
+    // Managed state
+    bool managed;           // added to window list
+    bool urgent;            // has urgency hint
+    bool focusable;          // can receive focus
+    
+    // For clientlist ordering
+    Client* next;
+    Client* prev;
+    Client* slist_next;     // stacking list next
+};
+```
+
+### Client Creation
+```c
+Client* client_create(xcb_window_t window) {
+    Client* c = malloc(sizeof(Client));
+    
+    // Base target initialization
+    c->target.id = window;
+    c->target.type = TARGET_TYPE_CLIENT;
+    c->target.data = c;
+    c->target.adopted_components = NULL;
+    c->target.num_components = 0;
+    c->target.sms = NULL;
+    c->target.num_sms = 0;
+    
+    // X properties
+    c->window = window;
+    c->title = NULL;
+    c->class_name = NULL;
+    c->monitor = NULL;
+    c->tags = 0;
+    c->managed = false;
+    c->urgent = false;
+    c->focusable = true;
+    c->next = c->prev = NULL;
+    c->slist_next = NULL;
+    
+    // Register with hub
+    hub_register_target(&c->target);
+    
+    // Adopt compatible components
+    Component** comps = hub_get_components_for_target_type(TARGET_TYPE_CLIENT);
+    for (int i = 0; comps[i]; i++) {
+        component_adopt(comps[i], &c->target);
+    }
+    
+    return c;
+}
+```
+
+---
+
+## Monitor Target
+
+```c
+struct Monitor {
+    // Base target
+    Target target;
+    
+    // XRandR properties
+    xcb_randr_output_t output;
+    xcb_randr_crtc_t crtc;
+    
+    // Geometry
+    int x, y;               // screen position
+    uint16_t width, height; // resolution
+    
+    // Tag state
+    uint32_t tagset;         // bitmask of visible tags
+    uint32_t prevtagset;     // for switching
+    
+    // Layout
+    Layout* current_layout;
+    Layout* layouts[];       // available layouts (pertag stores per-index)
+    
+    // Tiling
+    float mfact;             // master factor (0.0 - 1.0)
+    int nmaster;             // number in master area
+    
+    // Client list
+    Client* clients;         // first client
+    Client* sel;             // selected client
+    Client* stack;          // stacking order (bottom to top)
+    
+    // Bar
+    Bar* bar;
+    
+    // Next monitor (for iteration)
+    Monitor* next;
+};
+```
+
+### Monitor Creation
+```c
+Monitor* monitor_create(xcb_randr_output_t output) {
+    Monitor* m = malloc(sizeof(Monitor));
+    
+    // Base target
+    m->target.id = (TargetID)output;
+    m->target.type = TARGET_TYPE_MONITOR;
+    m->target.data = m;
+    
+    // RandR properties
+    m->output = output;
+    m->crtc = XCB_NONE;
+    
+    // Default state
+    m->tagset = 1 << 0;  // tag 1
+    m->mfact = 0.5;
+    m->nmaster = 1;
+    m->current_layout = &layouts[LAYOUT_TILE];
+    m->clients = NULL;
+    m->sel = NULL;
+    m->stack = NULL;
+    m->bar = NULL;
+    m->next = NULL;
+    
+    // Register with hub
+    hub_register_target(&m->target);
+    
+    // Adopt compatible components
+    Component** comps = hub_get_components_for_target_type(TARGET_TYPE_MONITOR);
+    for (int i = 0; comps[i]; i++) {
+        component_adopt(comps[i], &m->target);
+    }
+    
+    return m;
+}
+```
+
+---
+
+## Target Adoption
+
+When a target is created, it adopts all compatible components from the registry.
+
+### Adoption Process
+```c
+void target_adopt(Target* t, Component* c) {
+    // Check if already adopted
+    for (uint32_t i = 0; i < t->num_components; i++) {
+        if (t->adopted_components[i] == c) return;
+    }
+    
+    // Add to adopted list
+    t->adopted_components = realloc(t->adopted_components,
+        (t->num_components + 1) * sizeof(Component*));
+    t->adopted_components[t->num_components++] = c;
+    
+    // Call component's on_adopt hook
+    c->on_adopt(t);
+}
+```
+
+### Lazy SM Allocation
+```c
+StateMachine* target_get_sm(Target* t, const char* sm_name) {
+    // Check if SM already exists
+    for (uint32_t i = 0; i < t->num_sms; i++) {
+        if (strcmp(t->sm_names[i], sm_name) == 0) {
+            return t->sms[i];
+        }
+    }
+    
+    // Find component that provides this SM
+    Component* c = NULL;
+    for (uint32_t i = 0; i < t->num_components; i++) {
+        SMTemplate* tmpl = t->adopted_components[i]->get_sm_template();
+        if (tmpl && strcmp(tmpl->name, sm_name) == 0) {
+            c = t->adopted_components[i];
+            break;
+        }
+    }
+    
+    if (!c) return NULL;  // No component provides this SM
+    
+    // Create SM lazily
+    SMTemplate* tmpl = c->get_sm_template();
+    StateMachine* sm = sm_create(t, tmpl);
+    
+    // Add to target's SM list
+    t->sms = realloc(t->sms, (t->num_sms + 1) * sizeof(StateMachine*));
+    t->sm_names = realloc(t->sm_names, (t->num_sms + 1) * sizeof(char*));
+    t->sms[t->num_sms] = sm;
+    t->sm_names[t->num_sms] = strdup(sm_name);
+    t->num_sms++;
+    
+    return sm;
+}
+```
+
+---
+
+## Target Destruction
+
+```c
+void target_destroy(Target* t) {
+    // Call component unadopt hooks
+    for (uint32_t i = 0; i < t->num_components; i++) {
+        t->adopted_components[i]->on_unadopt(t);
+    }
+    
+    // Destroy all state machines
+    for (uint32_t i = 0; i < t->num_sms; i++) {
+        sm_destroy(t->sms[i]);
+        free(t->sm_names[i]);
+    }
+    free(t->sms);
+    free(t->sm_names);
+    
+    // Free adopted components array
+    free(t->adopted_components);
+    
+    // Unregister from hub
+    hub_unregister_target(t->id);
+}
+```
+
+---
+
+## Target Lookup
+
+```c
+// Get target by ID
+Target* target_by_id(TargetID id) {
+    return hub_get_target(id);
+}
+
+// Get target by X window
+Client* client_by_window(xcb_window_t window) {
+    Target* t = hub_get_target(window);
+    return t ? (Client*)t->data : NULL;
+}
+
+// Get all clients
+Client** get_all_clients(void) {
+    Target** targets = hub_get_targets_by_type(TARGET_TYPE_CLIENT);
+    Client** clients = malloc(sizeof(Client*) * (target_count + 1));
+    for (int i = 0; targets[i]; i++) {
+        clients[i] = targets[i]->data;
+    }
+    clients[target_count] = NULL;
+    return clients;
+}
+```
+
+---
+
+## Component Filtering
+
+Components declare which target types they accept:
+
+```c
+Component fullscreen_component = {
+    .name = "fullscreen",
+    .accepted_targets = (TargetType[]){ TARGET_TYPE_CLIENT },
+    .num_targets = 1,
+    // ...
+};
+
+Component connection_component = {
+    .name = "connection",
+    .accepted_targets = (TargetType[]){ TARGET_TYPE_MONITOR },
+    .num_targets = 1,
+    // ...
+};
+```
+
+When a target is created, the hub finds compatible components:
+
+```c
+Component** hub_get_components_for_target_type(TargetType type) {
+    static Component* results[64];
+    uint32_t count = 0;
+    
+    for (Component* c = registry; c; c = c->next) {
+        for (uint32_t i = 0; i < c->num_targets; i++) {
+            if (c->accepted_targets[i] == type) {
+                results[count++] = c;
+                break;
+            }
+        }
+    }
+    results[count] = NULL;
+    
+    return results;
+}
+```
+
+---
+
+## Lazy vs Eager Adoption
+
+### Current Design: Eager for Built-in Components
+
+When a target is created, it immediately adopts all compatible components. This ensures:
+- All functionality is available immediately
+- No race conditions on first use
+- Simpler code
+
+### Future: Plugin Adoption
+
+For plugins loaded at runtime, adoption should be optional:
+
+```c
+// Option 1: Plugin specifies what to adopt by default
+// In plugin registration
+PluginConfig gap_config = {
+    .default_adoption = TARGET_TYPE_MONITOR,
+};
+
+// Option 2: User config specifies
+// config.def.h:
+target "monitor" adopt: gap, bar, connection, ...
+```
+
+### Unadoption
+
+Targets can unadopt components (when plugins are unloaded):
+
+```c
+void target_unadopt(Target* t, Component* c) {
+    // Find in adopted list
+    int idx = -1;
+    for (uint32_t i = 0; i < t->num_components; i++) {
+        if (t->adopted_components[i] == c) {
+            idx = i;
+            break;
+        }
+    }
+    
+    if (idx < 0) return;  // Not adopted
+    
+    // Remove from list
+    for (uint32_t i = idx; i < t->num_components - 1; i++) {
+        t->adopted_components[i] = t->adopted_components[i + 1];
+    }
+    t->num_components--;
+    
+    // Call component's on_unadopt hook
+    c->on_unadopt(t);
+    
+    // Remove SM if it exists
+    SMTemplate* tmpl = c->get_sm_template();
+    if (tmpl) {
+        target_remove_sm(t, tmpl->name);
+    }
+}
+```
+
+---
+
+## Special Targets: Symbolic References
+
+The hub supports symbolic targets that resolve to concrete targets:
+
+```c
+enum SpecialTargets {
+    TARGET_CURRENT_CLIENT = 0,     // = 0, invalid as real ID
+    TARGET_CURRENT_MONITOR = 1,
+    TARGET_ALL_CLIENTS = 2,
+    TARGET_ALL_MONITORS = 3,
+    // ...
+};
+
+// Real targets use window IDs, output IDs, etc. which are > 100
+#define IS_SYMBOLIC(target) ((target) < 100)
+#define TARGET_CLIENT(id) ((TargetID)((id) + 100))
+```
+
+Resolution happens in the hub before routing:
+
+```c
+TargetID hub_resolve_target(TargetID symbolic) {
+    if (symbolic == TARGET_CURRENT_CLIENT) {
+        return focus_component_get_current_client();
+    }
+    if (symbolic == TARGET_CURRENT_MONITOR) {
+        return monitor_component_get_current_monitor();
+    }
+    if (symbolic == TARGET_ALL_CLIENTS || IS_SYMBOLIC(symbolic)) {
+        return symbolic;  // handled specially by router
+    }
+    return symbolic;  // already concrete
+}
+```
+
+---
+
+## Header: target.h
+
+```c
+#ifndef TARGET_H
+#define TARGET_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "types.h"
+#include "component.h"
+#include "sm.h"
+
+typedef uint64_t TargetID;
+typedef uint32_t TargetType;
+
+// Base target structure
+typedef struct Target {
+    TargetID id;
+    TargetType type;
+    void* data;  // points to Client*, Monitor*, etc.
+    
+    // Adopted components
+    Component** adopted_components;
+    uint32_t num_components;
+    
+    // Adopted state machines
+    StateMachine** sms;
+    char** sm_names;
+    uint32_t num_sms;
+} Target;
+
+// Target lifecycle
+Target* target_create(TargetType type, void* data);
+void target_destroy(Target* t);
+
+// Component adoption
+void target_adopt(Target* t, Component* c);
+void target_unadopt(Target* t, Component* c);
+
+// State machine lookup
+StateMachine* target_get_sm(Target* t, const char* sm_name);
+void target_remove_sm(Target* t, const char* sm_name);
+
+// Target types
+enum TargetType {
+    TARGET_TYPE_CLIENT,
+    TARGET_TYPE_MONITOR,
+    TARGET_TYPE_KEYBOARD,
+    TARGET_TYPE_TAG,
+    TARGET_TYPE_SYSTEM,
+};
+
+// Special targets
+enum SpecialTargets {
+    TARGET_CURRENT_CLIENT = 0,
+    TARGET_CURRENT_MONITOR = 1,
+    TARGET_ALL_CLIENTS = 2,
+    TARGET_ALL_MONITORS = 3,
+};
+
+#define IS_SYMBOLIC(target) ((target) < 100)
+
+#endif // TARGET_H
+```
+
+---
+
+## Type-Specific Headers
+
+```c
+// client.h
+#ifndef CLIENT_H
+#define CLIENT_H
+
+#include "target.h"
+
+struct Client {
+    // Base
+    Target target;
+    
+    // X
+    xcb_window_t window;
+    char* title;
+    char* class_name;
+    
+    // Geometry
+    int x, y;
+    uint16_t width, height;
+    uint16_t border_width;
+    
+    // Relations
+    Monitor* monitor;
+    uint32_t tags;
+    
+    // State
+    bool managed;
+    bool urgent;
+    bool focusable;
+    
+    // List
+    Client* next;
+    Client* prev;
+    Client* slist_next;
+};
+
+Client* client_create(xcb_window_t window);
+void client_destroy(Client* c);
+
+// Helper: get SM
+#define client_get_sm(c, name) target_get_sm(&(c)->target, name)
+
+#endif // CLIENT_H
+
+// monitor.h
+#ifndef MONITOR_H
+#define MONITOR_H
+
+#include "target.h"
+#include "layout.h"
+
+struct Monitor {
+    // Base
+    Target target;
+    
+    // RandR
+    xcb_randr_output_t output;
+    xcb_randr_crtc_t crtc;
+    
+    // Geometry
+    int x, y;
+    uint16_t width, height;
+    
+    // Tag state
+    uint32_t tagset;
+    uint32_t prevtagset;
+    
+    // Tiling
+    float mfact;
+    int nmaster;
+    Layout* current_layout;
+    
+    // Clients
+    Client* clients;
+    Client* sel;
+    Client* stack;
+    
+    // Bar
+    Bar* bar;
+    
+    // Next
+    Monitor* next;
+};
+
+Monitor* monitor_create(xcb_randr_output_t output);
+void monitor_destroy(Monitor* m);
+
+#define monitor_get_sm(m, name) target_get_sm(&(m)->target, name)
+
+#endif // MONITOR_H
+```
+
+---
+
+## Testing Strategy
+
+1. **Unit tests for target creation**: Verify components adopted
+2. **Unit tests for lazy SM allocation**: First access creates SM
+3. **Unit tests for component adoption/unadoption**: Correct hooks called
+4. **Unit tests for target lookup**: By ID, by window, by type
+5. **Integration tests**: Full lifecycle (create → use → destroy)
+
+---
+
+*See also:*
+- `architecture/overview.md` — High-level architecture
+- `architecture/component.md` — Component design
+- `architecture/state-machine.md` — SM framework
+- `architecture/hub.md` — Hub routing

--- a/docs/extensions/README.md
+++ b/docs/extensions/README.md
@@ -1,0 +1,135 @@
+# Extension Registry — ./wm/docs/extensions/
+
+This directory contains design documents for all planned extensions/plugins for the `./wm/` window manager.
+
+## Extension Index
+
+| ID | Name | Priority | DWM Equivalent | Dependencies |
+|----|------|----------|----------------|--------------|
+| [gap](gap.md) | Gap Plugin | High | dwm-gaps | Core tiling |
+| [pertag](pertag.md) | Per-Tag Settings | High | dwmpertag | Core tags |
+| [floatpos](floatpos.md) | Floating Position Rules | High | dwm-floatpos | Core floating |
+| [urgency](urgency.md) | Urgency Notifications | Medium | dwm-urgencyhook | Core focus |
+| [scratchpad](scratchpad.md) | Scratchpads | High | dwm-scratchpads | Core tags |
+| [bstack](bstack.md) | BStack Layout | Medium | dwm-bstack | Core tiling |
+| [cfact](cfact.md) | Client Factor (Relative Sizing) | Medium | dwm-cfacts | Core tiling |
+| [actualfullscreen](actualfullscreen.md) | Actual Fullscreen | Medium | dwm-actualfullscreen | Core fullscreen |
+| [resizecorners](resizecorners.md) | Resize Corners | Low | dwm-resizecorners | Core resize |
+| [focus-adjacent](focus-adjacent.md) | Focus Adjacent Tag | Low | dwm-focusadjacenttag | Core tags |
+| [ewmh-desktop](ewmh-desktop.md) | EWMH Desktop Support | High | dwm-ewmh | Core tags |
+| [bar-style](bar-style.md) | Bar Padding/Styling | Medium | dwm-bar-padding | Core bar |
+| [attach-policy](attach-policy.md) | Client Insertion Policy | Low | dwm-attach-aside-and-below | Core attach |
+
+## Priority Levels
+
+- **High**: Essential features, commonly requested, needed for basic workflow
+- **Medium**: Important but not essential, popular enhancements
+- **Low**: Convenience features, specific use cases
+
+## Cross-Extension Dependencies
+
+```
+gap ──────┬────── pertag ─────── ewmh-desktop
+          │                      │
+          └──────────┬───────────┘
+                     │
+         ┌──────────┴──────────┐
+         │                     │
+         ▼                     ▼
+       bstack               bar-style
+         │                     │
+         └──────────┬──────────┘
+                    │
+                    ▼
+                 cfact
+                    │
+         ┌──────────┴──────────┐
+         │                     │
+         ▼                     ▼
+    floatpos             resizecorners
+         │
+         └──────────┬──────────┐
+                    │          │
+                    ▼          ▼
+              scratchpad    urgency
+                    │
+                    ▼
+              actualfullscreen
+
+attach-policy ──→ (standalone, minimal deps)
+```
+
+## Implementation Order Suggestion
+
+### Phase 1: Core Infrastructure
+1. **ewmh-desktop** — Required for external tools to work with the WM
+2. **pertag** — Foundation for multi-tag workflows
+
+### Phase 2: Basic Extensions
+3. **gap** — Very common feature, demonstrates hook system
+4. **bstack** — New layout, proves layout extensibility
+5. **cfact** — Relative sizing, enhances tiling
+
+### Phase 3: User Experience
+6. **floatpos** — Floating window positioning
+7. **scratchpad** — Quick access windows
+8. **bar-style** — Visual customization
+
+### Phase 4: Polish
+9. **urgency** — Attention-getting
+10. **actualfullscreen** — Fullscreen enhancement
+11. **resizecorners** — Resize UX
+12. **focus-adjacent** — Navigation convenience
+
+### Phase 5: Advanced
+13. **attach-policy** — Client ordering
+
+## Event Coverage
+
+Each extension uses specific events. Here's the coverage:
+
+| Event | Extensions |
+|-------|------------|
+| `EVT_TAG_VIEW_CHANGED` | pertag, ewmh-desktop, urgency, focus-adjacent |
+| `EVT_CLIENT_MANAGED` | floatpos, pertag, attach-policy |
+| `EVT_CLIENT_FOCUS_GAIN/LOSE` | urgency, pertag |
+| `EVT_CLIENT_FLOAT_ENABLED/DISABLED` | floatpos, resizecorners |
+| `EVT_CLIENT_FULLSCREEN_ENTER/EXIT` | actualfullscreen |
+| `EVT_LAYOUT_CHANGED` | pertag, bstack, gap |
+| `EVT_TILING_PARAM_CHANGED` | gap, cfact |
+| `EVT_TILING_RECALCULATE` | cfact |
+| `EVT_BAR_SHOWN/HIDDEN` | bar-style, actualfullscreen |
+| `EVT_BAR_DRAW` | bar-style |
+| `EVT_RESIZE_START/UPDATE/END` | resizecorners |
+| `EVT_SCRATCHPAD_*` | scratchpad |
+
+## Extension Template
+
+To add a new extension, create a `.md` file with:
+
+```markdown
+# Extension: [Name]
+
+## Overview
+One paragraph description.
+
+## DWM Reference
+Which dwm patch/function this corresponds to.
+
+## State Machine Events
+Table of events this extension subscribes to.
+
+## Hook Points
+Code examples showing hook callbacks.
+
+## Configuration
+Config struct and keybindings.
+
+## Interactions
+How it interacts with other extensions.
+```
+
+---
+
+*Last updated: 2026-04-28*
+*Total extensions: 13*

--- a/docs/extensions/actualfullscreen.md
+++ b/docs/extensions/actualfullscreen.md
@@ -1,0 +1,100 @@
+# Extension: Actual Fullscreen
+
+## Overview
+
+A fullscreen mode that respects window borders and bar visibility, unlike dwm's default fullscreen which hides both. "Actual fullscreen" fills the entire monitor including the bar area, while still allowing EWMH compliance.
+
+## DWM Reference
+
+Based on `setfullscreen.md`, `togglefloating.md`:
+- `setfullscreen()` enters fullscreen, sets `isfullscreen = 1`
+- Fullscreen implies `isfloating = 1` (borders suppressed)
+- `bw = 0` for fullscreen clients
+- Bar hidden on fullscreen via `togglebar()` in `togglefullscr()`
+- Exit fullscreen restores `oldstate`, `oldbw`, geometry
+
+## State Machine Events
+
+| Event | Description | Payload |
+|-------|-------------|---------|
+| `EVT_CLIENT_FULLSCREEN_ENTER` | Client entered fullscreen | `Client*` |
+| `EVT_CLIENT_FULLSCREEN_EXIT` | Client exited fullscreen | `Client*` |
+| `EVT_BAR_SHOWN/HIDDEN` | Bar visibility changed | `Monitor*` |
+
+## Two Fullscreen Modes
+
+| Mode | Bar | Border | X11 Geometry |
+|------|-----|--------|--------------|
+| dwm Default | Hidden | 0 | Monitor size (mx, my, mw, mh) |
+| Actual Fullscreen | Visible | 0 | Full screen including bar |
+
+The extension adds an `actualfullscreen` flag per client:
+
+```c
+typedef struct {
+    int actual_fullscreen;      // If set, include bar in fullscreen
+    int preserve_bar_state;    // Remember bar state for restore
+} ActualFullscreenConfig;
+```
+
+## Hook Points
+
+```c
+void on_fullscreen_enter(const Event* evt, void* userdata) {
+    Client* c = evt->subject;
+    ActualFullscreenConfig* cfg = userdata;
+    
+    if (cfg->actual_fullscreen) {
+        // Resize to include bar area
+        Monitor* m = c->mon;
+        resizeclient(c, m->mx, m->my, m->mw, m->mh);  // Full physical screen
+        
+        // Keep bar visible (don't hide)
+    } else {
+        // Standard dwm behavior: resize to window area, hide bar
+        resizeclient(c, m->mx, m->my, m->mw, m->mh);  // Excludes bar
+        togglebar(NULL);  // Hide bar
+    }
+}
+
+void on_fullscreen_exit(const Event* evt, void* userdata) {
+    Client* c = evt->subject;
+    ActualFullscreenConfig* cfg = userdata;
+    
+    // Restore bar if it was hidden
+    if (cfg->preserve_bar_state && c->mon->oldbar) {
+        togglebar(NULL);
+    }
+}
+```
+
+## Configuration
+
+```c
+static ActualFullscreenConfig afs_config = {
+    .actual_fullscreen = 1,    // Enable actual fullscreen mode
+    .preserve_bar_state = 1,   // Remember and restore bar state
+};
+```
+
+## Keybindings
+
+```c
+static Key keys[] = {
+    // Toggle actual fullscreen (separate from standard fullscreen)
+    { MODKEY | ShiftMask, XK_f, actualfullscreen_toggle, {0} },
+};
+```
+
+## Interactions
+
+- Can work alongside standard fullscreen as separate mode
+- EWMH `_NET_WM_STATE_FULLSCREEN` can trigger either mode
+- Respects `lockfullscreen` config option
+- Bar visibility managed separately from fullscreen state
+
+---
+
+*Extension ID: actualfullscreen*
+*Priority: Medium (popular enhancement)*
+*DWM patch equivalent: dwm-actualfullscreen*

--- a/docs/extensions/attach-policy.md
+++ b/docs/extensions/attach-policy.md
@@ -1,0 +1,78 @@
+# Extension: Attach Below / Aside
+
+## Overview
+
+Controls how new clients are inserted into the client list. The default dwm prepends clients to the head; this extension allows alternative insertion policies:
+- **Attach Below**: Insert after the focused client
+- **Attach Aside**: Insert after focused client but maintain focus order
+- **Attach After Window**: Insert at specific position
+
+## DWM Reference
+
+Based on `attach.md`, `manage.md`:
+- `attach()` prepends to head (newest on top)
+- `attachstack()` prepends to stack
+- `attachBelow()` — custom patch in this dwm fork
+- `manage()` calls `attach(c)` then `attachstack(c)`
+
+## State Machine Events
+
+| Event | Description | Payload |
+|-------|-------------|---------|
+| `EVT_CLIENT_MANAGED` | Client being registered | `Client*`, `Monitor*` |
+| `EVT_CLIENT_INSERTED` | Client inserted into list | `Client*`, `position` |
+
+## Insertion Policies
+
+```c
+enum InsertPolicy {
+    INSERT_HEAD,      // Prepend (dwm default)
+    INSERT_TAIL,      // Append
+    INSERT_AFTER_SEL, // After focused client
+    INSERT_BELOW_SEL, // Below focused client in tiling order
+};
+
+typedef struct {
+    enum InsertPolicy policy;
+    int preserve_focus;   // Keep focus on current client
+} AttachConfig;
+```
+
+## Hook Points
+
+```c
+void on_client_managed(const Event* evt, void* userdata) {
+    Client* c = evt->subject;
+    AttachConfig* cfg = userdata;
+    
+    switch (cfg->policy) {
+    case INSERT_AFTER_SEL:
+        if (c->mon->sel && c->mon->sel->isfloating) {
+            // Insert after selected client
+            Client* sel = c->mon->sel;
+            c->next = sel->next;
+            sel->next = c;
+        } else {
+            attach(c);  // Default prepend
+        }
+        break;
+    case INSERT_TAIL:
+        attach_tail(c);
+        break;
+    default:
+        attach(c);
+    }
+}
+```
+
+## Interactions
+
+- Affects tiling order (which client gets tiled first)
+- Works with `pertag` (focus tracking per tag)
+- `attachBelow()` custom function from dwm patch
+
+---
+
+*Extension ID: attach-policy*
+*Priority: Low (specific use case)*
+*DWM patch equivalent: dwm-attach-aside-and-below*

--- a/docs/extensions/bar-style.md
+++ b/docs/extensions/bar-style.md
@@ -1,0 +1,117 @@
+# Extension: Bar Padding and Styling
+
+## Overview
+
+Configurable status bar appearance including padding, position (top/bottom), and visual styling. This extends the default bar with more customization options.
+
+## DWM Reference
+
+Based on `globals.md`, `togglebar.md`:
+- `bh` = bar height (font height + vertical padding)
+- `sp` = side padding
+- `lrpad` = left/right padding for text
+- `vp` = vertical padding (adjusts for top/bottom bar)
+- `topbar` = bar position (1=top, 0=bottom)
+- `showbar` = current visibility
+- `vertpadbar` = vertical padding of bar
+- `horizpadbar` = horizontal padding for status text
+
+## State Machine Events
+
+| Event | Description | Payload |
+|-------|-------------|---------|
+| `EVT_BAR_SHOWN` | Bar became visible | `Monitor*` |
+| `EVT_BAR_HIDDEN` | Bar became hidden | `Monitor*` |
+| `EVT_BAR_DRAW` | Bar being drawn | `Monitor*` |
+
+## Configuration
+
+```c
+typedef struct {
+    int height;                 // Bar height in pixels
+    int side_pad;              // Horizontal padding (left/right of bar)
+    int vert_pad;              // Vertical padding between bar and window area
+    int horiz_pad_bar;         // Horizontal padding for bar content
+    int top_bar;               // 1=top, 0=bottom
+    int show_by_default;       // Show bar on startup
+} BarStyleConfig;
+
+static BarStyleConfig bar_config = {
+    .height = 0,               // 0 = auto (font height + vert_pad_bar)
+    .side_pad = 2,
+    .vert_pad = 2,
+    .horiz_pad_bar = 2,
+    .top_bar = 1,
+    .show_by_default = 1,
+};
+```
+
+## Hook Points
+
+```c
+void on_bar_shown(const Event* evt, void* userdata) {
+    Monitor* m = evt->source;
+    BarStyleConfig* cfg = userdata;
+    
+    // Update bar window geometry
+    update_bar_geometry(m, cfg);
+    
+    // Map the bar window
+    xcb_map_window(dpy, m->barwin);
+}
+
+void on_bar_draw(const Event* evt, void* userdata) {
+    Monitor* m = evt->source;
+    BarStyleConfig* cfg = userdata;
+    
+    // Draw with configured padding
+    int x = cfg->side_pad;
+    int w = m->ww - 2 * cfg->side_pad;
+    
+    // Draw tags, layout symbol, client name, etc.
+    draw_tags(m, x, w, cfg);
+    draw_layout_symbol(m, ...);
+    draw_client_name(m, ...);
+    draw_status_text(m, ...);
+}
+```
+
+## Keybindings
+
+```c
+static Key keys[] = {
+    { MODKEY, XK_b, togglebar, {0} },
+};
+```
+
+## Bar Window Updates
+
+```c
+void update_bar_geometry(Monitor* m, BarStyleConfig* cfg) {
+    int bh = cfg->height ? cfg->height : font_height + 2 * cfg->vert_pad;
+    
+    if (cfg->top_bar) {
+        m->by = m->wy;              // Bar at top of work area
+        m->wy = m->wy + bh;         // Work area below bar
+    } else {
+        m->by = m->wy + m->wh;      // Bar at bottom
+        m->wh = m->wh - bh;        // Work area above bar
+    }
+    
+    // Resize bar window
+    xcb_set_window_rect(dpy, m->barwin, m->wx + cfg->side_pad, m->by,
+                        m->ww - 2 * cfg->side_pad, bh);
+}
+```
+
+## Interactions
+
+- Affects window area calculation (`wy, wh`)
+- Works with fullscreen mode (bar hidden/restored)
+- Works with `pertag` (bar visibility per tag)
+
+---
+
+*Extension ID: bar-style*
+*Priority: Medium (common customization)*
+*DWM patch equivalent: dwm-bar-padding, dwm-statuspadding*

--- a/docs/extensions/bstack.md
+++ b/docs/extensions/bstack.md
@@ -1,0 +1,126 @@
+# Extension: BStack Layout (Bottom Stack)
+
+## Overview
+
+A tiling layout variant where the master area is at the top and the stack area fills the bottom portion of the screen. Two sub-variants:
+- **BStack**: Master at top, stack below (horizontal slices)
+- **BStackHoriz**: Same but stack uses horizontal splits instead of vertical columns
+
+## DWM Reference
+
+Based on `tile.md` analysis:
+- `bstack()` and `bstackhoriz()` functions in dwm
+- BStack: master on top (full width), stack in columns below
+- BStackHoriz: master on top, stack rows below
+- Both use `nmaster` to determine how many clients in master area
+- `mfact` controls master height/width split
+
+## State Machine Events
+
+| Event | Description | Payload |
+|-------|-------------|---------|
+| `EVT_LAYOUT_CHANGED` | Layout switched to bstack | `Monitor*`, `layout` |
+| `EVT_LAYOUT_ARRANGE` | Layout arranges clients | `Monitor*`, `layout` |
+
+## Layout Function Signature
+
+```c
+typedef void (*ArrangeFn)(Monitor* m);
+
+typedef struct Layout {
+    const char* symbol;        // Display symbol in bar (e.g., "TTT")
+    ArrangeFn arrange;        // Tiling function, or NULL for floating
+} Layout;
+
+static Layout layouts[] = {
+    { .symbol = "[]=", .arrange = tile },
+    { .symbol = "><>", .arrange = NULL },  // Floating
+    { .symbol = "[M]", .arrange = monocle },
+    { .symbol = "TTT", .arrange = bstack },
+    { .symbol = "===", .arrange = bstackhoriz },
+};
+```
+
+## BStack Algorithm
+
+```c
+void bstack(Monitor* m) {
+    unsigned int i, n, h, mw, my;
+    Client* c;
+    
+    // Count visible clients
+    for (n = 0, c = nexttiled(m->clients); c; c = nexttiled(c->next), n++);
+    if (n == 0) return;
+    
+    // Determine master height
+    if (n > m->nmaster)
+        mw = m->mfact * m->wh;  // Master gets mfact fraction
+    else
+        mw = m->wh;              // All in master if fewer than nmaster
+    
+    // Master area (top)
+    h = mw;
+    my = 0;
+    for (i = 0, c = nexttiled(m->clients); c && i < m->nmaster; c = nexttiled(c->next)) {
+        resize(c, m->wx, m->wy + my, m->ww, h - 2*c->bw, 0);
+        my += HEIGHT(c);
+        i++;
+    }
+    
+    // Stack area (bottom) — vertical columns
+    for (i = 0, c = nexttiled(m->clients); c; c = nexttiled(c->next)) {
+        if (i < m->nmaster) {
+            i++; continue;
+        }
+        // Stack columns below master
+        resize(c, m->wx, m->wy + mw, m->ww, m->wh - mw - 2*c->bw, 0);
+    }
+}
+```
+
+## Hook Points
+
+```c
+void on_layout_arrange_begin(const Event* evt, void* userdata) {
+    if (evt->layout == LAYOUT_BSTACK || evt->layout == LAYOUT_BSTACK_HORIZ) {
+        // Pre-arrangement setup for bstack
+    }
+}
+
+void on_layout_arrange_end(const Event* evt, void* userdata) {
+    // Post-arrangement (e.g., update bar symbol with client count)
+}
+```
+
+## Configuration
+
+```c
+static LayoutConfig layout_config = {
+    .default_layout = &layouts[0],  // Tile
+    .bstack_cols = 0,               // 0 = automatic columns
+    .bstack_stretch = 1,           // Allow nmaster > visible clients
+};
+```
+
+## Keybindings
+
+```c
+static Key keys[] = {
+    { MODKEY, XK_u, setlayout, {.v = &layouts[3]} },  // BStack
+    { MODKEY, XK_o, setlayout, {.v = &layouts[4]} },  // BStackHoriz
+};
+```
+
+## Interactions
+
+- Uses `nmaster` and `mfact` like `tile()`
+- Respects `cfact` (client factor) for relative sizing
+- Works with `pertag` (layout saved per tag)
+- Works with `gap` plugin (gaps applied in resize calls)
+- Floating clients excluded from tiling (`nexttiled()`)
+
+---
+
+*Extension ID: bstack*
+*Priority: Medium (alternative layout)*
+*DWM patch equivalent: dwm-bstack*

--- a/docs/extensions/cfact.md
+++ b/docs/extensions/cfact.md
@@ -1,0 +1,102 @@
+# Extension: CFact (Client Factor / Relative Window Sizing)
+
+## Overview
+
+Adds per-client "factor" values that control relative sizing in the tiling layout. Each client has a `cfact` value (default 1.0) that scales its portion of the master or stack area. This allows some windows to be larger or smaller than others without changing mfact.
+
+## DWM Reference
+
+Based on `tile.md` and `setcfact.md`:
+- `cfact` field in `Client` struct (float)
+- `tile()` accumulates mfacts/sfacts from `c->cfact`
+- Height computed as: `(wh - my) * (cfact / mfacts)`
+- `setcfact()` adjusts cfact with delta or absolute value
+- Valid range: [0.25, 4.0]
+
+## State Machine Events
+
+| Event | Description | Payload |
+|-------|-------------|---------|
+| `EVT_CLIENT_CFACT_CHANGED` | Client factor updated | `Client*`, `old_cfact`, `new_cfact` |
+| `EVT_TILING_RECALCULATE` | Tiling layout recalculated | `Monitor*` |
+
+## Hook Points
+
+```c
+typedef struct {
+    float default_cfact;        // Default cfact for new clients
+    int allow_zero;             // Allow cfact = 0 (min is normally 0.25)
+} CFactConfig;
+
+void on_client_cfact_changed(const Event* evt, void* userdata) {
+    Client* c = evt->subject;
+    CFactConfig* cfg = userdata;
+    
+    LOG_DEBUG("Client %s cfact: %.2f -> %.2f", c->name, evt->old_val, evt->new_val);
+    
+    // Trigger re-tile if client is visible and tiled
+    if (ISVISIBLE(c) && !c->isfloating) {
+        arrange(c->mon);
+    }
+}
+```
+
+## Configuration
+
+```c
+static CFactConfig cfact_config = {
+    .default_cfact = 1.0,
+    .min_cfact = 0.25,
+    .max_cfact = 4.0,
+};
+```
+
+## Keybindings
+
+```c
+// Adjust cfact of focused client
+{ MODKEY | ShiftMask, XK_h, setcfact, {.f = +0.05} },   // Increase
+{ MODKEY | ShiftMask, XK_l, setcfact, {.f = -0.05} },   // Decrease
+{ MODKEY | ShiftMask, XK_o, setcfact, {.f = 0.0} },     // Reset to 1.0
+```
+
+## Tile Algorithm with CFacts
+
+```c
+// Phase 1: Count and accumulate
+n = 0; mfacts = 0; sfacts = 0;
+for (c = nexttiled(m->clients); c; c = nexttiled(c->next)) {
+    n++;
+    if (n <= m->nmaster)
+        mfacts += c->cfact;    // Sum of master cfacts
+    else
+        sfacts += c->cfact;    // Sum of stack cfacts
+}
+
+// Phase 2: Resize with proportional heights
+for (i = 0, c = nexttiled(m->clients); c; c = nexttiled(c->next)) {
+    if (i < m->nmaster) {
+        // Master area
+        if (mfacts > 0)
+            h = (m->wh - my) * (c->cfact / mfacts);  // Proportional
+        else
+            h = (m->wh - my) / (m->nmaster - i);      // Equal fallback
+        resize(c, m->wx, m->wy + my, mw - 2*c->bw, h - 2*c->bw, 0);
+        my += HEIGHT(c);
+        mfacts -= c->cfact;  // Decrement for next client
+    }
+}
+```
+
+## Interactions
+
+- Works with `tile()` layout — doesn't affect monocle or float
+- `cfact` persists across tag switches (stored in client)
+- `bstack` layout also respects cfact
+- Respects minimum size hints — cfact doesn't override size constraints
+
+---
+
+*Extension ID: cfact*
+*Priority: Medium (popular for multi-pane layouts)*
+*DWM patch equivalent: dwm-cfacts*

--- a/docs/extensions/ewmh-desktop.md
+++ b/docs/extensions/ewmh-desktop.md
@@ -1,0 +1,106 @@
+# Extension: EWMH Desktop Tags
+
+## Overview
+
+Provides EWMH-compliant desktop/tag management, allowing external tools (pagers, panels) to interact with the window manager's workspace system. This exposes tag state via `_NET_NUMBER_OF_DESKTOPS`, `_NET_DESKTOP_NAMES`, `_NET_CURRENT_DESKTOP`, etc.
+
+## DWM Reference
+
+Based on `view.md`, `clientmessage.md`:
+- `setnumdesktops()`, `setdesktopnames()`, `setcurrentdesktop()`, `setviewport()` in dwm
+- `updatecurrentdesktop()` called after tag changes
+- `_NET_DESKTOP_NAMES` uses UTF8 text property with tag names
+- External apps can request `_NET_CURRENT_DESKTOP` change
+
+## State Machine Events
+
+| Event | Description | Payload |
+|-------|-------------|---------|
+| `EVT_TAG_VIEW_CHANGED` | View changed | `Monitor*`, `tagset` |
+| `EVT_TAG_NAME_CHANGED` | Tag name modified | `tag_index`, `new_name` |
+| `EVT_EWMH_DESKTOP_REQUEST` | External desktop change request | `desktop_index` |
+
+## EWMH Atoms
+
+```c
+// Atoms that this extension manages
+static Atom netatom[] = {
+    [NetNumberOfDesktops] = "_NET_NUMBER_OF_DESKTOPS",
+    [NetDesktopNames] = "_NET_DESKTOP_NAMES",
+    [NetCurrentDesktop] = "_NET_CURRENT_DESKTOP",
+    [NetDesktopViewport] = "_NET_DESKTOP_VIEWPORT",
+};
+```
+
+## Hook Points
+
+```c
+typedef struct {
+    const char** tag_names;     // Tag display names
+    int num_tags;               // Number of tags
+    int ewmh_support;           // Enable EWMH support
+} EwmhConfig;
+
+void on_tag_view_changed(const Event* evt, void* userdata) {
+    // Update _NET_CURRENT_DESKTOP
+    Monitor* mon = evt->source;
+    unsigned int tagset = mon->tagset[mon->seltags];
+    
+    // Find index of active tag (assuming single tag)
+    int idx = 0;
+    unsigned int mask = 1;
+    for (int i = 0; i < num_tags; i++) {
+        if (tagset & mask) {
+            idx = i;
+            break;
+        }
+        mask <<= 1;
+    }
+    
+    // Send to root window
+    long data = idx;
+    XChangeProperty(dpy, root, netatom[NetCurrentDesktop], XA_CARDINAL, 32,
+                    PropModeReplace, (unsigned char*)&data, 1);
+}
+
+void on_ewmh_desktop_request(const Event* evt, void* userdata) {
+    // Handle _NET_CURRENT_DESKTOP from external app
+    int requested = evt->desktop_index;
+    if (requested >= 0 && requested < num_tags) {
+        Arg arg = { .ui = 1 << requested };
+        view(&arg);
+    }
+}
+```
+
+## Configuration
+
+```c
+static EwmhConfig ewmh_config = {
+    .tag_names = (const char*[]){"1", "2", "3", "4", "5", "6", "7", "8", "9"},
+    .num_tags = 9,
+    .ewmh_support = 1,
+};
+```
+
+## Root Window Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `_NET_NUMBER_OF_DESKTOPS` | CARDINAL | Number of tags/desktops |
+| `_NET_DESKTOP_NAMES` | UTF8_STRING | Tag names (null-separated) |
+| `_NET_CURRENT_DESKTOP` | CARDINAL | Currently active tag index |
+| `_NET_DESKTOP_VIEWPORT` | CARDINAL | Viewport position (for virtual desktops) |
+| `_NET_SUPPORTED` | ATOM | List of supported EWMH atoms |
+
+## Interactions
+
+- Required for external panels/pagers (e.g., polybar, xfce-panel)
+- Works with `pertag` (EWMH reflects current view)
+- Tag names can be changed at runtime
+
+---
+
+*Extension ID: ewmh-desktop*
+*Priority: High (interoperability)*
+*DWM patch equivalent: dwm-ewmh*

--- a/docs/extensions/floatpos.md
+++ b/docs/extensions/floatpos.md
@@ -1,0 +1,150 @@
+# Extension: Floatpos (Floating Window Position Rules)
+
+## Overview
+
+Allows floating windows to be positioned according to configurable rules. Each rule specifies a position and size for matching windows (by class, instance, or title). Rules are applied on window manage and can be toggled per-client.
+
+## DWM Reference
+
+Based on `togglefloating.md`, `configurerequest.md`, `manage.md`:
+- `floatpos` function parses position strings like "50% 50% 50% 50%"
+- `setfloatpos()` applies the position to a client
+- `getfloatpos()` does the actual geometry computation
+- Position format: "x y w h" where each can be:
+  - `NN%` — percentage of monitor
+  - `NNp` — pixel offset
+  - `G` — grid-based (with floatposgrid_x/y)
+  - `A` — absolute
+  - `C` — center
+  - `S` — sticky
+  - `Z` — right-aligned
+
+## State Machine Events
+
+| Event | Description | Payload |
+|-------|-------------|---------|
+| `EVT_CLIENT_MANAGED` | New client registered | `Client*`, `Monitor*` |
+| `EVT_CLIENT_FLOAT_ENABLED` | Client became floating | `Client*` |
+| `EVT_CLIENT_FLOAT_DISABLED` | Client became tiled | `Client*` |
+| `EVT_CLIENT_FLOAT_MOVED` | Floating client moved | `Client*`, `x`, `y`, `w`, `h` |
+| `EVT_RULE_APPLIED` | Rule matched and applied | `Client*`, `Rule*` |
+
+## Position Format
+
+```
+position := x y w h
+x := percent | pixel | grid | special
+y := percent | pixel | grid | special
+w := percent | pixel | grid | special
+h := percent | pixel | grid | special
+
+percent := NUMBER '%'     // e.g., "50%"
+pixel := NUMBER 'p'        // e.g., "100p" (pixels from edge)
+grid := NUMBER 'G'        // e.g., "3G" (grid position)
+special:
+  | 'A'                   // absolute
+  | 'C'                   // center
+  | 'S'                   // sticky (relative to client)
+  | 'Z'                   // right-aligned
+  | 'M'                   // mouse position
+```
+
+## Example Rules
+
+```c
+static FloatPosRule rules[] = {
+    // Steam: full screen
+    { .class = "Steam", .position = "0 0 100% 100%" },
+    
+    // Dialogs: center, 50% size
+    { .class = NULL, .title = "Save As", .position = "50% 50% 50% 50%" },
+    
+    // File picker: right side, 60% width, top half
+    { .instance = "filechooser", .position = "40% 0 60% 50%" },
+    
+    // Terminal scratchpad: grid-based
+    { .scratchkey = 's', .position = "6G 6G 1 1" },
+    
+    { .class = NULL }  // End
+};
+```
+
+## Hook Points
+
+```c
+typedef struct {
+    const char* class;
+    const char* instance;
+    const char* title;
+    char scratchkey;         // 0 = not a scratchpad
+    const char* position;    // Position string
+} FloatPosRule;
+
+void on_client_managed(const Event* evt, void* userdata) {
+    Client* c = evt->subject;
+    
+    // Find matching rule
+    FloatPosRule* rule = find_matching_rule(c);
+    if (rule && rule->position) {
+        // Apply position
+        apply_floatpos(c, rule->position);
+        
+        // Emit event for other plugins to react
+        Event rule_evt = {
+            .type = EVT_RULE_APPLIED,
+            .subject = c,
+            .data = rule
+        };
+        bus_emit(&rule_evt);
+    }
+}
+
+void on_client_float_enabled(const Event* evt, void* userdata) {
+    Client* c = evt->subject;
+    FloatPosConfig* cfg = userdata;
+    
+    // Re-apply position if rule exists
+    FloatPosRule* rule = find_matching_rule(c);
+    if (rule && rule->position && cfg->reapply_on_toggle) {
+        apply_floatpos(c, rule->position);
+    }
+}
+```
+
+## Configuration
+
+```c
+typedef struct {
+    FloatPosRule* rules;           // Array of rules
+    int grid_x;                    // Grid columns (default: 12)
+    int grid_y;                   // Grid rows (default: 12)
+    int reapply_on_toggle;        // Re-apply position when toggling float
+    int reapply_on_monitor_change; // Re-apply when moving between monitors
+} FloatPosConfig;
+```
+
+## Keybindings
+
+```c
+static Key keys[] = {
+    // Apply floatpos to focused client (use last rule or default)
+    { MODKEY | ShiftMask, XK_f, floatpos_apply, {.v = "50% 50% 50% 50%"} },
+    
+    // Cycle through preset positions
+    { MODKEY | ControlMask, XK_f, floatpos_cycle, {0} },
+};
+```
+
+## Interactions
+
+- Applied on `manage()` for new windows with rules
+- Re-applied when `togglefloating()` enables floating
+- Not applied to tiled clients (position ignored for tiled)
+- Works with `pertag` — position stored per-client, not per-tag
+- `floatposgrid_x/y` stored in config
+
+---
+
+*Extension ID: floatpos*
+*Priority: High (commonly requested feature)*
+*DWM patch equivalent: dwm-floatpos*

--- a/docs/extensions/focus-adjacent.md
+++ b/docs/extensions/focus-adjacent.md
@@ -1,0 +1,87 @@
+# Extension: Focus Adjacent Tag
+
+## Overview
+
+Allows navigating to the next/previous tag in cyclic order. When at the leftmost tag and going left, wraps to the rightmost tag, and vice versa. Similar to vim's tag navigation.
+
+## DWM Reference
+
+Based on `tagtoleft.md`, `tagtoright.md`, `viewtoleft.md`, `viewtoright.md`:
+- `tagtoleft()` shifts client's tags left: `tags >>= 1`
+- `tagtoright()` shifts client's tags right: `tags <<= 1`
+- `viewtoleft()` shifts view left: single bit → shift left
+- `viewtoright()` shifts view right: single bit → shift right
+- Current constraint: only works when single tag is active
+
+## State Machine Events
+
+| Event | Description | Payload |
+|-------|-------------|---------|
+| `EVT_TAG_VIEW_CHANGED` | View changed via navigation | `Monitor*`, `old_tag`, `new_tag` |
+
+## Hook Points
+
+```c
+typedef struct {
+    int wrap_around;           // Wrap at edges
+    int move_client_with_tag;  // Also move focused client
+} FocusAdjacentConfig;
+
+void view_left(Monitor* mon) {
+    unsigned int cur = mon->tagset[mon->seltags];
+    
+    // Find leftmost set bit
+    if (cur == 1) {  // Tag 1 is active
+        if (wrap_around)
+            cur = 1 << (NUM_TAGS - 1);  // Wrap to last tag
+        else
+            return;  // Can't go further left
+    } else {
+        cur >>= 1;  // Shift right (go left in tag order)
+    }
+    
+    Arg arg = { .ui = cur };
+    view(&arg);
+}
+
+void view_right(Monitor* mon) {
+    unsigned int cur = mon->tagset[mon->seltags];
+    
+    if (cur & (1 << (NUM_TAGS - 1))) {  // Last tag active
+        if (wrap_around)
+            cur = 1;  // Wrap to first tag
+        else
+            return;
+    } else {
+        cur <<= 1;  // Shift left (go right in tag order)
+    }
+    
+    Arg arg = { .ui = cur };
+    view(&arg);
+}
+```
+
+## Keybindings
+
+```c
+static Key keys[] = {
+    { MODKEY, XK_Left, viewtoleft, {0} },
+    { MODKEY, XK_Right, viewtoright, {0} },
+    { MODKEY | ShiftMask, XK_Left, tagtoleft, {0} },
+    { MODKEY | ShiftMask, XK_Right, tagtoright, {0} },
+    { ALTMOD, XK_comma, focusmon, {.i = -1} },  // Previous monitor
+    { ALTMOD, XK_period, focusmon, {.i = +1} },   // Next monitor
+};
+```
+
+## Interactions
+
+- Works with `pertag` (view changes trigger pertag)
+- Works with all layouts
+- Doesn't affect multi-tag views (only works with single tag)
+
+---
+
+*Extension ID: focus-adjacent*
+*Priority: Low (convenience feature)*
+*DWM patch equivalent: dwm-focusadjacenttag*

--- a/docs/extensions/gap.md
+++ b/docs/extensions/gap.md
@@ -1,0 +1,90 @@
+# Extension: Gap Plugin
+
+## Overview
+
+Adds configurable gaps between tiled windows. When enabled, each window has padding on all sides (top, bottom, left, right), creating a visual separation between windows. The gap size can be configured per-tag and toggled on/off.
+
+## DWM Reference
+
+Based on `tile.md` and `setmfact.md` analysis:
+- dwm has `gappx[]` array in `Pertag` struct
+- `tile()` checks `drawwithgaps` flag and applies gaps per-client
+- `setgaps()` modifies gaps via GAP_TOGGLE (100), GAP_RESET (0), or delta
+- Two modes: "single borders" (borders between clients) vs "full gaps" (all sides)
+
+## State Machine Events
+
+| Event | Description | Payload |
+|-------|-------------|---------|
+| `EVT_TILING_PARAM_CHANGED` | Tiling parameters updated | `Monitor*`, `param_type`, `old_val`, `new_val` |
+| `EVT_LAYOUT_CHANGED` | Layout switched | `Monitor*`, `old_layout`, `new_layout` |
+| `EVT_TAG_VIEW_CHANGED` | Tag/view switched | `Monitor*`, `old_tag`, `new_tag` |
+
+## Hook Points
+
+```c
+// Plugin subscribes to these events
+typedef struct {
+    int gap_size;        // Current gap in pixels
+    int enabled;         // Gaps enabled/disabled
+    int mode;            // 0=singular borders, 1=full gaps
+} GapPluginConfig;
+
+// Hook callbacks
+void on_tiling_param_changed(const Event* evt, void* userdata) {
+    GapPluginConfig* cfg = userdata;
+    Monitor* mon = evt->source;
+    // Update monitor's gap size from config
+    mon->gap_size = cfg->gap_size;
+}
+
+void on_layout_changed(const Event* evt, void* userdata) {
+    // Apply gaps based on current mode
+}
+```
+
+## Configuration
+
+```c
+// config.h
+#define DEFAULT_GAP_SIZE 10
+#define DEFAULT_DRAW_WITH_GAPS 1
+
+typedef struct {
+    int gap_size;           // Pixels between windows
+    int show_gaps;          // Boolean: gaps visible
+    int draw_with_gaps;     // 0=single borders, 1=full gaps
+    int toggleable;         // Can be toggled via keybind
+} GapConfig;
+```
+
+## Keybindings
+
+```c
+static Key keys[] = {
+    { MODKEY, XK_g, gap_toggle, {.i = GAP_TOGGLE} },      // Toggle gaps
+    { MODKEY, XK_0, gap_reset, {.i = GAP_RESET} },        // Reset to default
+    { MODKEY | ShiftMask, XK_g, gap_inc, {.i = +5} },      // Increase
+    { MODKEY | ControlMask, XK_g, gap_dec, {.i = -5} },    // Decrease
+};
+```
+
+## Implementation Notes
+
+- Gaps stored in `Monitor.gap_size` (per-monitor)
+- Per-tag: `Pertag.gappx[]` array stores per-tag values
+- Two tiling algorithms: "singular borders" (original) vs "full gaps" (separate all sides)
+- The plugin reads config and sets monitor values; the core tiling applies them
+- No modification to `tile()` function needed
+
+## Interactions
+
+- Works with all tiling layouts (tile, monocle, bstack)
+- Does not affect floating clients (they have their own positioning)
+- Bar height auto-adjusts if gaps affect window area
+
+---
+
+*Extension ID: gap*
+*Priority: High (very common feature)*
+*DWM patch equivalent: dwm-gaps*

--- a/docs/extensions/pertag.md
+++ b/docs/extensions/pertag.md
@@ -1,0 +1,113 @@
+# Extension: Pertag (Per-Tag Settings)
+
+## Overview
+
+Saves and restores per-tag settings including: layout, mfact, nmaster, bar visibility, and focused client. This allows each tag to have its own independent configuration. Switching tags restores all settings; switching back restores them again.
+
+## DWM Reference
+
+Based on `view.md`, `setmfact.md`, `setlayout.md`, `focus.md` analysis:
+- `Pertag` struct stores arrays indexed by tag number (1..N plus 0 for "all")
+- `view()` swaps `seltags` (active slot) and restores all per-tag settings
+- `tagset[2]` — two arrays, `seltags` is the active index (0 or 1)
+- `curtag` / `prevtag` track current/previous tag for toggle
+- `pertag->sel[tag]` stores focused client per tag
+
+## State Machine Events
+
+| Event | Description | Payload |
+|-------|-------------|---------|
+| `EVT_TAG_VIEW_CHANGED` | View/tag switched | `Monitor*`, `old_tag`, `new_tag`, `old_tagset`, `new_tagset` |
+| `EVT_LAYOUT_CHANGED` | Layout changed | `Monitor*`, `slot`, `new_layout` |
+| `EVT_TILING_PARAM_CHANGED` | mfact or nmaster changed | `Monitor*`, `param`, `value` |
+| `EVT_CLIENT_FOCUS_GAIN` | Client gained focus | `Client*`, `Monitor*` |
+| `EVT_BAR_SHOWN/HIDDEN` | Bar visibility changed | `Monitor*` |
+
+## Hook Points
+
+```c
+typedef struct {
+    // Per-tag state (index 0 = all tags, 1..N = specific tags)
+    Layout* layouts[NUM_TAGS + 1][2];      // Two layout pointers per tag
+    float mfacts[NUM_TAGS + 1];           // mfact per tag
+    int nmasters[NUM_TAGS + 1];           // nmaster per tag
+    uint8_t sellts[NUM_TAGS + 1];         // sellt (layout slot) per tag
+    int showbars[NUM_TAGS + 1];           // bar visibility per tag
+    Client* focused[NUM_TAGS + 1];        // focused client per tag
+    
+    // Current state
+    int curtag;                           // Current tag index (0 = all)
+    int prevtag;                          // Previous tag for toggle
+} PertagContext;
+
+// Hook: Called when tag changes — save old and restore new
+void on_tag_view_changed(const Event* evt, void* userdata) {
+    PertagContext* ctx = userdata;
+    Monitor* mon = evt->source;
+    
+    // Save current settings to prevtag
+    ctx->layouts[ctx->prevtag][mon->sellt] = mon->lt[mon->sellt];
+    ctx->mfacts[ctx->prevtag] = mon->mfact;
+    ctx->nmasters[ctx->prevtag] = mon->nmaster;
+    ctx->sellts[ctx->prevtag] = mon->sellt;
+    ctx->focused[ctx->prevtag] = mon->sel;
+    
+    // Restore settings for new tag
+    mon->lt[mon->sellt] = ctx->layouts[evt->new_tag][mon->sellt];
+    mon->mfact = ctx->mfacts[evt->new_tag];
+    mon->nmaster = ctx->nmasters[evt->new_tag];
+    mon->sellt = ctx->sellts[evt->new_tag];
+    mon->sel = ctx->focused[evt->new_tag];
+    
+    ctx->curtag = evt->new_tag;
+    ctx->prevtag = evt->old_tag;
+}
+```
+
+## Configuration
+
+```c
+typedef struct {
+    int enabled;
+    int save_focused_client;   // Remember which client was focused per tag
+    int save_layout;           // Remember layout per tag
+    int save_mfact;           // Remember mfact per tag
+    int save_nmaster;         // Remember nmaster per tag
+    int save_bar;             // Remember bar visibility per tag
+} PertagConfig;
+```
+
+## Keybindings (from dwm config)
+
+```c
+// view() is called with specific tag bits → saved to that tag
+{MODKEY, XK_1, view, {.ui = 1 << 0}},
+{MODKEY, XK_2, view, {.ui = 1 << 1}},
+// ...
+
+// view(NULL) → toggle to previous tag (swaps prevtag/curtag)
+{MODKEY, XK_Tab, view, {0}},
+
+// toggleview → toggle tag visibility (multi-tag view)
+{MODKEY | ControlMask, XK_1, toggleview, {.ui = 1 << 0}},
+```
+
+## Implementation Notes
+
+- Tag 0 is special: "all tags" mode (`curtag == 0`)
+- Arrays are sized `LENGTH(tags) + 1` to accommodate index 0
+- `curtag = 0` means no specific tag (view all)
+- When `arg->ui == ~0` (view all), `curtag = 0`
+- The core `view()` function handles tag switching; pertag hooks into the transition
+
+## Interactions
+
+- Works with all layouts (tile, float, monocle, bstack)
+- Works with gap plugin (pertag also stores gap settings)
+- When client is destroyed, `pertag->sel[]` must be cleared for that client
+
+---
+
+*Extension ID: pertag*
+*Priority: High (dwm staple feature)*
+*DWM patch equivalent: dwmpertag*

--- a/docs/extensions/resizecorners.md
+++ b/docs/extensions/resizecorners.md
@@ -1,0 +1,76 @@
+# Extension: Resize Corners
+
+## Overview
+
+Adds corner-based resizing for floating windows. Instead of only edge-based resizing, allows dragging from any corner to resize while maintaining aspect ratio or anchoring the opposite corner.
+
+## DWM Reference
+
+Based on `resizemouse.md`:
+- `resizemouse()` already detects corner from pointer position
+- `horizcorner` and `vertcorner` determine which edge(s) are dragged
+- Corner dragging: `nw = ocx2 - nx` (left edge moves) vs `nw = ev.x - ocx` (right edge moves)
+- Minimum size enforced via `c->minw, c->minh`
+
+## State Machine Events
+
+| Event | Description | Payload |
+|-------|-------------|---------|
+| `EVT_RESIZE_START` | Resize operation started | `Client*`, `corner`, `Monitor*` |
+| `EVT_RESIZE_UPDATE` | Resize position updated | `Client*`, `x`, `y`, `w`, `h` |
+| `EVT_RESIZE_END` | Resize operation ended | `Client*` |
+
+## Hook Points
+
+```c
+typedef struct {
+    int snap_to_edges;          // Snap to other windows' edges
+    int snap_threshold;         // Pixels before snap triggers
+    int maintain_aspect;        // Maintain aspect ratio on corner drag
+    int preserve_center;        // Keep center when resizing from edges
+} ResizeConfig;
+
+void on_resize_update(const Event* evt, void* userdata) {
+    Client* c = evt->subject;
+    ResizeConfig* cfg = userdata;
+    
+    if (cfg->maintain_aspect && evt->corner != CORNER_NONE) {
+        // Maintain original aspect ratio
+        float aspect = (float)c->w / c->h;
+        // Adjust height based on width change
+    }
+    
+    if (cfg->snap_to_edges) {
+        // Check for snap points (other windows, monitor edges)
+        check_and_apply_snap(c, cfg->snap_threshold);
+    }
+}
+```
+
+## Corner Constants
+
+```c
+enum Corner {
+    CORNER_NONE = 0,
+    CORNER_TOP_LEFT,
+    CORNER_TOP_RIGHT,
+    CORNER_BOTTOM_LEFT,
+    CORNER_BOTTOM_RIGHT,
+    CORNER_TOP_EDGE,
+    CORNER_BOTTOM_EDGE,
+    CORNER_LEFT_EDGE,
+    CORNER_RIGHT_EDGE,
+};
+```
+
+## Interactions
+
+- Works with floating clients only (tiled uses layout)
+- Can trigger `snap_to_float` auto-float during resize
+- Works with `floatpos` for initial positioning
+
+---
+
+*Extension ID: resizecorners*
+*Priority: Low (nice to have)*
+*DWM patch equivalent: dwm-resizecorners*

--- a/docs/extensions/scratchpad.md
+++ b/docs/extensions/scratchpad.md
@@ -1,0 +1,142 @@
+# Extension: Scratchpads
+
+## Overview
+
+Manages "scratchpad" windows — hidden windows that can be quickly shown/hidden with a key binding. Each scratchpad is identified by a unique key, and toggling shows/hides all scratchpads with that key. Multiple scratchpads per key are supported.
+
+## DWM Reference
+
+Based on `togglescratch()`, `showhide.md`, `manage.md`:
+- `scratchkey` field in `Client` struct (char, 0 = not a scratchpad)
+- `spawnscratch()` launches program with specific key
+- `togglescratch()` iterates all clients, shows/hides matching scratchpads
+- Scratchpads shown: `c->tags = mon->tagset[seltags]` (current view tags)
+- Scratchpads hidden: `c->tags = 0` (all tags cleared)
+- `scratchvisible` count tracks how many are currently visible
+- `numscratchpads` tracks total scratchpads per key
+- Multi-monitor: scratchpads moved to current monitor if all on same monitor
+
+## State Machine Events
+
+| Event | Description | Payload |
+|-------|-------------|---------|
+| `EVT_SCRATCHPAD_SHOWN` | Scratchpad shown | `Client*`, `key`, `Monitor*` |
+| `EVT_SCRATCHPAD_HIDDEN` | Scratchpad hidden | `Client*`, `key` |
+| `EVT_SCRATCHPAD_SPAWNED` | New scratchpad spawned | `key`, `Monitor*` |
+| `EVT_SCRATCHPAD_TOGGLE` | Toggle requested | `key`, `Monitor*` |
+
+## Hook Points
+
+```c
+typedef struct {
+    char key;                    // Scratchpad identifier
+    const char** cmd;           // Command to spawn (argv-style)
+    int visible_count;           // How many are currently visible
+    int total_count;            // Total scratchpads with this key
+    int last_monitor;          // Monitor where scratchpad last lived
+} ScratchpadConfig;
+
+typedef struct {
+    char key;
+    const char** cmd;
+    int floating;               // Scratchpad is floating
+    const char* position;       // Floatpos rule (optional)
+    int tags;                  // Tags to show on (0 = current view)
+} ScratchpadRule;
+
+static ScratchpadRule scratchpads[] = {
+    { .key = 's', .cmd = (const char*[]){"ghostty", "--instance-name=scratch", NULL} },
+    { .key = 'c', .cmd = (const char*[]){"speedcrunch", NULL} },
+    { .key = 'v', .cmd = (const char*[]){"nvim", "-c", "VimwikiMake打卡", NULL} },
+    { .key = 0 }  // End
+};
+
+void on_scratchpad_toggle(const Event* evt, void* userdata) {
+    ScratchpadContext* ctx = userdata;
+    char key = ctx->key;
+    
+    // Count visible and total scratchpads
+    int visible = 0, total = 0;
+    for (Client* c = all_clients; c; c = c->next) {
+        if (c->scratchkey != key) continue;
+        total++;
+        if (c->tags & current_tagset) visible++;
+    }
+    
+    if (visible == 0 && total == 0) {
+        // Spawn new scratchpad
+        spawn_scratchpad(key);
+        Event spawn_evt = { .type = EVT_SCRATCHPAD_SPAWNED, .data = &key };
+        bus_emit(&spawn_evt);
+    } else if (visible == total) {
+        // Hide all
+        for (Client* c = all_clients; c; c = c->next) {
+            if (c->scratchkey == key) {
+                c->tags = 0;
+                Event hide_evt = { .type = EVT_SCRATCHPAD_HIDDEN, .subject = c };
+                bus_emit(&hide_evt);
+            }
+        }
+    } else {
+        // Show all
+        for (Client* c = all_clients; c; c = c->next) {
+            if (c->scratchkey == key) {
+                c->tags = current_tagset;
+                Event show_evt = { .type = EVT_SCRATCHPAD_SHOWN, .subject = c };
+                bus_emit(&show_evt);
+            }
+        }
+    }
+    
+    arrange(NULL);  // Update visibility
+}
+```
+
+## Configuration
+
+```c
+static ScratchpadConfig scratchpad_config = {
+    .center_on_show = 1,      // Center floating scratchpads when shown
+    .follow_monitor = 1,      // Move scratchpad to current monitor on show
+    .auto_hide = 1,            // Auto-hide when moving to different tag
+};
+```
+
+## Keybindings
+
+```c
+static Key keys[] = {
+    { MODKEY, XK_grave, togglescratch, {.v = scratchtermcmd} },
+    { MODKEY | ControlMask, XK_grave, togglescratch, {.v = scratchcalcmd} },
+};
+```
+
+## Scratchpad Rule Format
+
+```c
+// First element (char*) is the key, rest is command
+static const char* scratchtermcmd[] = { "s", "ghostty", "--instance-name=scratch", NULL };
+static const char* scratchcalcmd[] = { "c", "speedcrunch", NULL };
+```
+
+## Multi-Scratchpad Logic
+
+From `togglescratch()` in dwm:
+1. First pass: count visible/total, track which monitor they're on
+2. If all on same monitor ≠ current → move to current monitor
+3. If all visible → hide (clear tags)
+4. If all hidden → show (set to current tagset)
+5. If partially visible → hide all
+
+## Interactions
+
+- Works with `floatpos` — scratchpads can have position rules
+- Works with `pertag` — scratchpad visibility is per-tag via `c->tags`
+- `showhide()` handles visibility (moves off-screen when hidden)
+- Auto-hide: when tag changes, scratchpads with `tags != 0` get `tags = 0`
+
+---
+
+*Extension ID: scratchpad*
+*Priority: High (very popular feature)*
+*DWM patch equivalent: dwm-scratchpads*

--- a/docs/extensions/urgency.md
+++ b/docs/extensions/urgency.md
@@ -1,0 +1,115 @@
+# Extension: Urgency Notifications
+
+## Overview
+
+Handles client urgency hints (WM_HINTS urgency flag) by:
+1. Visual indication in the status bar (urgent client's tag lights up)
+2. Optional audio notification when urgency is set
+3. Auto-focus option when urgent client becomes visible
+4. Optional flashing border on urgent clients
+
+## DWM Reference
+
+Based on `focus.md`, `clientmessage.md`, `seturgent()`:
+- `isurgent` flag in `Client` struct
+- `updatewmhints()` reads WM_HINTS, sets urgency
+- `seturgent(c, 1)` sets urgency flag and updates WM hints
+- `seturgent(c, 0)` clears when client gains focus
+- Bar draws urgency indicator (box) for tags with urgent clients
+- `clientmessage()` sets urgency for `_NET_ACTIVE_WINDOW` requests
+
+## State Machine Events
+
+| Event | Description | Payload |
+|-------|-------------|---------|
+| `EVT_CLIENT_URGENCY_SET` | Client became urgent | `Client*` |
+| `EVT_CLIENT_URGENCY_CLEAR` | Client urgency cleared | `Client*` |
+| `EVT_TAG_VIEW_CHANGED` | View switched — check for urgent | `Monitor*` |
+| `EVT_CLIENT_VISIBLE` | Urgent client became visible | `Client*` |
+
+## Hook Points
+
+```c
+typedef struct {
+    const char* sound_file;       // Path to sound file (e.g., "/usr/share/sounds/notify.wav")
+    int play_sound;              // Enable sound notifications
+    int auto_focus;              // Auto-focus urgent client when visible
+    int flash_border;            // Flash border when urgent
+    int flash_duration_ms;       // Border flash duration
+} UrgencyConfig;
+
+void on_urgency_set(const Event* evt, void* userdata) {
+    Client* c = evt->subject;
+    UrgencyConfig* cfg = userdata;
+    
+    if (cfg->play_sound && cfg->sound_file) {
+        // Play notification sound in background
+        char cmd[512];
+        snprintf(cmd, sizeof(cmd), "aplay '%s' &", cfg->sound_file);
+        system(cmd);
+    }
+    
+    if (cfg->flash_border) {
+        // Start border flash animation
+        start_border_flash(c, cfg->flash_duration_ms);
+    }
+    
+    LOG_INFO("Client %s marked as urgent", c->name);
+}
+
+void on_tag_view_changed(const Event* evt, void* userdata) {
+    if (!userdata->auto_focus) return;
+    
+    Monitor* mon = evt->source;
+    
+    // Find urgent client on new view
+    for (Client* c = mon->clients; c; c = c->next) {
+        if (c->isurgent && (c->tags & mon->tagset[mon->seltags])) {
+            // Focus the urgent client
+            focus(c);
+            break;
+        }
+    }
+}
+```
+
+## Configuration
+
+```c
+static UrgencyConfig urgency_config = {
+    .sound_file = "/usr/share/sounds/notification.wav",
+    .play_sound = 1,
+    .auto_focus = 0,           // Don't auto-focus by default
+    .flash_border = 1,
+    .flash_duration_ms = 500,
+};
+```
+
+## Bar Indicators
+
+The bar shows urgency via:
+- Small square indicator on urgent tags in tag list
+- Background color change for urgent tags
+- `urg` bitmask in `drawbar()`: `urg |= c->tags` for all urgent clients
+
+```c
+// In drawbar(), urgency indicators
+if (urg & (1 << i)) {
+    // Draw urgency indicator (box)
+    drw_rect(drw, x + boxw, 0, w - 2*boxw, boxw, 0, 1);
+}
+```
+
+## Interactions
+
+- Works with all layouts
+- Urgency state persists across tag switches
+- When urgent client loses focus (unfocus), `isurgent` stays set
+- Only cleared when client gains focus (`focus()` calls `seturgent(c, 0)`)
+- Multiple urgent clients: all indicators shown
+
+---
+
+*Extension ID: urgency*
+*Priority: Medium (nice to have)*
+*DWM patch equivalent: dwm-urgencyhook / dwm-systray integration*

--- a/plans/wm-architecture.md
+++ b/plans/wm-architecture.md
@@ -1,0 +1,477 @@
+# Plan: wm Architecture Implementation
+
+> Source PRD: `.github/ISSUE_TEMPLATE/prd.yml`
+
+## Architectural Decisions
+
+Durable decisions that apply across all phases:
+
+- **Hub scope**: Request routing + event bus only. Raw XCB events do NOT flow through hub.
+- **Components**: Self-contained containers owning all domain logic (XCB handlers, executor, listener, SM template)
+- **XCB event ownership**: Each component registers its own XCB event handlers at init. Handlers live inside the component.
+- **State machine location**: SMs live on targets (Client, Monitor), not on components. Components provide SM templates.
+- **Two writer types**: Raw writer (authoritative, no guard) vs request (with guard, may fail)
+- **Target ID system**: Window IDs for clients, output IDs for monitors, symbolic constants for `CURRENT_*`
+
+---
+
+## Phase 1: Hub Foundation
+
+**User stories**: 4 (add feature by writing component), 5 (independently testable)
+
+### What to build
+
+Core orchestrator providing request routing and event bus.
+
+- `hub_init()` / `hub_shutdown()`
+- `hub_register_component()` / `hub_unregister_component()`
+- `hub_register_target()` / `hub_unregister_target()`
+- `hub_get_component_by_name()` / `hub_get_component_by_request()`
+- `hub_get_target_by_id()` / `hub_get_targets_by_type()`
+- `hub_send_request(RequestType, TargetID, data)`
+- `hub_emit(EventType, TargetID, data)`
+- `hub_subscribe(EventType, handler)` / `hub_unsubscribe()`
+
+The hub does NOT handle XCB events. It only handles:
+1. Component and target registration
+2. Request routing (finds component by request type)
+3. Event pub/sub (components emit events, others subscribe)
+
+### Acceptance criteria
+
+- [ ] Components can register themselves at startup
+- [ ] Targets can register themselves at creation
+- [ ] Request `REQ_FOO` routes to component that handles it
+- [ ] Subscriber receives event after emission
+- [ ] Hub can be shutdown cleanly (no leaks)
+
+---
+
+## Phase 2: State Machine Framework
+
+**User stories**: 4 (add feature by writing component), 5 (independently testable), 21 (log transitions)
+
+### What to build
+
+Framework for targets to own state machines.
+
+**SM Template:**
+- `SMTemplate` struct: name, states[], transitions[], guards[], actions[], events[]
+- `sm_template_create()` / `sm_template_destroy()`
+
+**SM Instance:**
+- `StateMachine` struct: name, current_state, owner (Target*), template, data
+- `sm_create(Target*, SMTemplate*)` — lazy allocation
+- `sm_destroy(StateMachine*)`
+- `sm_raw_write(StateMachine*, uint32_t new_state)` — authoritative, no guard
+- `sm_transition(StateMachine*, uint32_t target_state)` — with guard, emits event
+- `sm_get_state(StateMachine*)`
+- `sm_get_available_transitions(StateMachine*)` — returns states reachable from current
+
+**Hook system (for plugins):**
+- `sm_add_hook(StateMachine*, HookPhase, HookFn, userdata)`
+- Hook phases: `PRE_GUARD`, `POST_GUARD`, `PRE_ACTION`, `POST_ACTION`, `PRE_EMIT`, `POST_EMIT`
+
+### Acceptance criteria
+
+- [ ] Template defines states and transitions
+- [ ] `sm_transition()` validates guard, executes action, updates state, emits event
+- [ ] `sm_transition()` fails if guard rejects
+- [ ] `sm_raw_write()` updates state without guard
+- [ ] `sm_raw_write()` emits same event as transition
+- [ ] Hooks execute in correct phase order
+- [ ] Available transitions query returns valid next states
+
+---
+
+## Phase 3: XCB Infrastructure
+
+**User stories**: 4 (add feature by writing component)
+
+### What to build
+
+Minimal XCB event dispatch infrastructure (NOT a component).
+
+**Existing code to adapt:**
+- `wm-xcb.c` — connection, event loop
+- Events currently handled directly in `handle_xcb_events()`
+
+**What to build:**
+- Event loop that dispatches to registered handler functions
+- Handler registration API: `xcb_register_handler(event_type, handler_fn)`
+- Components register their XCB handlers at init
+- Handlers are functions inside components, called by XCB infrastructure
+
+**Key principle:** XCB events go DIRECTLY to components, NOT through hub. Hub only used for:
+- Keybinding component sending requests (`hub_send_request()`)
+- Components emitting SM transition events (`hub_emit()`)
+
+### Component → XCB Event Mapping
+
+| Component | XCB Events It Handles |
+|-----------|----------------------|
+| keybinding | KEY_PRESS, KEY_RELEASE |
+| pointer | BUTTON_PRESS, BUTTON_RELEASE, MOTION_NOTIFY |
+| focus | ENTER_NOTIFY, FOCUS_IN, FOCUS_OUT |
+| monitor-manager | RANDR_NOTIFY |
+| client-list | CREATE_NOTIFY, DESTROY_NOTIFY, MAP_REQUEST, UNMAP_NOTIFY |
+| fullscreen | PROPERTY_NOTIFY |
+| urgency | PROPERTY_NOTIFY |
+| bar | EXPOSE |
+
+### Acceptance criteria
+
+- [ ] Components register XCB handlers at init
+- [ ] Event type routes to correct component handler
+- [ ] Handler receives event data with target window ID
+- [ ] Keybinding handler can call `hub_send_request()`
+- [ ] Focus/urgency handler can call `sm_raw_write()` directly
+
+---
+
+## Phase 4: Client Target + Client-List Component
+
+**User stories**: 3 (minimal WM), 7 (tile windows), 17 (floating), 18 (fullscreen), 19 (urgent)
+
+### What to build
+
+Client entity + client-list component (handles window lifecycle).
+
+**Client Target struct:**
+```c
+struct Client {
+    Target base;           // id = window, type = CLIENT
+    xcb_window_t window;
+    char* title;
+    char* class_name;
+    int x, y;
+    uint16_t width, height;
+    uint16_t border_width;
+    Monitor* monitor;
+    uint32_t tags;        // bitmask
+    bool managed;
+    Client* next;
+    Client* prev;
+};
+```
+
+**Client-list Component:**
+- Handles: CREATE_NOTIFY, DESTROY_NOTIFY, MAP_REQUEST, UNMAP_NOTIFY
+- Manages client list (linked list with sentinel — extend existing code)
+- On CREATE_NOTIFY/MAP_REQUEST: `client_create()`, register with hub, adopt components
+- On DESTROY_NOTIFY/UNMAP_NOTIFY: `client_destroy()`, unregister from hub
+
+**Adoption:**
+- Client created → adopts compatible components (fullscreen, floating, focus, urgency, etc.)
+- SMs allocated lazily on first access
+
+### Acceptance criteria
+
+- [ ] New window → Client created → added to list
+- [ ] Window destroyed → Client removed → list cleaned
+- [ ] Client registers with hub as TARGET_TYPE_CLIENT
+- [ ] Client adopts components matching TARGET_TYPE_CLIENT
+- [ ] Client has client_list reference for ordering
+
+---
+
+## Phase 5: Monitor Target + Monitor-Manager Component
+
+**User stories**: 3 (minimal WM), 10 (multi-monitor)
+
+### What to build
+
+Monitor entity + monitor-manager component (handles display detection).
+
+**Monitor Target struct:**
+```c
+struct Monitor {
+    Target base;           // id = output, type = MONITOR
+    xcb_randr_output_t output;
+    xcb_randr_crtc_t crtc;
+    int x, y;
+    uint16_t width, height;
+    uint32_t tagset;
+    float mfact;
+    int nmaster;
+    Client* clients;
+    Client* sel;
+    Client* stack;
+    Monitor* next;
+};
+```
+
+**Monitor-manager Component:**
+- Handles: RANDR_NOTIFY (output connected/disconnected, resolution changed)
+- Manages monitor list
+- Tracks selected monitor (selmon equivalent)
+- On RANDR event: create/destroy Monitor targets, raw_write to ConnectionSM/ResolutionSM
+
+**Adoption:**
+- Monitor created → adopts compatible components (connection, resolution, tiling, bar, etc.)
+
+### Acceptance criteria
+
+- [ ] RandR output connected → Monitor created
+- [ ] RandR output disconnected → Monitor destroyed
+- [ ] Monitor resolution changed → ResolutionSM raw_write
+- [ ] Multiple monitors tracked in list
+- [ ] Selected monitor trackable (selmon)
+
+---
+
+## Phase 6: Keybinding Component
+
+**User stories**: 6 (keybindings work), 9 (keyboard navigation)
+
+### What to build
+
+Component that handles keyboard input and sends requests to hub.
+
+**keybinding Component:**
+- Handles: KEY_PRESS, KEY_RELEASE (via XCB handler registration)
+- Parses key bindings from config
+- On matching key: `hub_send_request(REQ_*, TARGET_*)`
+- Key bindings map (keycode + modifiers) → (request type + target)
+
+**Example bindings:**
+- `Mod+Enter` → `hub_send_request(REQ_CLIENT_FOCUS, TARGET_CURRENT_CLIENT)`
+- `Mod+Shift+Enter` → focus next/prev client
+- `Mod+1-9` → `hub_send_request(REQ_TAG_VIEW, TARGET_CURRENT_MONITOR)`
+
+### Acceptance criteria
+
+- [ ] KeyPress with Mod+Enter triggers REQ_CLIENT_FOCUS
+- [ ] KeyPress with Mod+1 triggers REQ_TAG_VIEW for tag 1
+- [ ] KeyPress with Mod+Shift+1 triggers REQ_TAG_TOGGLE for tag 1
+- [ ] Unknown key does nothing (no crash)
+
+---
+
+## Phase 7: Pointer Component
+
+**User stories**: 6 (keybindings work), 8 (focus follows mouse)
+
+### What to build
+
+Component that handles mouse input for drag operations and focus.
+
+**pointer Component:**
+- Handles: BUTTON_PRESS, BUTTON_RELEASE, MOTION_NOTIFY
+- Drag state machine for move/resize:
+  - IDLE → DRAGGING → IDLE (on button release)
+  - RESIZING → IDLE (on button release)
+- Mouse pointer position determines target client (ENTER_NOTIFY also updates)
+
+**Focus integration:**
+- `handle_enter()` updates focus SM via raw_write
+- `hub_send_request(REQ_CLIENT_FOCUS, client_id)` on pointer enter
+
+### Acceptance criteria
+
+- [ ] Button press on client → enters DRAGGING or RESIZING state
+- [ ] Mouse motion while dragging → moves window
+- [ ] Button release → exits drag state, sends hub request if needed
+- [ ] Pointer entering client window → client receives focus
+
+---
+
+## Phase 8: Focus Component
+
+**User stories**: 8 (focus follows mouse), 9 (keyboard navigation)
+
+### What to build
+
+Component that tracks and manages client focus state.
+
+**focus Component:**
+- Owns FocusSM template: FOCUSED ↔ UNFOCUSED
+- Handles: ENTER_NOTIFY, FOCUS_IN, FOCUS_OUT (from pointer component or X)
+- `sm_raw_write(client->FocusSM, FOCUSED)` on focus change
+- `hub_send_request(REQ_CLIENT_FOCUS, client_id)` for keyboard focus (Mod+Enter)
+
+**Focus stack:**
+- Ordered client list for focus cycling (focusprev/focusnext)
+- `hub_send_request(REQ_CLIENT_FOCUS_NEXT)` and `_PREV`
+
+### Acceptance criteria
+
+- [ ] FocusSM transitions on client focus change
+- [ ] EVT_CLIENT_FOCUSED emitted on focus gain
+- [ ] EVT_CLIENT_UNFOCUSED emitted on focus loss
+- [ ] Focus cycling (prev/next) works via keybindings
+- [ ] Focus follows mouse on enter
+
+---
+
+## Phase 9: Tiling Engine + Tag Manager
+
+**User stories**: 7 (auto tile), 11 (tags/workspaces)
+
+### What to build
+
+Two components for layout and tag management.
+
+**tiling-engine Component:**
+- Owns LayoutSM template: TILE ↔ MONOCLE ↔ BSTACK ↔ FLOATING
+- Handles: REQ_LAYOUT_SET, REQ_LAYOUT_NEXT
+- Tile algorithm: master + stack arrangement
+- On layout change: restack clients, emit EVT_LAYOUT_CHANGED
+- Integrates with monitor's geometry and mfact
+
+**tag-manager Component:**
+- Owns TagViewSM template: tracks visible tag bitmask
+- Handles: REQ_TAG_VIEW (show specific tag), REQ_TAG_TOGGLE, REQ_TAG_SHIFT
+- Tag keybindings: Mod+1-9, Mod+Shift+1-9, Mod+Tab
+- On tag change: update monitor's tagset, restack clients, emit EVT_TAG_CHANGED
+
+**Shared data:**
+- Tag state per monitor (pertag optional for follow-up)
+- Client → monitor → tag association
+
+### Acceptance criteria
+
+- [ ] Mod+Enter tiles current client in master area
+- [ ] Mod+t sets tile layout
+- [ ] Mod+m sets monocle layout
+- [ ] Mod+1 shows tag 1
+- [ ] Mod+Shift+1 moves client to tag 1
+- [ ] Clients on hidden tags are not visible
+
+---
+
+## Phase 10: Bar Component
+
+**User stories**: 12 (see state at a glance), 22 (status bar)
+
+### What to build
+
+Status bar displaying WM state.
+
+**bar Component:**
+- Handles: EXPOSE (redraw on damage)
+- Subscribes to events: EVT_TAG_CHANGED, EVT_LAYOUT_CHANGED, EVT_CLIENT_FOCUSED
+- On subscribe event: redraw bar
+
+**Bar content:**
+- Tags: [1][2][3]... with highlight on visible
+- Layout indicator: [T] [M] [B] [F]
+- Client count or selected client title
+- System info: date/time (optional)
+
+**Positioning:**
+- Below monitor content, respects monitor geometry
+- Configurable height
+
+### Acceptance criteria
+
+- [ ] Bar visible on each monitor
+- [ ] Tag numbers shown, current tag highlighted
+- [ ] Layout symbol shown
+- [ ] Bar updates when tag/layout/focus changes
+- [ ] Date/time displayed (if implemented)
+
+---
+
+## Phase 11: Fullscreen + Floating + Urgency Components
+
+**User stories**: 17 (floating), 18 (fullscreen), 19 (urgent)
+
+### What to build
+
+Three client-focused components.
+
+**fullscreen Component:**
+- Owns FullscreenSM template: FULLSCREEN ↔ WINDOWED
+- Handles: REQ_CLIENT_FULLSCREEN
+- On fullscreen: configure window fullscreen, raw_write(FULLSCREEN)
+- Listens to PROPERTY_NOTIFY for _NET_WM_STATE changes
+
+**floating Component:**
+- Owns FloatingSM template: FLOATING ↔ TILED
+- Handles: REQ_CLIENT_FLOAT, REQ_CLIENT_TILE
+- On float: save geometry, enable floating
+- On tile: restore geometry, enable tiling
+- Integrates with tiling-engine for repositioning
+
+**urgency Component:**
+- Owns UrgencySM template: URGENT ↔ CALM
+- Handles: REQ_CLEAR_URGENT
+- Listens to PROPERTY_NOTIFY for WM_HINTS (urgency bit)
+- On urgency: mark client, maybe flash border or play sound
+- On clear: raw_write(CALM)
+
+### Acceptance criteria
+
+- [ ] Mod+f toggles fullscreen, EVT_FULLSCREEN_* emitted
+- [ ] Mod+Shift+space toggles floating, EVT_TILING_* emitted
+- [ ] Urgent client shows indicator (border flash)
+- [ ] Mod+Shift+c clears urgency, EVT_URGENCY_* emitted
+- [ ] Fullscreen/floating state preserved correctly
+
+---
+
+## Phase 12: Optional Extensions (Follow-up)
+
+Not in initial scope. See `./docs/extensions/` for specifications.
+
+- gap (gaps between tiled windows)
+- pertag (per-tag layouts, mfact, nmaster)
+- bstack (bottom-stack tiling layout)
+- actualfullscreen (fullscreen with bar visible)
+- resizecorners (corner-drag resize)
+- focus-adjacent (tag wrap-around navigation)
+- ewmh-desktop (EWMH atoms for external tools)
+- bar-style (bar sizing/position config)
+- attach-policy (client insertion policy)
+
+---
+
+## Testing Decisions
+
+### What Makes a Good Test
+
+- Test through hub interface (requests → events), not internal state
+- Test SM behavior in isolation with mocked owner target
+- Tests should be deterministic, fast, no external dependencies
+
+### Modules to Test by Phase
+
+| Phase | Modules to Test |
+|-------|----------------|
+| 1 | Hub registry, request routing, event subscription |
+| 2 | SM template, SM transition, guards, hooks |
+| 3 | Handler registration, event dispatch routing |
+| 4 | Client lifecycle, adoption, list management |
+| 5 | Monitor lifecycle, RandR events |
+| 6 | Key binding matching, request emission |
+| 7 | Focus transitions, focus stack |
+| 8 | Layout algorithms, tag view changes |
+| 9 | Bar rendering, event subscription |
+| 10 | Fullscreen toggle, floating state |
+| 11 | Urgency detection and clearing |
+
+### Test Patterns
+
+- Unit tests with assertions (similar to existing `test-wm-window-list.c`)
+- Mock hub/SM for isolation testing
+- Integration tests: request → component → SM → event
+
+---
+
+## Out of Scope
+
+- Dynamic plugin loading (dlopen) for v1 — compile-time plugins only
+- Persistence/session management
+- Non-X11 backends
+- Complex animations
+- Optional extensions (Phase 12)
+
+---
+
+*See also:*
+- `docs/architecture/overview.md` — Core concepts
+- `docs/architecture/hub.md` — Hub interface details
+- `docs/architecture/state-machine.md` — SM framework details
+- `docs/architecture/component.md` — Component interface details
+- `docs/architecture/target.md` — Target design details

--- a/task-issue-2.txt
+++ b/task-issue-2.txt
@@ -1,0 +1,61 @@
+# Task: Implement Hub Registry (Issue #2)
+
+You are implementing GitHub issue #2: https://github.com/kesor/wm-xcb/issues/2
+
+## Context
+
+Read these files first for architecture context:
+- `docs/architecture/overview.md` — core concepts
+- `docs/architecture/hub.md` — hub design details
+
+## Your Task
+
+Implement the Hub registry for components and targets.
+
+### Functions to Implement
+
+- `hub_init()` / `hub_shutdown()`
+- `hub_register_component()` / `hub_unregister_component()`
+- `hub_register_target()` / `hub_unregister_target()`
+- `hub_get_component_by_name()`
+- `hub_get_component_by_request_type()`
+- `hub_get_target_by_id()`
+- `hub_get_targets_by_type()`
+
+### Registry Structure
+
+The registry maintains:
+- Component by name
+- Component by request type it handles
+- Target by ID
+- Target by type
+
+### Code Location
+
+Create new files in the root directory following existing patterns:
+- `wm-hub.c` — implementation
+- `wm-hub.h` — header
+
+Update `Makefile` to include new files.
+
+### Acceptance Criteria
+
+- [ ] Component can register itself at startup
+- [ ] Component can be looked up by name
+- [ ] Component can be looked up by request type
+- [ ] Target can register itself at creation
+- [ ] Target can be looked up by ID
+- [ ] Targets can be queried by type
+- [ ] Cleanup on shutdown (no leaks)
+
+## Rules
+
+- Follow existing code style (see `wm-window-list.c`)
+- Write tests in `test-wm-hub.c`
+- Create a branch named `issue-2-hub-registry`
+- Push and create a PR when done
+- Reference issue #2 in commit message
+
+## Start
+
+Begin implementation now. Read the architecture docs first.

--- a/test-minimal.c
+++ b/test-minimal.c
@@ -1,0 +1,21 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+/* Minimal stub for wm-log.h */
+#define LOG_DEBUG(pFormat, ...) { fprintf(stderr, "DEBUG: " pFormat "\n", ##__VA_ARGS__); }
+#define LOG_ERROR(pFormat, ...) { fprintf(stderr, "ERROR: " pFormat "\n", ##__VA_ARGS__); }
+#define LOG_CLEAN(pFormat, ...) { printf(pFormat "\n", ##__VA_ARGS__); }
+
+/* Minimal stub for wm-running.h */
+int running = 1;
+
+#include "wm-hub.h"
+
+int main(void) {
+    hub_init();
+    printf("Components: %d, Targets: %d\n", hub_component_count(), hub_target_count());
+    hub_shutdown();
+    printf("After shutdown - Components: %d, Targets: %d\n", hub_component_count(), hub_target_count());
+    return 0;
+}

--- a/test-wm-hub.c
+++ b/test-wm-hub.c
@@ -1,0 +1,408 @@
+#include "test-wm.h"
+#include "wm-hub.h"
+
+/* Test component definitions */
+static RequestType fullscreen_requests[] = { 1, 2, 0 };   /* REQ_FULLSCREEN_ENTER = 1, REQ_FULLSCREEN_EXIT = 2 */
+static TargetType  client_targets[] = { TARGET_TYPE_CLIENT, 0 };
+static TargetType  monitor_targets[] = { TARGET_TYPE_MONITOR, 0 };
+
+static HubComponent test_fullscreen = {
+  .name       = "fullscreen",
+  .requests   = fullscreen_requests,
+  .targets    = client_targets,
+  .registered = false,
+};
+
+static HubComponent test_focus = {
+  .name       = "focus",
+  .requests   = (RequestType[]){ 3, 0 },  /* REQ_CLIENT_FOCUS = 3 */
+  .targets    = client_targets,
+  .registered = false,
+};
+
+static HubComponent test_monitor = {
+  .name       = "monitor",
+  .requests   = (RequestType[]){ 4, 5, 0 },  /* REQ_MONITOR_* = 4, 5 */
+  .targets    = monitor_targets,
+  .registered = false,
+};
+
+static HubTarget test_client1 = {
+  .id         = 100,
+  .type       = TARGET_TYPE_CLIENT,
+  .registered = false,
+};
+
+static HubTarget test_client2 = {
+  .id         = 101,
+  .type       = TARGET_TYPE_CLIENT,
+  .registered = false,
+};
+
+static HubTarget test_monitor1 = {
+  .id         = 200,
+  .type       = TARGET_TYPE_MONITOR,
+  .registered = false,
+};
+
+static HubTarget test_monitor2 = {
+  .id         = 201,
+  .type       = TARGET_TYPE_MONITOR,
+  .registered = false,
+};
+
+void
+test_hub_init_shutdown(void)
+{
+  LOG_CLEAN("== Testing hub init and shutdown");
+  hub_init();
+  assert(hub_component_count() == 0);
+  assert(hub_target_count() == 0);
+  hub_shutdown();
+  assert(hub_component_count() == 0);
+  assert(hub_target_count() == 0);
+}
+
+void
+test_register_unregister_component(void)
+{
+  LOG_CLEAN("== Testing component registration and unregistration");
+  hub_init();
+
+  assert(test_fullscreen.registered == false);
+  assert(hub_component_count() == 0);
+
+  hub_register_component(&test_fullscreen);
+  assert(test_fullscreen.registered == true);
+  assert(hub_component_count() == 1);
+
+  hub_register_component(&test_focus);
+  assert(test_focus.registered == true);
+  assert(hub_component_count() == 2);
+
+  hub_unregister_component("fullscreen");
+  assert(test_fullscreen.registered == false);
+  assert(hub_component_count() == 1);
+
+  hub_unregister_component("focus");
+  assert(test_focus.registered == false);
+  assert(hub_component_count() == 0);
+
+  hub_shutdown();
+}
+
+void
+test_register_null_component(void)
+{
+  LOG_CLEAN("== Testing registration of NULL component");
+  hub_init();
+  hub_register_component(NULL);
+  assert(hub_component_count() == 0);
+  hub_shutdown();
+}
+
+void
+test_unregister_nonexistent_component(void)
+{
+  LOG_CLEAN("== Testing unregistration of non-existent component");
+  hub_init();
+  hub_unregister_component("nonexistent");
+  assert(hub_component_count() == 0);
+  hub_shutdown();
+}
+
+void
+test_unregister_null_name(void)
+{
+  LOG_CLEAN("== Testing unregistration with NULL name");
+  hub_init();
+  hub_unregister_component(NULL);
+  hub_shutdown();
+}
+
+void
+test_get_component_by_name(void)
+{
+  LOG_CLEAN("== Testing get component by name");
+  hub_init();
+
+  hub_register_component(&test_fullscreen);
+  hub_register_component(&test_focus);
+
+  HubComponent* found = hub_get_component_by_name("fullscreen");
+  assert(found == &test_fullscreen);
+
+  found = hub_get_component_by_name("focus");
+  assert(found == &test_focus);
+
+  found = hub_get_component_by_name("nonexistent");
+  assert(found == NULL);
+
+  found = hub_get_component_by_name(NULL);
+  assert(found == NULL);
+
+  hub_shutdown();
+}
+
+void
+test_get_component_by_request_type(void)
+{
+  LOG_CLEAN("== Testing get component by request type");
+  hub_init();
+
+  hub_register_component(&test_fullscreen);
+  hub_register_component(&test_focus);
+
+  /* Request type 1 should map to fullscreen component */
+  HubComponent* found = hub_get_component_by_request_type(1);
+  assert(found == &test_fullscreen);
+
+  /* Request type 3 should map to focus component */
+  found = hub_get_component_by_request_type(3);
+  assert(found == &test_focus);
+
+  /* Unregister fullscreen - focus should now handle type 1 */
+  hub_unregister_component("fullscreen");
+  found = hub_get_component_by_request_type(1);
+  assert(found == &test_focus);
+
+  /* Unused request type */
+  found = hub_get_component_by_request_type(999);
+  assert(found == NULL);
+
+  hub_shutdown();
+}
+
+void
+test_register_unregister_target(void)
+{
+  LOG_CLEAN("== Testing target registration and unregistration");
+  hub_init();
+
+  assert(test_client1.registered == false);
+  assert(hub_target_count() == 0);
+
+  hub_register_target(&test_client1);
+  assert(test_client1.registered == true);
+  assert(hub_target_count() == 1);
+
+  hub_register_target(&test_monitor1);
+  assert(test_monitor1.registered == true);
+  assert(hub_target_count() == 2);
+
+  hub_unregister_target(100);
+  assert(test_client1.registered == false);
+  assert(hub_target_count() == 1);
+
+  hub_unregister_target(200);
+  assert(test_monitor1.registered == false);
+  assert(hub_target_count() == 0);
+
+  hub_shutdown();
+}
+
+void
+test_register_null_target(void)
+{
+  LOG_CLEAN("== Testing registration of NULL target");
+  hub_init();
+  hub_register_target(NULL);
+  assert(hub_target_count() == 0);
+  hub_shutdown();
+}
+
+void
+test_register_target_none_id(void)
+{
+  LOG_CLEAN("== Testing registration of target with NONE ID");
+  hub_init();
+
+  HubTarget none_target = {
+    .id         = TARGET_ID_NONE,
+    .type       = TARGET_TYPE_CLIENT,
+    .registered = false,
+  };
+  hub_register_target(&none_target);
+  assert(hub_target_count() == 0);
+
+  hub_shutdown();
+}
+
+void
+test_unregister_nonexistent_target(void)
+{
+  LOG_CLEAN("== Testing unregistration of non-existent target");
+  hub_init();
+  hub_unregister_target(999);
+  assert(hub_target_count() == 0);
+  hub_shutdown();
+}
+
+void
+test_unregister_none_id(void)
+{
+  LOG_CLEAN("== Testing unregistration with NONE ID");
+  hub_init();
+  hub_unregister_target(TARGET_ID_NONE);
+  hub_shutdown();
+}
+
+void
+test_get_target_by_id(void)
+{
+  LOG_CLEAN("== Testing get target by ID");
+  hub_init();
+
+  hub_register_target(&test_client1);
+  hub_register_target(&test_client2);
+  hub_register_target(&test_monitor1);
+
+  HubTarget* found = hub_get_target_by_id(100);
+  assert(found == &test_client1);
+
+  found = hub_get_target_by_id(101);
+  assert(found == &test_client2);
+
+  found = hub_get_target_by_id(200);
+  assert(found == &test_monitor1);
+
+  found = hub_get_target_by_id(999);
+  assert(found == NULL);
+
+  found = hub_get_target_by_id(TARGET_ID_NONE);
+  assert(found == NULL);
+
+  hub_shutdown();
+}
+
+void
+test_get_targets_by_type(void)
+{
+  LOG_CLEAN("== Testing get targets by type");
+  hub_init();
+
+  hub_register_target(&test_client1);
+  hub_register_target(&test_client2);
+  hub_register_target(&test_monitor1);
+  hub_register_target(&test_monitor2);
+
+  HubTarget** clients = hub_get_targets_by_type(TARGET_TYPE_CLIENT);
+  assert(clients != NULL);
+  assert(clients[0] == &test_client1);
+  assert(clients[1] == &test_client2);
+  assert(clients[2] == NULL);   /* NULL-terminated */
+
+  HubTarget** monitors = hub_get_targets_by_type(TARGET_TYPE_MONITOR);
+  assert(monitors != NULL);
+  assert(monitors[0] == &test_monitor1);
+  assert(monitors[1] == &test_monitor2);
+  assert(monitors[2] == NULL);   /* NULL-terminated */
+
+  HubTarget** empty = hub_get_targets_by_type(TARGET_TYPE_KEYBOARD);
+  assert(empty != NULL);
+  assert(empty[0] == NULL);   /* No keyboard targets registered */
+
+  /* Invalid type */
+  HubTarget** invalid = hub_get_targets_by_type(TARGET_TYPE_COUNT + 1);
+  assert(invalid == NULL);
+
+  hub_shutdown();
+}
+
+void
+test_double_registration(void)
+{
+  LOG_CLEAN("== Testing double registration prevention");
+  hub_init();
+
+  hub_register_component(&test_fullscreen);
+  assert(hub_component_count() == 1);
+
+  /* Try to register again - should be a no-op */
+  hub_register_component(&test_fullscreen);
+  assert(hub_component_count() == 1);
+
+  hub_register_target(&test_client1);
+  assert(hub_target_count() == 1);
+
+  /* Try to register again - should be a no-op */
+  hub_register_target(&test_client1);
+  assert(hub_target_count() == 1);
+
+  hub_shutdown();
+}
+
+void
+test_double_unregistration(void)
+{
+  LOG_CLEAN("== Testing double unregistration prevention");
+  hub_init();
+
+  hub_register_component(&test_fullscreen);
+  hub_unregister_component("fullscreen");
+  assert(test_fullscreen.registered == false);
+
+  /* Try to unregister again - should fail */
+  hub_unregister_component("fullscreen");
+  assert(hub_component_count() == 0);
+
+  hub_register_target(&test_client1);
+  hub_unregister_target(100);
+  assert(test_client1.registered == false);
+
+  /* Try to unregister again - should fail */
+  hub_unregister_target(100);
+  assert(hub_target_count() == 0);
+
+  hub_shutdown();
+}
+
+void
+test_idempotent_shutdown(void)
+{
+  LOG_CLEAN("== Testing idempotent shutdown");
+  hub_init();
+
+  hub_register_component(&test_fullscreen);
+  hub_register_component(&test_focus);
+  hub_register_target(&test_client1);
+  hub_register_target(&test_monitor1);
+
+  hub_shutdown();
+  assert(hub_component_count() == 0);
+  assert(hub_target_count() == 0);
+  assert(test_fullscreen.registered == false);
+  assert(test_focus.registered == false);
+  assert(test_client1.registered == false);
+  assert(test_monitor1.registered == false);
+
+  /* Call shutdown again - should be safe */
+  hub_shutdown();
+  assert(hub_component_count() == 0);
+  assert(hub_target_count() == 0);
+}
+
+int
+main(void)
+{
+  test_hub_init_shutdown();
+  test_register_unregister_component();
+  test_register_null_component();
+  test_unregister_nonexistent_component();
+  test_unregister_null_name();
+  test_get_component_by_name();
+  test_get_component_by_request_type();
+  test_register_unregister_target();
+  test_register_null_target();
+  test_register_target_none_id();
+  test_unregister_nonexistent_target();
+  test_unregister_none_id();
+  test_get_target_by_id();
+  test_get_targets_by_type();
+  test_double_registration();
+  test_double_unregistration();
+  test_idempotent_shutdown();
+
+  LOG_CLEAN("== All hub tests passed!");
+  return 0;
+}

--- a/test-wm-hub.c
+++ b/test-wm-hub.c
@@ -1,10 +1,10 @@
 #include "test-wm.h"
 #include "wm-hub.h"
 
-/* Test component definitions */
+/* Test component definitions - use TARGET_TYPE_NONE for proper termination */
 static RequestType fullscreen_requests[] = { 1, 2, 0 };   /* REQ_FULLSCREEN_ENTER = 1, REQ_FULLSCREEN_EXIT = 2 */
-static TargetType  client_targets[] = { TARGET_TYPE_CLIENT, 0 };
-static TargetType  monitor_targets[] = { TARGET_TYPE_MONITOR, 0 };
+static TargetType  client_targets[] = { TARGET_TYPE_CLIENT, TARGET_TYPE_NONE };
+static TargetType  monitor_targets[] = { TARGET_TYPE_MONITOR, TARGET_TYPE_NONE };
 
 static HubComponent test_fullscreen = {
   .name       = "fullscreen",
@@ -13,9 +13,11 @@ static HubComponent test_fullscreen = {
   .registered = false,
 };
 
+/* test_focus handles request type 1 AND 3 (for override/fallback testing) */
+static RequestType focus_requests[] = { 1, 3, 0 };   /* REQ_CLIENT_FOCUS = 3, also handles 1 */
 static HubComponent test_focus = {
   .name       = "focus",
-  .requests   = (RequestType[]){ 3, 0 },  /* REQ_CLIENT_FOCUS = 3 */
+  .requests   = focus_requests,
   .targets    = client_targets,
   .registered = false,
 };
@@ -153,22 +155,19 @@ test_get_component_by_request_type(void)
   hub_register_component(&test_fullscreen);
   hub_register_component(&test_focus);
 
-  /* Request type 1 should map to fullscreen component */
+  /* Request type 1: fullscreen handles it, but focus was registered last
+   * and also handles it, so focus wins (last registered wins) */
   HubComponent* found = hub_get_component_by_request_type(1);
-  assert(found == &test_fullscreen);
+  assert(found == &test_focus);
 
-  /* Request type 3 should map to focus component */
+  /* Request type 3: only focus handles it */
   found = hub_get_component_by_request_type(3);
   assert(found == &test_focus);
 
-  /* Unregister fullscreen - request type 1 should now have no handler */
-  hub_unregister_component("fullscreen");
+  /* Unregister focus - request type 1 should now fall back to fullscreen */
+  hub_unregister_component("focus");
   found = hub_get_component_by_request_type(1);
-  assert(found == NULL);   /* focus only handles type 3, not type 1 */
-
-  /* Focus component still handles type 3 */
-  found = hub_get_component_by_request_type(3);
-  assert(found == &test_focus);
+  assert(found == &test_fullscreen);   /* fullscreen now handles type 1 */
 
   /* Unused request type */
   found = hub_get_component_by_request_type(999);
@@ -386,6 +385,111 @@ test_idempotent_shutdown(void)
   assert(hub_target_count() == 0);
 }
 
+void
+test_shutdown_clears_indexes(void)
+{
+  LOG_CLEAN("== Testing shutdown clears lookup indexes");
+
+  hub_init();
+  hub_register_component(&test_fullscreen);
+  hub_register_target(&test_client1);
+
+  /* Verify lookups work */
+  assert(hub_get_component_by_name("fullscreen") != NULL);
+  assert(hub_get_component_by_request_type(1) != NULL);
+  assert(hub_get_target_by_id(100) != NULL);
+
+  hub_shutdown();
+
+  /* After shutdown, lookups should return NULL */
+  assert(hub_get_component_by_name("fullscreen") == NULL);
+  assert(hub_get_component_by_request_type(1) == NULL);
+  assert(hub_get_target_by_id(100) == NULL);
+
+  /* Re-init should work correctly */
+  hub_init();
+  assert(hub_component_count() == 0);
+  assert(hub_target_count() == 0);
+
+  hub_shutdown();
+}
+
+void
+test_duplicate_target_id_rejected(void)
+{
+  LOG_CLEAN("== Testing duplicate target ID is rejected");
+  hub_init();
+
+  hub_register_target(&test_client1);
+  assert(hub_target_count() == 1);
+  assert(hub_get_target_by_id(100) == &test_client1);
+
+  /* Try to register another target with the same ID - should fail */
+  HubTarget duplicate_target = {
+    .id         = 100,
+    .type       = TARGET_TYPE_MONITOR,
+    .registered = false,
+  };
+  hub_register_target(&duplicate_target);
+  assert(hub_target_count() == 1);  /* Should not increase */
+  assert(hub_get_target_by_id(100) == &test_client1);  /* Should still be client1 */
+
+  hub_shutdown();
+}
+
+void
+test_large_target_id_lookup(void)
+{
+  LOG_CLEAN("== Testing large TargetID values (beyond array bounds)");
+  hub_init();
+
+  /* Use a target ID larger than MAX_TARGETS (256) */
+  HubTarget large_id_target = {
+    .id         = 1000,
+    .type       = TARGET_TYPE_CLIENT,
+    .registered = false,
+  };
+
+  hub_register_target(&large_id_target);
+  assert(hub_target_count() == 1);
+
+  /* Should still be lookupable even though id > MAX_TARGETS */
+  HubTarget* found = hub_get_target_by_id(1000);
+  assert(found == &large_id_target);
+
+  hub_unregister_target(1000);
+  assert(hub_target_count() == 0);
+
+  /* After unregister, lookup should return NULL */
+  found = hub_get_target_by_id(1000);
+  assert(found == NULL);
+
+  hub_shutdown();
+}
+
+void
+test_target_type_null_termination(void)
+{
+  LOG_CLEAN("== Testing target type arrays have proper NULL termination");
+  hub_init();
+
+  hub_register_target(&test_client1);
+  hub_register_target(&test_client2);
+
+  HubTarget** clients = hub_get_targets_by_type(TARGET_TYPE_CLIENT);
+
+  /* Verify proper iteration with NULL terminator */
+  int count = 0;
+  for (int i = 0; clients[i] != NULL; i++) {
+    count++;
+    /* Should not exceed our registered count */
+    assert(i < 10);  /* Safety limit */
+  }
+  assert(count == 2);
+
+  hub_shutdown();
+}
+
 int
 main(void)
 {
@@ -406,6 +510,10 @@ main(void)
   test_double_registration();
   test_double_unregistration();
   test_idempotent_shutdown();
+  test_shutdown_clears_indexes();
+  test_duplicate_target_id_rejected();
+  test_large_target_id_lookup();
+  test_target_type_null_termination();
 
   LOG_CLEAN("== All hub tests passed!");
   return 0;

--- a/test-wm-hub.c
+++ b/test-wm-hub.c
@@ -161,9 +161,13 @@ test_get_component_by_request_type(void)
   found = hub_get_component_by_request_type(3);
   assert(found == &test_focus);
 
-  /* Unregister fullscreen - focus should now handle type 1 */
+  /* Unregister fullscreen - request type 1 should now have no handler */
   hub_unregister_component("fullscreen");
   found = hub_get_component_by_request_type(1);
+  assert(found == NULL);   /* focus only handles type 3, not type 1 */
+
+  /* Focus component still handles type 3 */
+  found = hub_get_component_by_request_type(3);
   assert(found == &test_focus);
 
   /* Unused request type */

--- a/vendor/libxcb-errors/include/xcb/errors.h
+++ b/vendor/libxcb-errors/include/xcb/errors.h
@@ -1,0 +1,50 @@
+#ifndef __ERRORS_H__
+#define __ERRORS_H__
+
+/* Copyright © 2015 Uli Schlachter
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the names of the authors or their
+ * institutions shall not be used in advertising or otherwise to promote the
+ * sale, use or other dealings in this Software without prior written
+ * authorization from the authors.
+ */
+
+#include "xcb_errors.h"
+
+struct static_extension_info_t {
+	uint16_t num_minor;
+	uint16_t num_xge_events;
+	uint8_t num_events;
+	uint8_t num_errors;
+	const char *strings_minor;
+	const char *strings_xge_events;
+	const char *strings_events;
+	const char *strings_errors;
+	const char *name;
+};
+
+extern const struct static_extension_info_t xproto_info;
+
+int register_extensions(xcb_errors_context_t *ctx, xcb_connection_t *conn);
+int register_extension(xcb_errors_context_t *ctx, xcb_connection_t *conn,
+		xcb_query_extension_cookie_t cookie,
+		const struct static_extension_info_t *static_info);
+
+#endif /* __ERRORS_H__ */

--- a/vendor/libxcb-errors/include/xcb/xcb_errors.h
+++ b/vendor/libxcb-errors/include/xcb/xcb_errors.h
@@ -1,0 +1,157 @@
+#ifndef __XCB_ERRORS_H__
+#define __XCB_ERRORS_H__
+
+/* Copyright © 2015 Uli Schlachter
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the names of the authors or their
+ * institutions shall not be used in advertising or otherwise to promote the
+ * sale, use or other dealings in this Software without prior written
+ * authorization from the authors.
+ */
+
+#include <xcb/xcb.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * A context for using this library.
+ *
+ * Create a context with @ref xcb_errors_context_new () and destroy it with @ref
+ * xcb_errors_context_free (). Except for @ref xcb_errors_context_free (), all
+ * functions in this library are thread-safe and can be called from multiple
+ * threads at the same time, even on the same context.
+ */
+typedef struct xcb_errors_context_t xcb_errors_context_t;
+
+/**
+ * Create a new @ref xcb_errors_context_t.
+ *
+ * @param conn A XCB connection which will be used until you destroy the context
+ * with @ref xcb_errors_context_free ().
+ * @param ctx A pointer to an xcb_cursor_context_t* which will be modified to
+ * refer to the newly created context.
+ * @return 0 on success, -1 otherwise. This function may fail due to memory
+ * allocation failures or if the connection ends up in an error state.
+ */
+int xcb_errors_context_new(xcb_connection_t *conn, xcb_errors_context_t **ctx);
+
+/**
+ * Free the @ref xcb_cursor_context_t.
+ *
+ * @param ctx The context to free.
+ */
+void xcb_errors_context_free(xcb_errors_context_t *ctx);
+
+/**
+ * Get the name corresponding to some major code. This is either the name of
+ * some core request or the name of the extension that owns this major code.
+ *
+ * @param ctx An errors context, created with @ref xcb_errors_context_new ()
+ * @param major_code The major code
+ * @return A string allocated in static storage that contains a name for this
+ * major code. This will never return NULL, but other functions in this library
+ * may.
+ */
+const char *xcb_errors_get_name_for_major_code(xcb_errors_context_t *ctx,
+		uint8_t major_code);
+
+/**
+ * Get the name corresponding to some minor code. When the major_code does not
+ * belong to any extension or the minor_code is not assigned inside this
+ * extension, NULL is returned.
+ *
+ * @param ctx An errors context, created with @ref xcb_errors_context_new ()
+ * @param major_code The major code under which to look up the minor code
+ * @param major_code The minor code
+ * @return A string allocated in static storage that contains a name for this
+ * major code or NULL for unknown codes.
+ */
+const char *xcb_errors_get_name_for_minor_code(xcb_errors_context_t *ctx,
+		uint8_t major_code,
+		uint16_t minor_code);
+
+/**
+ * Get the name corresponding to some core event code. If possible, you should
+ * use @ref xcb_errors_get_name_for_xcb_event instead.
+ *
+ * @param ctx An errors context, created with @ref xcb_errors_context_new ()
+ * @param event_code The response_type of an event.
+ * @param extension Will be set to the name of the extension that generated this
+ * event or NULL for unknown events or core X11 events. This argument may be
+ * NULL.
+ * @return A string allocated in static storage that contains a name for this
+ * major code. This will never return NULL, but other functions in this library
+ * may.
+ */
+const char *xcb_errors_get_name_for_core_event(xcb_errors_context_t *ctx,
+		uint8_t event_code, const char **extension);
+
+/**
+ * Get the name corresponding to some XGE or XKB event. XKB does not actually
+ * use the X generic event extension, but implements its own event multiplexing.
+ * This function also handles XKB's xkbType events as a event_type.
+ *
+ * If possible, you should use @ref xcb_errors_get_name_for_xcb_event instead.
+ *
+ * @param ctx An errors context, created with @ref xcb_errors_context_new ()
+ * @param major_code The extension's major code
+ * @param event_type The type of the event in that extension.
+ * @return A string allocated in static storage that contains a name for this
+ * event or NULL for unknown event types.
+ */
+const char *xcb_errors_get_name_for_xge_event(xcb_errors_context_t *ctx,
+		uint8_t major_code, uint16_t event_type);
+
+/**
+ * Get a human printable name describing the type of some event.
+ *
+ * @param ctx An errors context, created with @ref xcb_errors_context_new ()
+ * @param event The event to investigate.
+ * @param extension Will be set to the name of the extension that generated this
+ * event or NULL for unknown events or core X11 events. This argument may be
+ * NULL.
+ * @return A string allocated in static storage that contains a name for this
+ * event or NULL for unknown event types.
+ */
+const char *xcb_errors_get_name_for_xcb_event(xcb_errors_context_t *ctx,
+		xcb_generic_event_t *event, const char **extension);
+
+/**
+ * Get the name corresponding to some error.
+ *
+ * @param ctx An errors context, created with @ref xcb_errors_context_new ()
+ * @param error_code The error_code of an error reply.
+ * @param extension Will be set to the name of the extension that generated this
+ * event or NULL for unknown errors or core X11 errors. This argument may be
+ * NULL.
+ * @return A string allocated in static storage that contains a name for this
+ * major code. This will never return NULL, but other functions in this library
+ * may.
+ */
+const char *xcb_errors_get_name_for_error(xcb_errors_context_t *ctx,
+		uint8_t error_code, const char **extension);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __XCB_ERRORS_H__ */

--- a/wm-hub.c
+++ b/wm-hub.c
@@ -13,7 +13,6 @@ static HubComponent* components[MAX_COMPONENTS];
 static uint32_t      component_count = 0;
 
 /* Component lookup by name */
-#define MAX_NAME_LEN 64
 typedef struct {
   const char*    name;
   HubComponent* comp;
@@ -29,8 +28,23 @@ static HubComponent* component_by_request_type[MAX_REQUEST_TYPES];
 static HubTarget* targets[MAX_TARGETS];
 static uint32_t   target_count = 0;
 
-/* Target lookup by ID */
-static HubTarget* target_by_id[MAX_TARGETS];
+/* Target lookup by ID - use hash map for TargetID (uint64_t) beyond MAX_TARGETS */
+#define TARGET_ID_MAP_SIZE 512
+
+typedef struct target_id_entry {
+  TargetID        id;
+  HubTarget*      target;
+  struct target_id_entry* next;
+} target_id_entry_t;
+
+static target_id_entry_t* target_by_id_map[TARGET_ID_MAP_SIZE];
+
+static uint32_t
+target_id_hash(TargetID id)
+{
+  /* Simple hash function for TargetID */
+  return (uint32_t)((id ^ (id >> 16)) % TARGET_ID_MAP_SIZE);
+}
 
 /* Targets grouped by type (array of arrays) */
 static HubTarget* targets_by_type[TARGET_TYPE_COUNT][MAX_TARGETS];
@@ -38,24 +52,38 @@ static uint32_t   targets_by_type_count[TARGET_TYPE_COUNT];
 
 /* Forward declarations */
 static void component_add_to_request_type_index(HubComponent* comp);
+static void target_by_id_map_insert(HubTarget* target);
+static void target_by_id_map_remove(TargetID id);
+static HubTarget* target_by_id_map_lookup(TargetID id);
+
+/*
+ * Clear all registry state.
+ * Called on both init and shutdown for consistent cleanup.
+ */
+static void
+clear_registry_state(void)
+{
+  /* Clear component arrays */
+  memset(components, 0, sizeof(components));
+  memset(component_by_name, 0, sizeof(component_by_name));
+  memset(component_by_request_type, 0, sizeof(component_by_request_type));
+
+  /* Clear target arrays */
+  memset(targets, 0, sizeof(targets));
+  memset(target_by_id_map, 0, sizeof(target_by_id_map));
+  memset(targets_by_type, 0, sizeof(targets_by_type));
+  memset(targets_by_type_count, 0, sizeof(targets_by_type_count));
+
+  component_count = 0;
+  name_entry_count = 0;
+  target_count = 0;
+}
 
 void
 hub_init(void)
 {
   LOG_DEBUG("Initializing hub registry");
-
-  component_count        = 0;
-  name_entry_count       = 0;
-  target_count           = 0;
-
-  /* Clear all arrays */
-  memset(components, 0, sizeof(components));
-  memset(component_by_name, 0, sizeof(component_by_name));
-  memset(component_by_request_type, 0, sizeof(component_by_request_type));
-  memset(targets, 0, sizeof(targets));
-  memset(target_by_id, 0, sizeof(target_by_id));
-  memset(targets_by_type, 0, sizeof(targets_by_type));
-  memset(targets_by_type_count, 0, sizeof(targets_by_type_count));
+  clear_registry_state();
 }
 
 void
@@ -73,12 +101,10 @@ hub_shutdown(void)
   while (target_count > 0) {
     target_count--;
     targets[target_count]->registered = false;
-    target_by_id[targets[target_count]->id] = NULL;
   }
 
-  component_count = 0;
-  name_entry_count = 0;
-  target_count = 0;
+  /* Clear all registry state including indexes */
+  clear_registry_state();
 }
 
 void
@@ -136,13 +162,36 @@ hub_unregister_component(const char* name)
     return;
   }
 
-  /* Remove from request type index */
+  /* Remove from main component array FIRST */
+  for (uint32_t i = 0; i < component_count; i++) {
+    if (components[i] == comp) {
+      components[i] = components[component_count - 1];
+      component_count--;
+      break;
+    }
+  }
+
+  /* Recompute request type mappings - scan remaining components */
   if (comp->requests != NULL) {
     for (int i = 0; comp->requests[i] != 0; i++) {
       RequestType rt = comp->requests[i];
       if (rt < MAX_REQUEST_TYPES) {
+        /* Only recompute if this component was the handler */
         if (component_by_request_type[rt] == comp) {
           component_by_request_type[rt] = NULL;
+          /* Recompute from remaining registered components */
+          for (int32_t j = (int32_t)component_count - 1; j >= 0; j--) {
+            HubComponent* other = components[j];
+            if (other != NULL && other->requests != NULL) {
+              for (int k = 0; other->requests[k] != 0; k++) {
+                if (other->requests[k] == rt) {
+                  component_by_request_type[rt] = other;
+                  j = -1;  /* Signal found, break outer loop */
+                  break;
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -154,15 +203,6 @@ hub_unregister_component(const char* name)
       /* Swap with last and decrement */
       component_by_name[i] = component_by_name[name_entry_count - 1];
       name_entry_count--;
-      break;
-    }
-  }
-
-  /* Remove from main component array */
-  for (uint32_t i = 0; i < component_count; i++) {
-    if (components[i] == comp) {
-      components[i] = components[component_count - 1];
-      component_count--;
       break;
     }
   }
@@ -223,18 +263,26 @@ hub_register_target(HubTarget* target)
     return;
   }
 
+  /* Check for duplicate ID */
+  if (hub_get_target_by_id(target->id) != NULL) {
+    LOG_ERROR("Target with ID %lu already registered", (unsigned long)target->id);
+    return;
+  }
+
   /* Add to main target array */
   targets[target_count++] = target;
   target->registered = true;
 
-  /* Add to ID index */
-  if (target->id < MAX_TARGETS) {
-    target_by_id[target->id] = target;
-  }
+  /* Add to ID index (hash map for arbitrary TargetID values) */
+  target_by_id_map_insert(target);
 
-  /* Add to type index */
+  /* Add to type index with NULL terminator */
   if (targets_by_type_count[target->type] < MAX_TARGETS) {
     targets_by_type[target->type][targets_by_type_count[target->type]++] = target;
+    /* Ensure NULL terminator */
+    if (targets_by_type_count[target->type] < MAX_TARGETS) {
+      targets_by_type[target->type][targets_by_type_count[target->type]] = NULL;
+    }
   }
 
   LOG_DEBUG("Registered target: id=%lu, type=%u", (unsigned long)target->id, target->type);
@@ -260,14 +308,14 @@ hub_unregister_target(TargetID id)
       targets_by_type[target->type][i] =
         targets_by_type[target->type][targets_by_type_count[target->type] - 1];
       targets_by_type_count[target->type]--;
+      /* Clear vacated slot and ensure NULL terminator */
+      targets_by_type[target->type][targets_by_type_count[target->type]] = NULL;
       break;
     }
   }
 
   /* Remove from ID index */
-  if (id < MAX_TARGETS) {
-    target_by_id[id] = NULL;
-  }
+  target_by_id_map_remove(id);
 
   /* Remove from main target array */
   for (uint32_t i = 0; i < target_count; i++) {
@@ -288,10 +336,7 @@ hub_get_target_by_id(TargetID id)
   if (id == TARGET_ID_NONE)
     return NULL;
 
-  if (id >= MAX_TARGETS)
-    return NULL;
-
-  return target_by_id[id];
+  return target_by_id_map_lookup(id);
 }
 
 HubTarget**
@@ -299,6 +344,11 @@ hub_get_targets_by_type(TargetType type)
 {
   if (type >= TARGET_TYPE_COUNT)
     return NULL;
+
+  /* Ensure NULL terminator is set */
+  if (targets_by_type_count[type] < MAX_TARGETS) {
+    targets_by_type[type][targets_by_type_count[type]] = NULL;
+  }
 
   /* Return pointer to the array - caller should not modify */
   return targets_by_type[type];
@@ -331,4 +381,53 @@ component_add_to_request_type_index(HubComponent* comp)
       component_by_request_type[rt] = comp;
     }
   }
+}
+
+/* Hash map implementation for TargetID lookup */
+static void
+target_by_id_map_insert(HubTarget* target)
+{
+  uint32_t hash = target_id_hash(target->id);
+  target_id_entry_t* entry = malloc(sizeof(target_id_entry_t));
+  if (entry == NULL) {
+    LOG_ERROR("Failed to allocate target ID map entry");
+    return;
+  }
+  entry->id = target->id;
+  entry->target = target;
+  entry->next = target_by_id_map[hash];
+  target_by_id_map[hash] = entry;
+}
+
+static void
+target_by_id_map_remove(TargetID id)
+{
+  uint32_t hash = target_id_hash(id);
+  target_id_entry_t** prev = &target_by_id_map[hash];
+  target_id_entry_t* curr = *prev;
+
+  while (curr != NULL) {
+    if (curr->id == id) {
+      *prev = curr->next;
+      free(curr);
+      return;
+    }
+    prev = &curr->next;
+    curr = curr->next;
+  }
+}
+
+static HubTarget*
+target_by_id_map_lookup(TargetID id)
+{
+  uint32_t hash = target_id_hash(id);
+  target_id_entry_t* curr = target_by_id_map[hash];
+
+  while (curr != NULL) {
+    if (curr->id == id) {
+      return curr->target;
+    }
+    curr = curr->next;
+  }
+  return NULL;
 }

--- a/wm-hub.c
+++ b/wm-hub.c
@@ -1,0 +1,334 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "wm-hub.h"
+#include "wm-log.h"
+
+/* Registry data structures */
+#define MAX_COMPONENTS 64
+#define MAX_TARGETS    256
+#define MAX_REQUEST_TYPES 256
+
+static HubComponent* components[MAX_COMPONENTS];
+static uint32_t      component_count = 0;
+
+/* Component lookup by name */
+#define MAX_NAME_LEN 64
+typedef struct {
+  const char*    name;
+  HubComponent* comp;
+} component_name_entry_t;
+
+static component_name_entry_t component_by_name[MAX_COMPONENTS];
+static uint32_t               name_entry_count = 0;
+
+/* Component lookup by request type (array indexed by RequestType) */
+static HubComponent* component_by_request_type[MAX_REQUEST_TYPES];
+
+/* Target registry */
+static HubTarget* targets[MAX_TARGETS];
+static uint32_t   target_count = 0;
+
+/* Target lookup by ID */
+static HubTarget* target_by_id[MAX_TARGETS];
+
+/* Targets grouped by type (array of arrays) */
+static HubTarget* targets_by_type[TARGET_TYPE_COUNT][MAX_TARGETS];
+static uint32_t   targets_by_type_count[TARGET_TYPE_COUNT];
+
+/* Forward declarations */
+static void component_add_to_request_type_index(HubComponent* comp);
+
+void
+hub_init(void)
+{
+  LOG_DEBUG("Initializing hub registry");
+
+  component_count        = 0;
+  name_entry_count       = 0;
+  target_count           = 0;
+
+  /* Clear all arrays */
+  memset(components, 0, sizeof(components));
+  memset(component_by_name, 0, sizeof(component_by_name));
+  memset(component_by_request_type, 0, sizeof(component_by_request_type));
+  memset(targets, 0, sizeof(targets));
+  memset(target_by_id, 0, sizeof(target_by_id));
+  memset(targets_by_type, 0, sizeof(targets_by_type));
+  memset(targets_by_type_count, 0, sizeof(targets_by_type_count));
+}
+
+void
+hub_shutdown(void)
+{
+  LOG_DEBUG("Shutting down hub registry");
+
+  /* Unregister all components */
+  while (component_count > 0) {
+    component_count--;
+    components[component_count]->registered = false;
+  }
+
+  /* Unregister all targets */
+  while (target_count > 0) {
+    target_count--;
+    targets[target_count]->registered = false;
+    target_by_id[targets[target_count]->id] = NULL;
+  }
+
+  component_count = 0;
+  name_entry_count = 0;
+  target_count = 0;
+}
+
+void
+hub_register_component(HubComponent* comp)
+{
+  if (comp == NULL) {
+    LOG_ERROR("Cannot register NULL component");
+    return;
+  }
+
+  if (comp->registered) {
+    LOG_ERROR("Component '%s' is already registered", comp->name);
+    return;
+  }
+
+  if (component_count >= MAX_COMPONENTS) {
+    LOG_ERROR("Maximum number of components reached (%d)", MAX_COMPONENTS);
+    return;
+  }
+
+  /* Add to main component array */
+  components[component_count++] = comp;
+  comp->registered = true;
+
+  /* Add to name index */
+  if (name_entry_count < MAX_COMPONENTS) {
+    component_by_name[name_entry_count].name = comp->name;
+    component_by_name[name_entry_count].comp = comp;
+    name_entry_count++;
+  }
+
+  /* Add to request type index */
+  component_add_to_request_type_index(comp);
+
+  LOG_DEBUG("Registered component: %s", comp->name);
+}
+
+void
+hub_unregister_component(const char* name)
+{
+  if (name == NULL) {
+    LOG_ERROR("Cannot unregister component with NULL name");
+    return;
+  }
+
+  /* Find component by name */
+  HubComponent* comp = hub_get_component_by_name(name);
+  if (comp == NULL) {
+    LOG_ERROR("Component '%s' not found", name);
+    return;
+  }
+
+  if (!comp->registered) {
+    LOG_ERROR("Component '%s' is not registered", name);
+    return;
+  }
+
+  /* Remove from request type index */
+  if (comp->requests != NULL) {
+    for (int i = 0; comp->requests[i] != 0; i++) {
+      RequestType rt = comp->requests[i];
+      if (rt < MAX_REQUEST_TYPES) {
+        if (component_by_request_type[rt] == comp) {
+          component_by_request_type[rt] = NULL;
+        }
+      }
+    }
+  }
+
+  /* Remove from name index */
+  for (uint32_t i = 0; i < name_entry_count; i++) {
+    if (component_by_name[i].comp == comp) {
+      /* Swap with last and decrement */
+      component_by_name[i] = component_by_name[name_entry_count - 1];
+      name_entry_count--;
+      break;
+    }
+  }
+
+  /* Remove from main component array */
+  for (uint32_t i = 0; i < component_count; i++) {
+    if (components[i] == comp) {
+      components[i] = components[component_count - 1];
+      component_count--;
+      break;
+    }
+  }
+
+  comp->registered = false;
+  LOG_DEBUG("Unregistered component: %s", name);
+}
+
+HubComponent*
+hub_get_component_by_name(const char* name)
+{
+  if (name == NULL)
+    return NULL;
+
+  for (uint32_t i = 0; i < name_entry_count; i++) {
+    if (component_by_name[i].name != NULL &&
+        strcmp(component_by_name[i].name, name) == 0) {
+      return component_by_name[i].comp;
+    }
+  }
+  return NULL;
+}
+
+HubComponent*
+hub_get_component_by_request_type(RequestType type)
+{
+  if (type >= MAX_REQUEST_TYPES)
+    return NULL;
+
+  return component_by_request_type[type];
+}
+
+void
+hub_register_target(HubTarget* target)
+{
+  if (target == NULL) {
+    LOG_ERROR("Cannot register NULL target");
+    return;
+  }
+
+  if (target->registered) {
+    LOG_ERROR("Target %lu is already registered", (unsigned long)target->id);
+    return;
+  }
+
+  if (target_count >= MAX_TARGETS) {
+    LOG_ERROR("Maximum number of targets reached (%d)", MAX_TARGETS);
+    return;
+  }
+
+  if (target->id == TARGET_ID_NONE) {
+    LOG_ERROR("Cannot register target with ID NONE");
+    return;
+  }
+
+  if (target->type >= TARGET_TYPE_COUNT) {
+    LOG_ERROR("Invalid target type %u", target->type);
+    return;
+  }
+
+  /* Add to main target array */
+  targets[target_count++] = target;
+  target->registered = true;
+
+  /* Add to ID index */
+  if (target->id < MAX_TARGETS) {
+    target_by_id[target->id] = target;
+  }
+
+  /* Add to type index */
+  if (targets_by_type_count[target->type] < MAX_TARGETS) {
+    targets_by_type[target->type][targets_by_type_count[target->type]++] = target;
+  }
+
+  LOG_DEBUG("Registered target: id=%lu, type=%u", (unsigned long)target->id, target->type);
+}
+
+void
+hub_unregister_target(TargetID id)
+{
+  if (id == TARGET_ID_NONE) {
+    LOG_ERROR("Cannot unregister target with ID NONE");
+    return;
+  }
+
+  HubTarget* target = hub_get_target_by_id(id);
+  if (target == NULL) {
+    LOG_ERROR("Target %lu not found", (unsigned long)id);
+    return;
+  }
+
+  /* Remove from type index */
+  for (uint32_t i = 0; i < targets_by_type_count[target->type]; i++) {
+    if (targets_by_type[target->type][i] == target) {
+      targets_by_type[target->type][i] =
+        targets_by_type[target->type][targets_by_type_count[target->type] - 1];
+      targets_by_type_count[target->type]--;
+      break;
+    }
+  }
+
+  /* Remove from ID index */
+  if (id < MAX_TARGETS) {
+    target_by_id[id] = NULL;
+  }
+
+  /* Remove from main target array */
+  for (uint32_t i = 0; i < target_count; i++) {
+    if (targets[i] == target) {
+      targets[i] = targets[target_count - 1];
+      target_count--;
+      break;
+    }
+  }
+
+  target->registered = false;
+  LOG_DEBUG("Unregistered target: id=%lu", (unsigned long)id);
+}
+
+HubTarget*
+hub_get_target_by_id(TargetID id)
+{
+  if (id == TARGET_ID_NONE)
+    return NULL;
+
+  if (id >= MAX_TARGETS)
+    return NULL;
+
+  return target_by_id[id];
+}
+
+HubTarget**
+hub_get_targets_by_type(TargetType type)
+{
+  if (type >= TARGET_TYPE_COUNT)
+    return NULL;
+
+  /* Return pointer to the array - caller should not modify */
+  return targets_by_type[type];
+}
+
+uint32_t
+hub_component_count(void)
+{
+  return component_count;
+}
+
+uint32_t
+hub_target_count(void)
+{
+  return target_count;
+}
+
+/* Internal helper: add component to request type index */
+static void
+component_add_to_request_type_index(HubComponent* comp)
+{
+  if (comp->requests == NULL)
+    return;
+
+  for (int i = 0; comp->requests[i] != 0; i++) {
+    RequestType rt = comp->requests[i];
+    if (rt < MAX_REQUEST_TYPES) {
+      /* If there's already a component for this request type,
+       * the last registered one wins (overwrites) */
+      component_by_request_type[rt] = comp;
+    }
+  }
+}

--- a/wm-hub.h
+++ b/wm-hub.h
@@ -1,0 +1,66 @@
+#ifndef _WM_HUB_H_
+#define _WM_HUB_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <xcb/xcb.h>
+
+/* Forward declarations */
+typedef struct HubComponent HubComponent;
+typedef struct HubTarget HubTarget;
+
+/* Type definitions */
+typedef uint64_t TargetID;
+typedef uint32_t TargetType;
+typedef uint32_t RequestType;
+typedef uint32_t EventType;
+
+/* Target types */
+enum {
+	TARGET_TYPE_CLIENT,
+	TARGET_TYPE_MONITOR,
+	TARGET_TYPE_KEYBOARD,
+	TARGET_TYPE_TAG,
+	TARGET_TYPE_SYSTEM,
+	TARGET_TYPE_COUNT,
+};
+
+/* Invalid ID sentinel */
+#define TARGET_ID_NONE ((TargetID)0)
+
+/* Component structure */
+struct HubComponent {
+	const char*    name;
+	RequestType*   requests;   /* NULL-terminated array of request types handled */
+	TargetType*    targets;    /* NULL-terminated array of target types accepted */
+	bool           registered;
+};
+
+/* Target structure */
+struct HubTarget {
+	TargetID       id;
+	TargetType     type;
+	bool           registered;
+};
+
+/* Hub initialization */
+void hub_init(void);
+void hub_shutdown(void);
+
+/* Component registration */
+void             hub_register_component(HubComponent* comp);
+void             hub_unregister_component(const char* name);
+HubComponent*    hub_get_component_by_name(const char* name);
+HubComponent*    hub_get_component_by_request_type(RequestType type);
+
+/* Target registration */
+void         hub_register_target(HubTarget* target);
+void         hub_unregister_target(TargetID id);
+HubTarget*   hub_get_target_by_id(TargetID id);
+HubTarget**  hub_get_targets_by_type(TargetType type);
+
+/* Utility */
+uint32_t hub_component_count(void);
+uint32_t hub_target_count(void);
+
+#endif

--- a/wm-hub.h
+++ b/wm-hub.h
@@ -3,7 +3,6 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <xcb/xcb.h>
 
 /* Forward declarations */
 typedef struct HubComponent HubComponent;

--- a/wm-hub.h
+++ b/wm-hub.h
@@ -24,6 +24,9 @@ enum {
 	TARGET_TYPE_COUNT,
 };
 
+/* Explicit sentinel for NULL-terminated target arrays (avoids collision with 0) */
+#define TARGET_TYPE_NONE ((TargetType) UINT32_MAX)
+
 /* Invalid ID sentinel */
 #define TARGET_ID_NONE ((TargetID)0)
 
@@ -31,7 +34,7 @@ enum {
 struct HubComponent {
 	const char*    name;
 	RequestType*   requests;   /* NULL-terminated array of request types handled */
-	TargetType*    targets;    /* NULL-terminated array of target types accepted */
+	TargetType*    targets;    /* TARGET_TYPE_NONE-terminated array of accepted types */
 	bool           registered;
 };
 


### PR DESCRIPTION
Implements GitHub issue #2: Hub Registry

## Summary

This PR implements the Hub registry for components and targets as specified in the architecture documentation.

## Changes

### New Files
-  - Header with type definitions and function declarations
-  - Implementation of the hub registry
-  - Comprehensive unit tests

### Functions Implemented
-  /  - Registry lifecycle
-  /  - Component registration
-  /  - Target registration  
-  - Lookup component by name
-  - Lookup component by request type (for routing)
-  - Lookup target by ID
-  - Query targets by type

### Registry Structure
- Component by name (for discovery)
- Component by request type (for request routing)
- Target by ID (for direct lookup)
- Target by type (for querying all of a type)

### Acceptance Criteria
- [x] Component can register itself at startup
- [x] Component can be looked up by name
- [x] Component can be looked up by request type
- [x] Target can register itself at creation
- [x] Target can be looked up by ID
- [x] Targets can be queried by type
- [x] Cleanup on shutdown (no leaks)

Closes #2