### PR TITLE
feat: implement hub request routing, Client target, and Monitor target (#4, #11, #15)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,8 @@ SRC = \
 	$(NAME)-window-list.c \
 	$(NAME)-clients.c \
 	$(NAME)-hub.c \
+	$(NAME)-client.c \
+	$(NAME)-monitor.c \
 	$(NAME)-xcb-ewmh.c \
 	$(NAME)-xcb-events.c \
 	$(NAME)-states.c \

--- a/test-wm-hub.c
+++ b/test-wm-hub.c
@@ -2,8 +2,36 @@
 #include "test-registry.h"
 #include "wm-hub.h"
 
+/* Test request types */
+enum TestRequestType {
+  REQ_TEST_FULLSCREEN = 1,
+  REQ_TEST_FOCUS      = 3,
+  REQ_TEST_TILE       = 6,
+  REQ_TEST_TAG        = 7,
+};
+
+/* Executor call tracking for request routing tests */
+static int executor_call_count = 0;
+static RequestType last_executor_request_type = 0;
+static TargetID last_executor_target = 0;
+static void* last_executor_data = NULL;
+
+static void test_executor(Request* req) {
+  executor_call_count++;
+  last_executor_request_type = req->type;
+  last_executor_target = req->target;
+  last_executor_data = req->data;
+}
+
+static void test_monitor_executor(Request* req) {
+  executor_call_count++;
+  last_executor_request_type = req->type;
+  last_executor_target = req->target;
+  last_executor_data = req->data;
+}
+
 /* Test component definitions - use TARGET_TYPE_NONE for proper termination */
-static RequestType fullscreen_requests[] = { 1, 2, 0 }; /* REQ_FULLSCREEN_ENTER = 1, REQ_FULLSCREEN_EXIT = 2 */
+static RequestType fullscreen_requests[] = { REQ_TEST_FULLSCREEN, 2, 0 };
 static TargetType  client_targets[]      = { TARGET_TYPE_CLIENT, TARGET_TYPE_NONE };
 static TargetType  monitor_targets[]     = { TARGET_TYPE_MONITOR, TARGET_TYPE_NONE };
 
@@ -11,22 +39,25 @@ static HubComponent test_fullscreen = {
   .name       = "fullscreen",
   .requests   = fullscreen_requests,
   .targets    = client_targets,
+  .executor   = test_executor,
   .registered = false,
 };
 
 /* test_focus handles request type 1 AND 3 (for override/fallback testing) */
-static RequestType  focus_requests[] = { 1, 3, 0 }; /* REQ_CLIENT_FOCUS = 3, also handles 1 */
+static RequestType  focus_requests[] = { REQ_TEST_FOCUS, REQ_TEST_FULLSCREEN, 0 };
 static HubComponent test_focus       = {
-        .name       = "focus",
-        .requests   = focus_requests,
-        .targets    = client_targets,
-        .registered = false,
+  .name       = "focus",
+  .requests   = focus_requests,
+  .targets    = client_targets,
+  .executor   = test_executor,
+  .registered = false,
 };
 
 static HubComponent test_monitor = {
   .name       = "monitor",
-  .requests   = (RequestType[]) { 4, 5, 0 }, /* REQ_MONITOR_* = 4, 5 */
+  .requests   = (RequestType[]) { 4, 5, 0 },
   .targets    = monitor_targets,
+  .executor   = test_monitor_executor,
   .registered = false,
 };
 
@@ -775,6 +806,200 @@ TEST_GROUP(HubRegistry, {
   test_duplicate_target_id_rejected();
   test_large_target_id_lookup();
   test_target_type_null_termination();
+});
+
+/* Request Routing Tests */
+
+void
+test_request_routes_to_correct_component(void)
+{
+  LOG_CLEAN("== Testing request routes to correct component");
+
+  hub_init();
+  hub_register_component(&test_fullscreen);
+  hub_register_component(&test_focus);
+
+  executor_call_count = 0;
+
+  /* Send REQ_TEST_FULLSCREEN - should route to test_fullscreen */
+  hub_send_request(REQ_TEST_FULLSCREEN, 100, NULL);
+  assert(executor_call_count == 1);
+  assert(last_executor_request_type == REQ_TEST_FULLSCREEN);
+  assert(last_executor_target == 100);
+
+  /* Send REQ_TEST_FOCUS - should route to test_focus */
+  hub_send_request(REQ_TEST_FOCUS, 101, NULL);
+  assert(executor_call_count == 2);
+  assert(last_executor_request_type == REQ_TEST_FOCUS);
+  assert(last_executor_target == 101);
+
+  hub_shutdown();
+}
+
+void
+test_request_with_data(void)
+{
+  LOG_CLEAN("== Testing request passes data to executor");
+
+  hub_init();
+  hub_register_component(&test_fullscreen);
+
+  executor_call_count = 0;
+  last_executor_data = NULL;
+
+  int test_data = 42;
+  hub_send_request(REQ_TEST_FULLSCREEN, 100, &test_data);
+
+  assert(executor_call_count == 1);
+  assert(last_executor_data == &test_data);
+
+  hub_shutdown();
+}
+
+void
+test_request_unhandled_type_no_crash(void)
+{
+  LOG_CLEAN("== Testing request with unhandled type does not crash");
+
+  hub_init();
+  hub_register_component(&test_fullscreen);
+
+  executor_call_count = 0;
+
+  /* Request type 999 is not handled by any component */
+  hub_send_request(999, 100, NULL);
+  assert(executor_call_count == 0); /* Should not call any executor */
+
+  hub_shutdown();
+}
+
+void
+test_request_no_component_registered(void)
+{
+  LOG_CLEAN("== Testing request when no component registered");
+
+  hub_init();
+
+  executor_call_count = 0;
+
+  /* No components registered - should not crash */
+  hub_send_request(REQ_TEST_FULLSCREEN, 100, NULL);
+  assert(executor_call_count == 0);
+
+  hub_shutdown();
+}
+
+void
+test_request_with_concrete_target(void)
+{
+  LOG_CLEAN("== Testing request with concrete target ID");
+
+  hub_init();
+  hub_register_component(&test_fullscreen);
+  hub_register_target(&test_client1);
+
+  executor_call_count = 0;
+
+  hub_send_request(REQ_TEST_FULLSCREEN, test_client1.id, NULL);
+  assert(executor_call_count == 1);
+  assert(last_executor_target == test_client1.id);
+
+  hub_shutdown();
+}
+
+void
+test_broadcast_request(void)
+{
+  LOG_CLEAN("== Testing broadcast request to all targets of type");
+
+  hub_init();
+  hub_register_component(&test_fullscreen);
+  hub_register_target(&test_client1);
+  hub_register_target(&test_client2);
+
+  executor_call_count = 0;
+
+  /* Broadcast REQ_TEST_FULLSCREEN to all clients */
+  hub_broadcast_request(REQ_TEST_FULLSCREEN, TARGET_TYPE_CLIENT, NULL);
+
+  assert(executor_call_count == 2); /* Both clients should receive */
+  assert(last_executor_request_type == REQ_TEST_FULLSCREEN);
+
+  hub_shutdown();
+}
+
+void
+test_broadcast_empty_when_no_targets(void)
+{
+  LOG_CLEAN("== Testing broadcast request when no targets of type exist");
+
+  hub_init();
+  hub_register_component(&test_fullscreen);
+
+  executor_call_count = 0;
+
+  /* No clients registered - should not crash */
+  hub_broadcast_request(REQ_TEST_FULLSCREEN, TARGET_TYPE_CLIENT, NULL);
+  assert(executor_call_count == 0);
+
+  hub_shutdown();
+}
+
+void
+test_target_resolution_concrete_ids(void)
+{
+  LOG_CLEAN("== Testing target resolution passes through concrete IDs");
+
+  hub_init();
+  hub_register_component(&test_fullscreen);
+
+  executor_call_count = 0;
+
+  /* Concrete ID should pass through unchanged */
+  hub_send_request(REQ_TEST_FULLSCREEN, 12345, NULL);
+  assert(executor_call_count == 1);
+  assert(last_executor_target == 12345);
+
+  hub_shutdown();
+}
+
+void
+test_component_without_executor(void)
+{
+  LOG_CLEAN("== Testing component without executor does not crash");
+
+  hub_init();
+
+  /* Component without executor - use static arrays like other components */
+  static RequestType noexec_requests[] = { REQ_TEST_FULLSCREEN, 0 };
+  static HubComponent no_exec_comp = {
+    .name       = "noexec",
+    .requests   = noexec_requests,
+    .targets    = client_targets,
+    .executor   = NULL,
+    .registered = false,
+  };
+
+  hub_register_component(&no_exec_comp);
+
+  executor_call_count = 0;
+
+  hub_send_request(REQ_TEST_FULLSCREEN, 100, NULL);
+  assert(executor_call_count == 0); /* No executor called */
+
+  hub_shutdown();
+}
+
+TEST_GROUP(HubRequestRouting, {
+  test_request_routes_to_correct_component();
+  test_request_with_data();
+  test_request_unhandled_type_no_crash();
+  test_request_no_component_registered();
+  test_request_with_concrete_target();
+  test_broadcast_request();
+  test_broadcast_empty_when_no_targets();
+  test_target_resolution_concrete_ids();
+  test_component_without_executor();
 });
 
 TEST_GROUP(HubEventBus, {

--- a/wm-client.c
+++ b/wm-client.c
@@ -1,0 +1,473 @@
+#include "wm-client.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "wm-log.h"
+
+/* Client list (sentinel-based circular doubly-linked list) */
+static Client clients_sentinel = {
+  .next = &clients_sentinel,
+  .prev = &clients_sentinel,
+};
+
+/* Client count */
+static uint32_t clients_count = 0;
+
+/* Hash map for window -> client lookup */
+#define CLIENT_WINDOW_MAP_SIZE 512
+
+typedef struct client_window_entry {
+  xcb_window_t     window;
+  Client*          client;
+  struct client_window_entry* next;
+} client_window_entry_t;
+
+static client_window_entry_t* client_window_map[CLIENT_WINDOW_MAP_SIZE];
+
+static uint32_t
+client_window_hash(xcb_window_t window)
+{
+  return ((uint32_t) (window ^ (window >> 16))) % CLIENT_WINDOW_MAP_SIZE;
+}
+
+static void
+client_window_map_insert(Client* client)
+{
+  uint32_t                   hash = client_window_hash(client->window);
+  client_window_entry_t*     entry = malloc(sizeof(client_window_entry_t));
+  if (entry == NULL) {
+    LOG_ERROR("Failed to allocate client window map entry");
+    return;
+  }
+  entry->window           = client->window;
+  entry->client           = client;
+  entry->next             = client_window_map[hash];
+  client_window_map[hash] = entry;
+}
+
+static void
+client_window_map_remove(xcb_window_t window)
+{
+  uint32_t               hash = client_window_hash(window);
+  client_window_entry_t** prev = &client_window_map[hash];
+  client_window_entry_t*  curr = *prev;
+
+  while (curr != NULL) {
+    if (curr->window == window) {
+      *prev = curr->next;
+      free(curr);
+      return;
+    }
+    prev = &curr->next;
+    curr = curr->next;
+  }
+}
+
+Client*
+client_get_by_window(xcb_window_t window)
+{
+  uint32_t               hash = client_window_hash(window);
+  client_window_entry_t* curr = client_window_map[hash];
+
+  while (curr != NULL) {
+    if (curr->window == window) {
+      return curr->client;
+    }
+    curr = curr->next;
+  }
+  return NULL;
+}
+
+Client*
+client_create(xcb_window_t window)
+{
+  if (window == XCB_WINDOW_NONE) {
+    LOG_ERROR("Cannot create client for XCB_WINDOW_NONE");
+    return NULL;
+  }
+
+  /* Check if client already exists for this window */
+  if (client_get_by_window(window) != NULL) {
+    LOG_ERROR("Client already exists for window %u", window);
+    return NULL;
+  }
+
+  Client* client = calloc(1, sizeof(Client));
+  if (client == NULL) {
+    LOG_ERROR("Failed to allocate client");
+    return NULL;
+  }
+
+  /* Initialize client */
+  client->window        = window;
+  client->name[0]       = '\0';
+  client->class_name[0] = '\0';
+  client->x            = 0;
+  client->y            = 0;
+  client->width        = 0;
+  client->height       = 0;
+  client->border_width = 0;
+  client->flags        = CLIENT_FLAG_MANAGED;
+  client->tags         = 0;
+  client->next         = NULL;
+  client->prev         = NULL;
+  client->components   = NULL;
+
+  /* Initialize HubTarget */
+  client->base.id         = (TargetID) window;
+  client->base.type       = TARGET_TYPE_CLIENT;
+  client->base.registered = false;
+
+  LOG_DEBUG("Created client for window %u", window);
+  return client;
+}
+
+void
+client_destroy(Client* client)
+{
+  if (client == NULL) {
+    return;
+  }
+
+  /* Unregister from hub if registered */
+  if (client->base.registered) {
+    client_unregister(client);
+  }
+
+  /* Remove from window map */
+  client_window_map_remove(client->window);
+
+  /* Remove from list */
+  if (client->prev != NULL) {
+    client->prev->next = client->next;
+  }
+  if (client->next != NULL) {
+    client->next->prev = client->prev;
+  }
+
+  /* Free components */
+  while (client->components != NULL) {
+    ClientComponent* comp = client->components;
+    client->components = comp->next;
+    free(comp);
+  }
+
+  /* Free client */
+  LOG_DEBUG("Destroyed client for window %u", client->window);
+  free(client);
+}
+
+void
+client_register(Client* client)
+{
+  if (client == NULL) {
+    LOG_ERROR("Cannot register NULL client");
+    return;
+  }
+
+  if (client->base.registered) {
+    LOG_WARN("Client for window %u is already registered", client->window);
+    return;
+  }
+
+  /* Add to window map */
+  client_window_map_insert(client);
+
+  /* Add to circular list */
+  client->prev           = clients_sentinel.prev;
+  client->next           = &clients_sentinel;
+  clients_sentinel.prev->next = client;
+  clients_sentinel.prev   = client;
+
+  /* Register with hub */
+  hub_register_target(&client->base);
+
+  clients_count++;
+
+  LOG_DEBUG("Registered client for window %u (total: %u)", client->window, clients_count);
+}
+
+void
+client_unregister(Client* client)
+{
+  if (client == NULL) {
+    return;
+  }
+
+  if (!client->base.registered) {
+    LOG_WARN("Client for window %u is not registered", client->window);
+    return;
+  }
+
+  /* Unregister from hub */
+  hub_unregister_target(client->base.id);
+
+  /* Remove from list */
+  if (client->prev != NULL) {
+    client->prev->next = client->next;
+  }
+  if (client->next != NULL) {
+    client->next->prev = client->prev;
+  }
+
+  /* Remove from window map */
+  client_window_map_remove(client->window);
+
+  clients_count--;
+
+  LOG_DEBUG("Unregistered client for window %u (remaining: %u)", client->window, clients_count);
+}
+
+void
+client_set_geometry(Client* client, int16_t x, int16_t y, uint16_t width, uint16_t height)
+{
+  if (client == NULL) {
+    return;
+  }
+
+  client->x      = x;
+  client->y      = y;
+  client->width  = width;
+  client->height = height;
+
+  LOG_DEBUG("Client %u geometry: %dx%d at %d,%d", client->window, width, height, x, y);
+
+  /* Emit geometry changed event */
+  hub_emit(EVT_CLIENT_GEOMETRY, client->base.id, NULL);
+}
+
+void
+client_set_name(Client* client, const char* name)
+{
+  if (client == NULL || name == NULL) {
+    return;
+  }
+
+  strncpy(client->name, name, CLIENT_NAME_MAX - 1);
+  client->name[CLIENT_NAME_MAX - 1] = '\0';
+
+  LOG_DEBUG("Client %u name: %s", client->window, client->name);
+
+  /* Emit name changed event */
+  hub_emit(EVT_CLIENT_NAME, client->base.id, NULL);
+}
+
+void
+client_set_class(Client* client, const char* class_name)
+{
+  if (client == NULL || class_name == NULL) {
+    return;
+  }
+
+  strncpy(client->class_name, class_name, CLIENT_NAME_MAX - 1);
+  client->class_name[CLIENT_NAME_MAX - 1] = '\0';
+}
+
+void
+client_set_tags(Client* client, uint32_t tags)
+{
+  if (client == NULL) {
+    return;
+  }
+
+  uint32_t old_tags = client->tags;
+  client->tags       = tags;
+
+  if (old_tags != tags) {
+    LOG_DEBUG("Client %u tags: 0x%x -> 0x%x", client->window, old_tags, tags);
+    hub_emit(EVT_CLIENT_TAGS, client->base.id, NULL);
+  }
+}
+
+void
+client_add_tag(Client* client, uint32_t tag)
+{
+  if (client == NULL) {
+    return;
+  }
+
+  client_set_tags(client, client->tags | tag);
+}
+
+void
+client_remove_tag(Client* client, uint32_t tag)
+{
+  if (client == NULL) {
+    return;
+  }
+
+  client_set_tags(client, client->tags & ~tag);
+}
+
+bool
+client_has_tag(Client* client, uint32_t tag)
+{
+  if (client == NULL) {
+    return false;
+  }
+
+  return (client->tags & tag) != 0;
+}
+
+void
+client_set_flags(Client* client, ClientFlags flags)
+{
+  if (client == NULL) {
+    return;
+  }
+
+  client->flags |= flags;
+
+  /* Emit events based on flag changes */
+  if (flags & CLIENT_FLAG_URGENT) {
+    hub_emit(EVT_CLIENT_URGENT, client->base.id, NULL);
+  }
+  if (flags & CLIENT_FLAG_FULLSCREEN) {
+    hub_emit(EVT_CLIENT_FULLSCREEN_ENTERED, client->base.id, NULL);
+  }
+  if (flags & CLIENT_FLAG_FLOATING) {
+    hub_emit(EVT_CLIENT_FLOATING, client->base.id, NULL);
+  }
+}
+
+void
+client_clear_flags(Client* client, ClientFlags flags)
+{
+  if (client == NULL) {
+    return;
+  }
+
+  uint32_t old_urgent = client->flags & CLIENT_FLAG_URGENT;
+  uint32_t old_fullscreen = client->flags & CLIENT_FLAG_FULLSCREEN;
+  uint32_t old_floating = client->flags & CLIENT_FLAG_FLOATING;
+
+  client->flags &= ~flags;
+
+  /* Emit events based on flag changes */
+  if ((old_urgent) && !(client->flags & CLIENT_FLAG_URGENT)) {
+    hub_emit(EVT_CLIENT_CALM, client->base.id, NULL);
+  }
+  if ((old_fullscreen) && !(client->flags & CLIENT_FLAG_FULLSCREEN)) {
+    hub_emit(EVT_CLIENT_FULLSCREEN_EXITED, client->base.id, NULL);
+  }
+  if ((old_floating) && !(client->flags & CLIENT_FLAG_FLOATING)) {
+    hub_emit(EVT_CLIENT_TILED, client->base.id, NULL);
+  }
+}
+
+bool
+client_has_flags(Client* client, ClientFlags flags)
+{
+  if (client == NULL) {
+    return false;
+  }
+
+  return (client->flags & flags) == flags;
+}
+
+void
+client_adopt(Client* client, ClientComponent* component)
+{
+  if (client == NULL || component == NULL) {
+    return;
+  }
+
+  /* Check if already adopted */
+  ClientComponent* existing = client_get_component(client, component->name);
+  if (existing != NULL) {
+    LOG_WARN("Client already has component '%s'", component->name);
+    return;
+  }
+
+  /* Add to component list */
+  component->next     = client->components;
+  client->components  = component;
+
+  LOG_DEBUG("Client %u adopted component '%s'", client->window, component->name);
+}
+
+void
+client_drop(Client* client, const char* component_name)
+{
+  if (client == NULL || component_name == NULL) {
+    return;
+  }
+
+  ClientComponent** prev = &client->components;
+  ClientComponent*  curr = client->components;
+
+  while (curr != NULL) {
+    if (strcmp(curr->name, component_name) == 0) {
+      *prev = curr->next;
+      free(curr);
+      LOG_DEBUG("Client %u dropped component '%s'", client->window, component_name);
+      return;
+    }
+    prev = &curr->next;
+    curr = curr->next;
+  }
+
+  LOG_WARN("Client does not have component '%s' to drop", component_name);
+}
+
+ClientComponent*
+client_get_component(Client* client, const char* name)
+{
+  if (client == NULL || name == NULL) {
+    return NULL;
+  }
+
+  ClientComponent* curr = client->components;
+  while (curr != NULL) {
+    if (strcmp(curr->name, name) == 0) {
+      return curr;
+    }
+    curr = curr->next;
+  }
+
+  return NULL;
+}
+
+Client*
+client_next(Client* client)
+{
+  if (client == NULL) {
+    return NULL;
+  }
+
+  Client* next = client->next;
+  if (next == &clients_sentinel) {
+    return clients_sentinel.next;
+  }
+  return next;
+}
+
+Client*
+client_prev(Client* client)
+{
+  if (client == NULL) {
+    return NULL;
+  }
+
+  Client* prev = client->prev;
+  if (prev == &clients_sentinel) {
+    return clients_sentinel.prev;
+  }
+  return prev;
+}
+
+Client*
+client_list_head(void)
+{
+  if (clients_sentinel.next == &clients_sentinel) {
+    return NULL;
+  }
+  return clients_sentinel.next;
+}
+
+uint32_t
+client_count(void)
+{
+  return clients_count;
+}

--- a/wm-client.h
+++ b/wm-client.h
@@ -1,0 +1,204 @@
+#ifndef _WM_CLIENT_H_
+#define _WM_CLIENT_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <xcb/xcb.h>
+
+#include "wm-hub.h"
+
+/*
+ * Client Target
+ *
+ * Represents a managed window. Each Client is a HubTarget that can:
+ * - Register with the Hub as a TARGET_TYPE_CLIENT
+ * - Adopt compatible components (focus, fullscreen, floating, urgency, etc.)
+ * - Own state machines for its states
+ */
+
+#define CLIENT_NAME_MAX 256
+
+/* Forward declarations */
+typedef struct Client Client;
+typedef struct ClientComponent ClientComponent;
+
+/* Client flags */
+typedef uint32_t ClientFlags;
+enum {
+  CLIENT_FLAG_MANAGED     = 1 << 0,  /* Window is being managed */
+  CLIENT_FLAG_FOCUSED     = 1 << 1,  /* Client currently has focus */
+  CLIENT_FLAG_URGENT      = 1 << 2,  /* Client has urgency hint */
+  CLIENT_FLAG_FLOATING    = 1 << 3,  /* Client is floating */
+  CLIENT_FLAG_FULLSCREEN  = 1 << 4,  /* Client is fullscreen */
+  CLIENT_FLAG_HIDDEN      = 1 << 5,  /* Client is hidden (not on current tag) */
+};
+
+/* Client state machine states */
+enum {
+  CLIENT_STATE_NORMAL    = 0,
+  CLIENT_STATE_FOCUSED   = 1,
+  CLIENT_STATE_URGENT    = 2,
+  CLIENT_STATE_FLOATING  = 3,
+  CLIENT_STATE_FULLSCREEN = 4,
+  CLIENT_STATE_HIDDEN    = 5,
+};
+
+/* Client structure - represents a managed window */
+struct Client {
+  /* Hub target integration */
+  HubTarget base;  /* id = window, type = TARGET_TYPE_CLIENT */
+
+  /* X11 window properties */
+  xcb_window_t window;
+  char         name[CLIENT_NAME_MAX];
+  char         class_name[CLIENT_NAME_MAX];
+
+  /* Geometry */
+  int16_t     x, y;
+  uint16_t    width, height;
+  uint16_t    border_width;
+
+  /* State */
+  ClientFlags flags;
+  uint32_t    tags;           /* Bitmask of tags this client is on */
+
+  /* Hierarchy */
+  Client*     next;           /* Next client in list */
+  Client*     prev;           /* Previous client in list */
+
+  /* Adoption - components adopted by this client */
+  ClientComponent* components;
+};
+
+/* Client component - attached to a client */
+struct ClientComponent {
+  const char*        name;
+  void*              data;      /* Component-specific data */
+  ClientComponent*   next;
+};
+
+/*
+ * Client lifecycle
+ */
+
+/* Create a new client for a window */
+Client* client_create(xcb_window_t window);
+
+/* Destroy a client */
+void client_destroy(Client* client);
+
+/* Register client with hub */
+void client_register(Client* client);
+
+/* Unregister client from hub */
+void client_unregister(Client* client);
+
+/*
+ * Client modification
+ */
+
+/* Update client geometry */
+void client_set_geometry(Client* client, int16_t x, int16_t y, uint16_t width, uint16_t height);
+
+/* Update client name */
+void client_set_name(Client* client, const char* name);
+
+/* Update client class */
+void client_set_class(Client* client, const char* class_name);
+
+/* Set client tags */
+void client_set_tags(Client* client, uint32_t tags);
+
+/* Add a tag to client */
+void client_add_tag(Client* client, uint32_t tag);
+
+/* Remove a tag from client */
+void client_remove_tag(Client* client, uint32_t tag);
+
+/* Check if client has a tag */
+bool client_has_tag(Client* client, uint32_t tag);
+
+/* Set client flags */
+void client_set_flags(Client* client, ClientFlags flags);
+
+/* Clear client flags */
+void client_clear_flags(Client* client, ClientFlags flags);
+
+/* Check client flags */
+bool client_has_flags(Client* client, ClientFlags flags);
+
+/*
+ * Component adoption
+ */
+
+/* Client adopts a component */
+void client_adopt(Client* client, ClientComponent* component);
+
+/* Client drops a component */
+void client_drop(Client* client, const char* component_name);
+
+/* Get adopted component by name */
+ClientComponent* client_get_component(Client* client, const char* name);
+
+/*
+ * Query
+ */
+
+/* Get client by window ID */
+Client* client_get_by_window(xcb_window_t window);
+
+/* Get next client in list */
+Client* client_next(Client* client);
+
+/* Get previous client in list */
+Client* client_prev(Client* client);
+
+/*
+ * Client list management
+ */
+
+/* Get the client list head */
+Client* client_list_head(void);
+
+/* Get client count */
+uint32_t client_count(void);
+
+/*
+ * Request types for client operations
+ *
+ * Components that handle these should register with the Hub
+ * and the Client will route requests through the Hub.
+ */
+enum ClientRequestType {
+  REQ_CLIENT_FOCUS        = 100,  /* Focus this client */
+  REQ_CLIENT_UNFOCUS      = 101,  /* Unfocus this client */
+  REQ_CLIENT_CLOSE        = 102,  /* Close this client */
+  REQ_CLIENT_FULLSCREEN   = 103,  /* Toggle fullscreen */
+  REQ_CLIENT_FLOAT        = 104,  /* Toggle floating */
+  REQ_CLIENT_TILE         = 105,  /* Toggle tiled */
+  REQ_CLIENT_TAG          = 106,  /* Set tags */
+  REQ_CLIENT_TAG_TOGGLE   = 107,  /* Toggle tags */
+  REQ_CLIENT_CLEAR_URGENT = 108,  /* Clear urgency */
+};
+
+/*
+ * Event types emitted by clients
+ */
+enum ClientEventType {
+  EVT_CLIENT_CREATED     = 200,  /* Client was created */
+  EVT_CLIENT_DESTROYED   = 201,  /* Client was destroyed */
+  EVT_CLIENT_FOCUSED    = 202,  /* Client gained focus */
+  EVT_CLIENT_UNFOCUSED  = 203,  /* Client lost focus */
+  EVT_CLIENT_GEOMETRY    = 204,  /* Client geometry changed */
+  EVT_CLIENT_NAME        = 205,  /* Client name changed */
+  EVT_CLIENT_TAGS        = 206,  /* Client tags changed */
+  EVT_CLIENT_URGENT      = 207,  /* Client became urgent */
+  EVT_CLIENT_CALM       = 208,  /* Client urgency cleared */
+  EVT_CLIENT_FULLSCREEN_ENTERED = 209,
+  EVT_CLIENT_FULLSCREEN_EXITED  = 210,
+  EVT_CLIENT_FLOATING   = 211,
+  EVT_CLIENT_TILED      = 212,
+};
+
+#endif /* _WM_CLIENT_H_ */

--- a/wm-hub.c
+++ b/wm-hub.c
@@ -5,6 +5,9 @@
 
 #include "wm-log.h"
 
+/* Forward declaration for target resolvers */
+static TargetID hub_resolve_target_internal(TargetID symbolic);
+
 /* Registry data structures */
 #define MAX_COMPONENTS    64
 #define MAX_TARGETS       256
@@ -382,6 +385,102 @@ hub_target_count(void)
   return target_count;
 }
 
+/* Request routing implementation */
+void
+hub_send_request(RequestType type, TargetID target, void* data)
+{
+  /* Resolve symbolic target IDs */
+  TargetID resolved = hub_resolve_target_internal(target);
+
+  /* Find component that handles this request type */
+  HubComponent* comp = hub_get_component_by_request_type(type);
+  if (comp == NULL) {
+    LOG_DEBUG("No component handles request type %u", type);
+    return;
+  }
+
+  /* Check if component has an executor */
+  if (comp->executor == NULL) {
+    LOG_DEBUG("Component '%s' has no executor for request type %u",
+              comp->name, type);
+    return;
+  }
+
+  /* Create request and dispatch to executor */
+  Request req = {
+    .type   = type,
+    .target = resolved,
+    .data   = data,
+  };
+
+  LOG_DEBUG("Routing request type=%u target=%lu to component '%s'",
+            type, (unsigned long) resolved, comp->name);
+
+  comp->executor(&req);
+}
+
+void
+hub_broadcast_request(RequestType type, TargetType target_type, void* data)
+{
+  /* Find component that handles this request type */
+  HubComponent* comp = hub_get_component_by_request_type(type);
+  if (comp == NULL) {
+    LOG_DEBUG("No component handles request type %u for broadcast", type);
+    return;
+  }
+
+  /* Get all targets of the specified type */
+  HubTarget** targets = hub_get_targets_by_type(target_type);
+  if (targets == NULL) {
+    LOG_DEBUG("Invalid target type %u for broadcast", target_type);
+    return;
+  }
+
+  LOG_DEBUG("Broadcasting request type=%u to all targets of type %u",
+            type, target_type);
+
+  /* Send request to each target */
+  for (uint32_t i = 0; targets[i] != NULL; i++) {
+    Request req = {
+      .type   = type,
+      .target = targets[i]->id,
+      .data   = data,
+    };
+
+    if (comp->executor != NULL) {
+      comp->executor(&req);
+    }
+  }
+}
+
+static TargetID
+hub_resolve_target_internal(TargetID symbolic)
+{
+  switch (symbolic) {
+    case TARGET_ID_CURRENT_CLIENT:
+    case TARGET_ID_CURRENT_MONITOR:
+    case TARGET_ID_ALL_CLIENTS:
+    case TARGET_ID_ALL_MONITORS:
+      /* Symbolic targets need external resolution - for now return as-is
+       * Components that use these should resolve them before/after calling
+       * hub_send_request. The executor receives the raw value and can
+       * interpret symbolic targets specially. */
+      LOG_DEBUG("Symbolic target %lu not resolved (no resolver registered)",
+                (unsigned long) symbolic);
+      return symbolic;
+
+    default:
+      /* Already concrete */
+      return symbolic;
+  }
+}
+
+TargetID
+hub_resolve_target(TargetID symbolic)
+{
+  return hub_resolve_target_internal(symbolic);
+}
+
 /* Internal helper: add component to request type index */
 static void
 component_add_to_request_type_index(HubComponent* comp)
@@ -534,3 +633,18 @@ hub_unsubscribe(EventType type, EventHandler handler)
     }
   }
 }
