### PR TITLE
chore: set up lefthook and git hooks (Issue #0)

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,14 @@
+# lefthook.yml - Git hooks configuration for wm
+# This file is tracked in git, so hooks work in worktrees
+
+commit-msg:
+  commands:
+    format:
+      glob: "*.{c,h}"
+      run: clang-format --style=file -i {staged_files}
+
+pre-push:
+  commands:
+    format:
+      glob: "*.{c,h}"
+      run: clang-format --style=file -i {staged_files}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,6 +9,7 @@ pre-commit:
       stage: true
 
 pre-push:
+  skip: [pre-commit]
   commands:
     format:
       glob: "*.{c,h}"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,6 +6,7 @@ pre-commit:
     format:
       glob: "*.{c,h}"
       run: clang-format --style=file -i {staged_files}
+      stage: true
 
 pre-push:
   commands:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,7 +1,7 @@
 # lefthook.yml - Git hooks configuration for wm
 # This file is tracked in git, so hooks work in worktrees
 
-commit-msg:
+pre-commit:
   commands:
     format:
       glob: "*.{c,h}"
@@ -11,4 +11,4 @@ pre-push:
   commands:
     format:
       glob: "*.{c,h}"
-      run: clang-format --style=file -i {staged_files}
+      run: clang-format --style=file --dry-run --Werror {staged_files}

--- a/unformatted.c
+++ b/unformatted.c
@@ -1,1 +1,0 @@
-int   main(){int x=0;return 0;}

--- a/unformatted.c
+++ b/unformatted.c
@@ -1,0 +1,1 @@
+int   main(){int x=0;return 0;}


### PR DESCRIPTION
Implements [GitHub issue #24](https://github.com/kesor/wm-xcb/issues/24): Set up lefthook and git hooks for code formatting.

## Changes
- Create `lefthook.yml` with `pre-commit` hook that runs `clang-format --style=file -i` on staged .c and .h files
- Add `pre-push` hook using `clang-format --dry-run --Werror` for non-mutating format checks

## Notes
- Hooks are in the repo root so they work in worktrees
- `.git/hooks/` is shared, so hooks apply to all worktrees