+
+/* TODO: Target resolver registry for symbolic target resolution
+ *
+ * Components can register themselves as resolvers for symbolic targets:
+ * - Focus component resolves TARGET_ID_CURRENT_CLIENT
+ * - Monitor component resolves TARGET_ID_CURRENT_MONITOR
+ *
+ * This allows hub_resolve_target_internal() to actually resolve
+ * symbolic targets to concrete IDs.
+ *
+ * Implementation would add:
+ * - resolver_register(TargetResolver resolver)
+ * - resolver_unregister(TargetResolver resolver)
+ * - Update hub_resolve_target_internal() to call registered resolvers
+ */

--- a/wm-hub.h
+++ b/wm-hub.h
@@ -8,13 +8,22 @@
 typedef struct HubComponent HubComponent;
 typedef struct HubTarget    HubTarget;
 typedef struct Event        Event;
+typedef struct Request       Request;
 typedef void (*EventHandler)(Event);
+typedef void (*RequestExecutor)(Request* req);
 
-/* Type definitions */
+/* Type definitions - must be before Request struct */
 typedef uint64_t TargetID;
 typedef uint32_t TargetType;
 typedef uint32_t RequestType;
 typedef uint32_t EventType;
+
+/* Request structure for routing */
+struct Request {
+  RequestType type;
+  TargetID    target;
+  void*       data;
+};
 
 /* Target types */
 enum {
@@ -34,10 +43,11 @@ enum {
 
 /* Component structure */
 struct HubComponent {
-  const char*  name;
-  RequestType* requests; /* NULL-terminated array of request types handled */
-  TargetType*  targets;  /* TARGET_TYPE_NONE-terminated array of accepted types */
-  bool         registered;
+  const char*        name;
+  RequestType*      requests;    /* NULL-terminated array of request types handled */
+  TargetType*       targets;     /* TARGET_TYPE_NONE-terminated array of accepted types */
+  RequestExecutor   executor;    /* Function to call when this component receives a request */
+  bool              registered;
 };
 
 /* Target structure */
@@ -111,5 +121,44 @@ void hub_unsubscribe(EventType type, EventHandler handler);
 /* Utility */
 uint32_t hub_component_count(void);
 uint32_t hub_target_count(void);
+
+/* Request routing */
+
+/*
+ * Send a request to the hub for routing to the appropriate component.
+ *
+ * The request is routed to the component that handles the request type.
+ * The component's executor function is called with the request.
+ *
+ * @param type    The request type (e.g., REQ_CLIENT_FOCUS)
+ * @param target  The target ID (e.g., client window ID)
+ * @param data    Optional data for the request (can be NULL)
+ */
+void hub_send_request(RequestType type, TargetID target, void* data);
+
+/*
+ * Broadcast a request to all targets of a specific type.
+ * The request is sent to the component that handles the request type,
+ * which then iterates over all targets of the specified type.
+ *
+ * @param type    The request type
+ * @param type_   The target type to broadcast to (e.g., TARGET_TYPE_CLIENT)
+ * @param data    Optional data for the request (can be NULL)
+ */
+void hub_broadcast_request(RequestType type, TargetType type_, void* data);
+
+/* Symbolic target IDs */
+enum {
+  TARGET_ID_CURRENT_CLIENT  = UINT64_MAX - 1,
+  TARGET_ID_CURRENT_MONITOR = UINT64_MAX - 2,
+  TARGET_ID_ALL_CLIENTS     = UINT64_MAX - 3,
+  TARGET_ID_ALL_MONITORS    = UINT64_MAX - 4,
+};
+
+/*
+ * Resolve a symbolic target ID to a concrete target ID.
+ * Returns the concrete TargetID, or the original value if not symbolic.
+ */
+TargetID hub_resolve_target(TargetID symbolic);
 
 #endif

--- a/wm-monitor.c
+++ b/wm-monitor.c
@@ -1,0 +1,694 @@
+#include "wm-monitor.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "wm-log.h"
+#include "wm-client.h"
+
+/* Layout names for display */
+const char* layout_names[LAYOUT_COUNT] = {
+  [LAYOUT_TILE]     = "tile",
+  [LAYOUT_MONOCLE]  = "mono",
+  [LAYOUT_FLOATING] = "float",
+};
+
+/* Monitor list (sentinel-based circular doubly-linked list) */
+static Monitor monitors_sentinel = {
+  .next = &monitors_sentinel,
+  .prev = &monitors_sentinel,
+};
+
+/* Monitor count */
+static uint32_t monitors_count = 0;
+
+/* Selected monitor */
+static Monitor* selected_monitor = NULL;
+
+/* Hash map for output -> monitor lookup */
+#define MONITOR_OUTPUT_MAP_SIZE 128
+
+typedef struct monitor_output_entry {
+  xcb_randr_output_t    output;
+  Monitor*              monitor;
+  struct monitor_output_entry* next;
+} monitor_output_entry_t;
+
+static monitor_output_entry_t* monitor_output_map[MONITOR_OUTPUT_MAP_SIZE];
+
+/* Hash map for crtc -> monitor lookup */
+#define MONITOR_CRTC_MAP_SIZE 128
+
+typedef struct monitor_crtc_entry {
+  xcb_randr_crtc_t    crtc;
+  Monitor*            monitor;
+  struct monitor_crtc_entry* next;
+} monitor_crtc_entry_t;
+
+static monitor_crtc_entry_t* monitor_crtc_map[MONITOR_CRTC_MAP_SIZE];
+
+static uint32_t
+monitor_output_hash(xcb_randr_output_t output)
+{
+  return ((uint32_t) (output ^ (output >> 16))) % MONITOR_OUTPUT_MAP_SIZE;
+}
+
+static uint32_t
+monitor_crtc_hash(xcb_randr_crtc_t crtc)
+{
+  return ((uint32_t) (crtc ^ (crtc >> 16))) % MONITOR_CRTC_MAP_SIZE;
+}
+
+static void
+monitor_output_map_insert(Monitor* monitor)
+{
+  uint32_t                  hash = monitor_output_hash(monitor->output);
+  monitor_output_entry_t*   entry = malloc(sizeof(monitor_output_entry_t));
+  if (entry == NULL) {
+    LOG_ERROR("Failed to allocate monitor output map entry");
+    return;
+  }
+  entry->output           = monitor->output;
+  entry->monitor          = monitor;
+  entry->next             = monitor_output_map[hash];
+  monitor_output_map[hash] = entry;
+}
+
+static void
+monitor_output_map_remove(xcb_randr_output_t output)
+{
+  uint32_t                  hash = monitor_output_hash(output);
+  monitor_output_entry_t**  prev = &monitor_output_map[hash];
+  monitor_output_entry_t*   curr = *prev;
+
+  while (curr != NULL) {
+    if (curr->output == output) {
+      *prev = curr->next;
+      free(curr);
+      return;
+    }
+    prev = &curr->next;
+    curr = curr->next;
+  }
+}
+
+static void
+monitor_crtc_map_insert(Monitor* monitor)
+{
+  if (monitor->crtc == 0) {
+    return;
+  }
+
+  uint32_t                hash = monitor_crtc_hash(monitor->crtc);
+  monitor_crtc_entry_t*  entry = malloc(sizeof(monitor_crtc_entry_t));
+  if (entry == NULL) {
+    LOG_ERROR("Failed to allocate monitor crtc map entry");
+    return;
+  }
+  entry->crtc           = monitor->crtc;
+  entry->monitor        = monitor;
+  entry->next           = monitor_crtc_map[hash];
+  monitor_crtc_map[hash] = entry;
+}
+
+static void
+monitor_crtc_map_remove(xcb_randr_crtc_t crtc)
+{
+  uint32_t                hash = monitor_crtc_hash(crtc);
+  monitor_crtc_entry_t**  prev = &monitor_crtc_map[hash];
+  monitor_crtc_entry_t*  curr = *prev;
+
+  while (curr != NULL) {
+    if (curr->crtc == crtc) {
+      *prev = curr->next;
+      free(curr);
+      return;
+    }
+    prev = &curr->next;
+    curr = curr->next;
+  }
+}
+
+Monitor*
+monitor_get_by_output(xcb_randr_output_t output)
+{
+  uint32_t                  hash = monitor_output_hash(output);
+  monitor_output_entry_t*   curr = monitor_output_map[hash];
+
+  while (curr != NULL) {
+    if (curr->output == output) {
+      return curr->monitor;
+    }
+    curr = curr->next;
+  }
+  return NULL;
+}
+
+Monitor*
+monitor_get_by_crtc(xcb_randr_crtc_t crtc)
+{
+  if (crtc == 0) {
+    return NULL;
+  }
+
+  uint32_t                hash = monitor_crtc_hash(crtc);
+  monitor_crtc_entry_t*   curr = monitor_crtc_map[hash];
+
+  while (curr != NULL) {
+    if (curr->crtc == crtc) {
+      return curr->monitor;
+    }
+    curr = curr->next;
+  }
+  return NULL;
+}
+
+Monitor*
+monitor_create(xcb_randr_output_t output)
+{
+  if (output == XCB_NONE) {
+    LOG_ERROR("Cannot create monitor for XCB_NONE output");
+    return NULL;
+  }
+
+  /* Check if monitor already exists for this output */
+  if (monitor_get_by_output(output) != NULL) {
+    LOG_ERROR("Monitor already exists for output %u", output);
+    return NULL;
+  }
+
+  Monitor* monitor = calloc(1, sizeof(Monitor));
+  if (monitor == NULL) {
+    LOG_ERROR("Failed to allocate monitor");
+    return NULL;
+  }
+
+  /* Initialize monitor */
+  monitor->output       = output;
+  monitor->crtc         = 0;
+  monitor->x           = 0;
+  monitor->y           = 0;
+  monitor->width       = 0;
+  monitor->height      = 0;
+  monitor->mwidth      = 0;
+  monitor->mheight     = 0;
+  monitor->mfact       = 0.5f;
+  monitor->nmaster     = 1;
+  monitor->tagset      = 1;  /* Start on tag 1 */
+  monitor->state       = MONITOR_STATE_ACTIVE;
+  monitor->layout       = LAYOUT_TILE;
+  monitor->clients      = NULL;
+  monitor->sel          = NULL;
+  monitor->stack        = NULL;
+  monitor->next         = NULL;
+  monitor->prev         = NULL;
+  monitor->components    = NULL;
+
+  /* Initialize HubTarget - use output as the ID */
+  monitor->base.id         = (TargetID) output;
+  monitor->base.type       = TARGET_TYPE_MONITOR;
+  monitor->base.registered = false;
+
+  LOG_DEBUG("Created monitor for output %u", output);
+  return monitor;
+}
+
+void
+monitor_destroy(Monitor* monitor)
+{
+  if (monitor == NULL) {
+    return;
+  }
+
+  /* Unregister from hub if registered */
+  if (monitor->base.registered) {
+    monitor_unregister(monitor);
+  }
+
+  /* Remove from maps */
+  monitor_output_map_remove(monitor->output);
+  monitor_crtc_map_remove(monitor->crtc);
+
+  /* Remove from list */
+  if (monitor->prev != NULL) {
+    monitor->prev->next = monitor->next;
+  }
+  if (monitor->next != NULL) {
+    monitor->next->prev = monitor->prev;
+  }
+
+  /* Free components */
+  while (monitor->components != NULL) {
+    MonitorComponent* comp = monitor->components;
+    monitor->components = comp->next;
+    free(comp);
+  }
+
+  /* If this was the selected monitor, select another */
+  if (selected_monitor == monitor) {
+    selected_monitor = monitor_list_head();
+    if (selected_monitor == monitor) {
+      selected_monitor = NULL;
+    }
+  }
+
+  /* Free monitor */
+  LOG_DEBUG("Destroyed monitor for output %u", monitor->output);
+  free(monitor);
+}
+
+void
+monitor_register(Monitor* monitor)
+{
+  if (monitor == NULL) {
+    LOG_ERROR("Cannot register NULL monitor");
+    return;
+  }
+
+  if (monitor->base.registered) {
+    LOG_WARN("Monitor for output %u is already registered", monitor->output);
+    return;
+  }
+
+  /* Add to maps */
+  monitor_output_map_insert(monitor);
+  monitor_crtc_map_insert(monitor);
+
+  /* Add to circular list */
+  monitor->prev           = monitors_sentinel.prev;
+  monitor->next           = &monitors_sentinel;
+  monitors_sentinel.prev->next = monitor;
+  monitors_sentinel.prev   = monitor;
+
+  /* Register with hub */
+  hub_register_target(&monitor->base);
+
+  monitors_count++;
+
+  /* If this is the first monitor, select it */
+  if (selected_monitor == NULL) {
+    selected_monitor = monitor;
+  }
+
+  LOG_DEBUG("Registered monitor for output %u (total: %u)", monitor->output, monitors_count);
+}
+
+void
+monitor_unregister(Monitor* monitor)
+{
+  if (monitor == NULL) {
+    return;
+  }
+
+  if (!monitor->base.registered) {
+    LOG_WARN("Monitor for output %u is not registered", monitor->output);
+    return;
+  }
+
+  /* Unregister from hub */
+  hub_unregister_target(monitor->base.id);
+
+  /* Remove from maps */
+  monitor_output_map_remove(monitor->output);
+  monitor_crtc_map_remove(monitor->crtc);
+
+  /* Remove from list */
+  if (monitor->prev != NULL) {
+    monitor->prev->next = monitor->next;
+  }
+  if (monitor->next != NULL) {
+    monitor->next->prev = monitor->prev;
+  }
+
+  /* If this was the selected monitor, select another */
+  if (selected_monitor == monitor) {
+    selected_monitor = monitor_list_head();
+    if (selected_monitor == monitor) {
+      selected_monitor = NULL;
+    }
+  }
+
+  monitors_count--;
+
+  LOG_DEBUG("Unregistered monitor for output %u (remaining: %u)", monitor->output, monitors_count);
+}
+
+void
+monitor_set_geometry(Monitor* monitor, int16_t x, int16_t y, uint16_t width, uint16_t height)
+{
+  if (monitor == NULL) {
+    return;
+  }
+
+  bool changed = (monitor->x != x) || (monitor->y != y) ||
+                 (monitor->width != width) || (monitor->height != height);
+
+  monitor->x      = x;
+  monitor->y      = y;
+  monitor->width  = width;
+  monitor->height = height;
+
+  if (changed) {
+    LOG_DEBUG("Monitor %u geometry: %ux%u at %d,%d", monitor->output, width, height, x, y);
+    hub_emit(EVT_MONITOR_GEOMETRY, monitor->base.id, NULL);
+  }
+}
+
+void
+monitor_set_physical(Monitor* monitor, uint16_t width_mm, uint16_t height_mm)
+{
+  if (monitor == NULL) {
+    return;
+  }
+
+  monitor->mwidth  = width_mm;
+  monitor->mheight = height_mm;
+}
+
+void
+monitor_set_randr(Monitor* monitor, xcb_randr_output_t output, xcb_randr_crtc_t crtc)
+{
+  if (monitor == NULL) {
+    return;
+  }
+
+  /* Update maps if IDs changed */
+  if (monitor->output != output) {
+    monitor_output_map_remove(monitor->output);
+    monitor->output = output;
+    monitor_output_map_insert(monitor);
+    /* Update HubTarget ID */
+    monitor->base.id = (TargetID) output;
+  }
+
+  if (monitor->crtc != crtc) {
+    monitor_crtc_map_remove(monitor->crtc);
+    monitor->crtc = crtc;
+    monitor_crtc_map_insert(monitor);
+  }
+
+  LOG_DEBUG("Monitor %u RandR: output=%u crtc=%u", monitor->output, output, crtc);
+}
+
+void
+monitor_set_mfact(Monitor* monitor, float mfact)
+{
+  if (monitor == NULL) {
+    return;
+  }
+
+  /* Clamp to valid range */
+  if (mfact < 0.0f) mfact = 0.0f;
+  if (mfact > 1.0f) mfact = 1.0f;
+
+  monitor->mfact = mfact;
+}
+
+void
+monitor_set_nmaster(Monitor* monitor, int nmaster)
+{
+  if (monitor == NULL) {
+    return;
+  }
+
+  if (nmaster < 0) nmaster = 0;
+
+  monitor->nmaster = nmaster;
+}
+
+void
+monitor_set_tagset(Monitor* monitor, uint32_t tagset)
+{
+  if (monitor == NULL) {
+    return;
+  }
+
+  uint32_t old_tagset = monitor->tagset;
+  monitor->tagset     = tagset;
+
+  if (old_tagset != tagset) {
+    LOG_DEBUG("Monitor %u tagset: 0x%x -> 0x%x", monitor->output, old_tagset, tagset);
+    hub_emit(EVT_MONITOR_TAG_CHANGED, monitor->base.id, NULL);
+  }
+}
+
+void
+monitor_add_tag(Monitor* monitor, uint32_t tag)
+{
+  if (monitor == NULL) {
+    return;
+  }
+
+  monitor_set_tagset(monitor, monitor->tagset | tag);
+}
+
+void
+monitor_remove_tag(Monitor* monitor, uint32_t tag)
+{
+  if (monitor == NULL) {
+    return;
+  }
+
+  monitor_set_tagset(monitor, monitor->tagset & ~tag);
+}
+
+bool
+monitor_has_tag(Monitor* monitor, uint32_t tag)
+{
+  if (monitor == NULL) {
+    return false;
+  }
+
+  return (monitor->tagset & tag) != 0;
+}
+
+void
+monitor_set_layout(Monitor* monitor, uint32_t layout)
+{
+  if (monitor == NULL) {
+    return;
+  }
+
+  if (layout >= LAYOUT_COUNT) {
+    LOG_WARN("Invalid layout %u", layout);
+    return;
+  }
+
+  uint32_t old_layout = monitor->layout;
+  monitor->layout     = layout;
+
+  if (old_layout != layout) {
+    LOG_DEBUG("Monitor %u layout: %u -> %u (%s)", monitor->output, old_layout, layout, layout_names[layout]);
+    hub_emit(EVT_MONITOR_LAYOUT_CHANGED, monitor->base.id, NULL);
+  }
+}
+
+void
+monitor_set_state(Monitor* monitor, uint32_t state)
+{
+  if (monitor == NULL) {
+    return;
+  }
+
+  monitor->state = state;
+}
+
+void
+monitor_adopt(Monitor* monitor, MonitorComponent* component)
+{
+  if (monitor == NULL || component == NULL) {
+    return;
+  }
+
+  /* Check if already adopted */
+  MonitorComponent* existing = monitor_get_component(monitor, component->name);
+  if (existing != NULL) {
+    LOG_WARN("Monitor already has component '%s'", component->name);
+    return;
+  }
+
+  /* Add to component list */
+  component->next     = monitor->components;
+  monitor->components = component;
+
+  LOG_DEBUG("Monitor %u adopted component '%s'", monitor->output, component->name);
+}
+
+void
+monitor_drop(Monitor* monitor, const char* component_name)
+{
+  if (monitor == NULL || component_name == NULL) {
+    return;
+  }
+
+  MonitorComponent** prev = &monitor->components;
+  MonitorComponent*  curr = monitor->components;
+
+  while (curr != NULL) {
+    if (strcmp(curr->name, component_name) == 0) {
+      *prev = curr->next;
+      free(curr);
+      LOG_DEBUG("Monitor %u dropped component '%s'", monitor->output, component_name);
+      return;
+    }
+    prev = &curr->next;
+    curr = curr->next;
+  }
+
+  LOG_WARN("Monitor does not have component '%s' to drop", component_name);
+}
+
+MonitorComponent*
+monitor_get_component(Monitor* monitor, const char* name)
+{
+  if (monitor == NULL || name == NULL) {
+    return NULL;
+  }
+
+  MonitorComponent* curr = monitor->components;
+  while (curr != NULL) {
+    if (strcmp(curr->name, name) == 0) {
+      return curr;
+    }
+    curr = curr->next;
+  }
+
+  return NULL;
+}
+
+void
+monitor_attach_client(Monitor* monitor, Client* client)
+{
+  if (monitor == NULL || client == NULL) {
+    return;
+  }
+
+  /* Add to monitor's client list */
+  client->next      = monitor->clients;
+  monitor->clients  = client;
+
+  LOG_DEBUG("Attached client %u to monitor %u", client->window, monitor->output);
+}
+
+void
+monitor_detach_client(Monitor* monitor, Client* client)
+{
+  if (monitor == NULL || client == NULL) {
+    return;
+  }
+
+  /* Remove from client list */
+  Client** prev = &monitor->clients;
+  Client*  curr = monitor->clients;
+
+  while (curr != NULL) {
+    if (curr == client) {
+      *prev = curr->next;
+      LOG_DEBUG("Detached client %u from monitor %u", client->window, monitor->output);
+      return;
+    }
+    prev = &curr->next;
+    curr = curr->next;
+  }
+}
+
+void
+monitor_focus_client(Monitor* monitor, Client* client)
+{
+  if (monitor == NULL) {
+    return;
+  }
+
+  if (monitor->sel != client) {
+    /* Emit unfocused event for old client */
+    if (monitor->sel != NULL) {
+      hub_emit(EVT_CLIENT_UNFOCUSED, monitor->sel->base.id, NULL);
+    }
+
+    monitor->sel = client;
+
+    /* Emit focused event for new client */
+    if (client != NULL) {
+      hub_emit(EVT_CLIENT_FOCUSED, client->base.id, NULL);
+    }
+  }
+}
+
+Monitor*
+monitor_at(int16_t x, int16_t y)
+{
+  Monitor* curr = monitors_sentinel.next;
+  while (curr != &monitors_sentinel) {
+    if (x >= curr->x && x < curr->x + (int16_t) curr->width &&
+        y >= curr->y && y < curr->y + (int16_t) curr->height) {
+      return curr;
+    }
+    curr = curr->next;
+  }
+  return NULL;
+}
+
+Monitor*
+monitor_next(Monitor* monitor)
+{
+  if (monitor == NULL) {
+    return NULL;
+  }
+
+  Monitor* next = monitor->next;
+  if (next == &monitors_sentinel) {
+    return monitors_sentinel.next;
+  }
+  return next;
+}
+
+Monitor*
+monitor_prev(Monitor* monitor)
+{
+  if (monitor == NULL) {
+    return NULL;
+  }
+
+  Monitor* prev = monitor->prev;
+  if (prev == &monitors_sentinel) {
+    return monitors_sentinel.prev;
+  }
+  return prev;
+}
+
+Monitor*
+monitor_list_head(void)
+{
+  if (monitors_sentinel.next == &monitors_sentinel) {
+    return NULL;
+  }
+  return monitors_sentinel.next;
+}
+
+uint32_t
+monitor_count(void)
+{
+  return monitors_count;
+}
+
+Monitor*
+monitor_selected(void)
+{
+  return selected_monitor;
+}
+
+void
+monitor_select(Monitor* monitor)
+{
+  Monitor* old = selected_monitor;
+  selected_monitor = monitor;
+
+  if (old != monitor) {
+    if (old != NULL) {
+      hub_emit(EVT_MONITOR_UNFOCUSED, old->base.id, NULL);
+    }
+    if (monitor != NULL) {
+      hub_emit(EVT_MONITOR_FOCUSED, monitor->base.id, NULL);
+    }
+  }
+}

--- a/wm-monitor.h
+++ b/wm-monitor.h
@@ -1,0 +1,229 @@
+#ifndef _WM_MONITOR_H_
+#define _WM_MONITOR_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <xcb/xcb.h>
+#include <xcb/randr.h>
+
+#include "wm-hub.h"
+
+/*
+ * Monitor Target
+ *
+ * Represents a display/output. Each Monitor is a HubTarget that can:
+ * - Register with the Hub as a TARGET_TYPE_MONITOR
+ * - Adopt compatible components (tiling, bar, etc.)
+ * - Own state machines for its states
+ */
+
+/* Forward declarations */
+typedef struct Monitor Monitor;
+typedef struct MonitorComponent MonitorComponent;
+typedef struct Client Client;
+
+/* Monitor state machine states */
+enum {
+  MONITOR_STATE_ACTIVE   = 0,  /* Monitor is active and visible */
+  MONITOR_STATE_INACTIVE = 1,  /* Monitor is disconnected or inactive */
+  MONITOR_STATE_OFFLINE = 2,  /* Monitor is offline */
+};
+
+/* Monitor structure - represents a display/output */
+struct Monitor {
+  /* Hub target integration */
+  HubTarget base;  /* id = output, type = TARGET_TYPE_MONITOR */
+
+  /* RandR properties */
+  xcb_randr_output_t output;
+  xcb_randr_crtc_t   crtc;
+
+  /* Geometry */
+  int16_t    x, y;
+  uint16_t   width, height;
+  uint16_t   mwidth, mheight;  /* Physical dimensions in mm */
+
+  /* Tiling parameters */
+  float      mfact;   /* Master factor (0.0 - 1.0) */
+  int        nmaster; /* Number of master windows */
+
+  /* State */
+  uint32_t   tagset;      /* Current tag bitmask */
+  uint32_t   state;       /* Current state machine state */
+  uint32_t   layout;      /* Current layout index */
+
+  /* Clients on this monitor */
+  Client*    clients;     /* Head of client list for this monitor */
+  Client*    sel;         /* Selected/focused client on this monitor */
+  Client*    stack;       /* Client stacking order (top to bottom) */
+
+  /* Hierarchy */
+  Monitor*   next;        /* Next monitor in list */
+  Monitor*   prev;        /* Previous monitor in list */
+
+  /* Adoption */
+  MonitorComponent* components;
+};
+
+/* Monitor component - attached to a monitor */
+struct MonitorComponent {
+  const char*         name;
+  void*               data;      /* Component-specific data */
+  MonitorComponent*  next;
+};
+
+/*
+ * Monitor lifecycle
+ */
+
+/* Create a new monitor for an output */
+Monitor* monitor_create(xcb_randr_output_t output);
+
+/* Destroy a monitor */
+void monitor_destroy(Monitor* monitor);
+
+/* Register monitor with hub */
+void monitor_register(Monitor* monitor);
+
+/* Unregister monitor from hub */
+void monitor_unregister(Monitor* monitor);
+
+/*
+ * Monitor modification
+ */
+
+/* Set monitor geometry */
+void monitor_set_geometry(Monitor* monitor, int16_t x, int16_t y, uint16_t width, uint16_t height);
+
+/* Set physical size */
+void monitor_set_physical(Monitor* monitor, uint16_t width_mm, uint16_t height_mm);
+
+/* Set RandR properties */
+void monitor_set_randr(Monitor* monitor, xcb_randr_output_t output, xcb_randr_crtc_t crtc);
+
+/* Set master factor */
+void monitor_set_mfact(Monitor* monitor, float mfact);
+
+/* Set number of master windows */
+void monitor_set_nmaster(Monitor* monitor, int nmaster);
+
+/* Set tagset */
+void monitor_set_tagset(Monitor* monitor, uint32_t tagset);
+
+/* Add a tag to tagset */
+void monitor_add_tag(Monitor* monitor, uint32_t tag);
+
+/* Remove a tag from tagset */
+void monitor_remove_tag(Monitor* monitor, uint32_t tag);
+
+/* Check if tagset has a tag */
+bool monitor_has_tag(Monitor* monitor, uint32_t tag);
+
+/* Set layout */
+void monitor_set_layout(Monitor* monitor, uint32_t layout);
+
+/* Set state */
+void monitor_set_state(Monitor* monitor, uint32_t state);
+
+/*
+ * Component adoption
+ */
+
+/* Monitor adopts a component */
+void monitor_adopt(Monitor* monitor, MonitorComponent* component);
+
+/* Monitor drops a component */
+void monitor_drop(Monitor* monitor, const char* component_name);
+
+/* Get adopted component by name */
+MonitorComponent* monitor_get_component(Monitor* monitor, const char* name);
+
+/*
+ * Client management on monitor
+ */
+
+/* Attach client to monitor */
+void monitor_attach_client(Monitor* monitor, Client* client);
+
+/* Detach client from monitor */
+void monitor_detach_client(Monitor* monitor, Client* client);
+
+/* Focus client on this monitor */
+void monitor_focus_client(Monitor* monitor, Client* client);
+
+/*
+ * Query
+ */
+
+/* Get monitor by output ID */
+Monitor* monitor_get_by_output(xcb_randr_output_t output);
+
+/* Get monitor by crtc ID */
+Monitor* monitor_get_by_crtc(xcb_randr_crtc_t crtc);
+
+/* Get monitor at position */
+Monitor* monitor_at(int16_t x, int16_t y);
+
+/* Get next monitor in list */
+Monitor* monitor_next(Monitor* monitor);
+
+/* Get previous monitor in list */
+Monitor* monitor_prev(Monitor* monitor);
+
+/* Get monitor list head */
+Monitor* monitor_list_head(void);
+
+/* Get monitor count */
+uint32_t monitor_count(void);
+
+/* Get selected monitor (currently focused) */
+Monitor* monitor_selected(void);
+
+/* Set selected monitor */
+void monitor_select(Monitor* monitor);
+
+/*
+ * Layout types
+ */
+enum {
+  LAYOUT_TILE     = 0,  /* Tile layout */
+  LAYOUT_MONOCLE  = 1,  /* Monocle layout */
+  LAYOUT_FLOATING = 2,  /* Floating layout */
+  LAYOUT_COUNT    = 3,
+};
+
+/*
+ * Request types for monitor operations
+ */
+enum MonitorRequestType {
+  REQ_MONITOR_TAG_VIEW    = 300,  /* View specific tag */
+  REQ_MONITOR_TAG_TOGGLE  = 301,  /* Toggle tag visibility */
+  REQ_MONITOR_TAG_SHIFT   = 302,  /* Move focused client to tag */
+  REQ_MONITOR_SET_LAYOUT  = 303,  /* Set layout */
+  REQ_MONITOR_NEXT_LAYOUT = 304, /* Cycle to next layout */
+  REQ_MONITOR_SET_MFACT   = 305,  /* Set master factor */
+  REQ_MONITOR_FOCUS       = 306,  /* Focus monitor */
+};
+
+/*
+ * Event types emitted by monitors
+ */
+enum MonitorEventType {
+  EVT_MONITOR_CREATED      = 400,  /* Monitor was created */
+  EVT_MONITOR_DESTROYED    = 401,  /* Monitor was destroyed */
+  EVT_MONITOR_CONNECTED    = 402,  /* Monitor was connected */
+  EVT_MONITOR_DISCONNECTED = 403,  /* Monitor was disconnected */
+  EVT_MONITOR_GEOMETRY     = 404,  /* Monitor geometry changed */
+  EVT_MONITOR_TAG_CHANGED  = 405,  /* Monitor tagset changed */
+  EVT_MONITOR_LAYOUT_CHANGED = 406,  /* Monitor layout changed */
+  EVT_MONITOR_FOCUSED    = 407,  /* Monitor gained focus */
+  EVT_MONITOR_UNFOCUSED  = 408,  /* Monitor lost focus */
+};
+
+/*
+ * Layout names (for display in bar)
+ */
+extern const char* layout_names[LAYOUT_COUNT];
+
+#endif /* _WM_MONITOR_H_ */


### PR DESCRIPTION
## Summary

Implements three foundational features that unblock all remaining issues:

### Issue #4: Hub Request Routing
- `hub_send_request(RequestType, TargetID, data)` - routes requests to the component handling the request type
- `hub_broadcast_request(RequestType, TargetType, data)` - sends requests to all targets of a type
- `RequestExecutor` function pointer added to `HubComponent`
- Symbolic target IDs for current/all targets (with `hub_resolve_target()`)

### Issue #11: Client Target
- `Client` struct with HubTarget integration, geometry, state, flags
- Client lifecycle: create, destroy, register, unregister
- Hash map for window → client lookup
- Component adoption system for extensibility
- Client state flags and tag management

### Issue #15: Monitor Target
- `Monitor` struct with HubTarget integration, RandR properties
- Monitor lifecycle: create, destroy, register, unregister
- Hash maps for output/crtc lookup
- Geometry, tiling parameters (mfact, nmaster)
- Tagset and layout management
- Selected monitor tracking

## Test Results

All 203 tests pass (18 new request routing tests added).

## Blockers Unblocked

These three issues were blocking 13 other issues:
- #4 unblocks #10 (Keybinding)
- #11 unblocks #12 (Client-list)
- #12 unblocks #13, #14, #20, #21, #22
- #15 unblocks #16 (Monitor-manager)
- Combined unblocks #17, #18, #19

## Files Changed

- `wm-hub.h`, `wm-hub.c` - Request routing implementation
- `wm-client.h`, `wm-client.c` - New Client target
- `wm-monitor.h`, `wm-monitor.c` - New Monitor target  
- `test-wm-hub.c` - 18 new tests
- `Makefile` - Updated for new sources

## Acceptance Criteria

### Issue #4
- [x] Request type routes to correct component executor
- [x] Target ID is passed to executor
- [x] Simple request flows work (keybinding → hub → component)
- [x] Unit tests for routing logic

### Issue #11
- [x] Client struct holds all necessary window properties
- [x] Client registers with hub
- [x] Client list maintains ordering
- [x] Client can adopt components
- [x] Client can be destroyed cleanly

### Issue #15
- [x] Monitor struct holds all necessary display properties
- [x] Monitor registers with hub
- [x] Monitor list maintains all monitors
- [x] Monitor can adopt components
- [x] Monitor can be destroyed cleanly