### PR TITLE
feat(hub): implement request routing (issue #4)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endif
 # Vendor dependencies - symlink external headers for portable builds
 VENDOR_INCLUDES = -I. -Ivendor/xcb-errors-include -Ivendor/libxcb-errors/include
 
-CPPFLAGS = -DVERSION=\"${VERSION}\"
+CPPFLAGS = -DVERSION=\"${VERSION}\" -DWM_HUB_TESTING
 CFLAGS = $(PKG_CFLAGS) $(VENDOR_INCLUDES) $(CPPFLAGS)
 LDFLAGS = $(PKG_LDFLAGS) -pthread -lc
 

--- a/src/sm/sm-instance.c
+++ b/src/sm/sm-instance.c
@@ -1,8 +1,8 @@
 #include <stdlib.h>
 
 #include "sm-instance.h"
-#include "sm-template.h"
 #include "sm-registry.h"
+#include "sm-template.h"
 #include "wm-hub.h"
 #include "wm-log.h"
 

--- a/src/sm/sm-registry.c
+++ b/src/sm/sm-registry.c
@@ -9,17 +9,17 @@
 /* Registry entry - uses separate typed function pointer fields to avoid
  * casting between function pointers and data pointers (UB in standard C) */
 typedef struct RegistryEntry {
-  const char*  name;
+  const char* name;
   union {
     SMGuardFn  guard_fn;
     SMActionFn action_fn;
   } fn;
   struct RegistryEntry* next;
-  bool is_guard;  /* true for guard entries, false for action entries */
+  bool                  is_guard; /* true for guard entries, false for action entries */
 } RegistryEntry;
 
 /* Registry buckets */
-#define GUARD_REGISTRY_BUCKETS 16
+#define GUARD_REGISTRY_BUCKETS  16
 #define ACTION_REGISTRY_BUCKETS 16
 
 static RegistryEntry* guard_registry[GUARD_REGISTRY_BUCKETS];
@@ -44,7 +44,7 @@ lookup_in_bucket(RegistryEntry** buckets, int num_buckets, const char* name, boo
   if (name == NULL)
     return NULL;
 
-  uint32_t hash = hash_string(name) % (uint32_t) num_buckets;
+  uint32_t       hash  = hash_string(name) % (uint32_t) num_buckets;
   RegistryEntry* entry = buckets[hash];
 
   while (entry != NULL) {
@@ -79,7 +79,7 @@ register_in_bucket(RegistryEntry** buckets, int num_buckets,
     return;
   }
 
-  entry->name    = name;
+  entry->name     = name;
   entry->is_guard = is_guard;
   /* Store in union field based on type */
   if (is_guard) {
@@ -87,7 +87,7 @@ register_in_bucket(RegistryEntry** buckets, int num_buckets,
   } else {
     entry->fn.action_fn = (SMActionFn) fn;
   }
-  entry->next = buckets[hash];
+  entry->next   = buckets[hash];
   buckets[hash] = entry;
 }
 
@@ -98,9 +98,9 @@ unregister_from_bucket(RegistryEntry** buckets, int num_buckets,
   if (name == NULL)
     return;
 
-  uint32_t hash = hash_string(name) % (uint32_t) num_buckets;
+  uint32_t        hash = hash_string(name) % (uint32_t) num_buckets;
   RegistryEntry** prev = &buckets[hash];
-  RegistryEntry* curr = *prev;
+  RegistryEntry*  curr = *prev;
 
   while (curr != NULL) {
     if (strcmp(curr->name, name) == 0) {
@@ -225,12 +225,12 @@ bool
 sm_run_guard(StateMachine* sm, const char* guard_name, void* data)
 {
   if (guard_name == NULL)
-    return true;  /* No guard = always allowed */
+    return true; /* No guard = always allowed */
 
   SMGuardFn guard = sm_lookup_guard(guard_name);
   if (guard == NULL) {
     LOG_WARN("Guard '%s' not found, allowing transition", guard_name);
-    return true;  /* Failsafe: allow if guard not found */
+    return true; /* Failsafe: allow if guard not found */
   }
 
   return guard(sm, data);
@@ -240,12 +240,12 @@ bool
 sm_run_action(StateMachine* sm, const char* action_name, void* data)
 {
   if (action_name == NULL)
-    return true;  /* No action = success */
+    return true; /* No action = success */
 
   SMActionFn action = sm_lookup_action(action_name);
   if (action == NULL) {
     LOG_WARN("Action '%s' not found", action_name);
-    return false;  /* Fail if action not found */
+    return false; /* Fail if action not found */
   }
 
   return action(sm, data);

--- a/src/sm/sm-template.h
+++ b/src/sm/sm-template.h
@@ -32,12 +32,12 @@ typedef struct SMTransition {
  * Defines the blueprint for a state machine.
  */
 struct SMTemplate {
-  const char*   name;              /* template name */
-  uint32_t*     states;            /* array of state values */
-  uint32_t      num_states;        /* number of states */
-  SMTransition* transitions;       /* array of valid transitions */
-  uint32_t      num_transitions;   /* number of transitions */
-  uint32_t      initial_state;    /* default initial state */
+  const char*   name;            /* template name */
+  uint32_t*     states;          /* array of state values */
+  uint32_t      num_states;      /* number of states */
+  SMTransition* transitions;     /* array of valid transitions */
+  uint32_t      num_transitions; /* number of transitions */
+  uint32_t      initial_state;   /* default initial state */
 };
 
 /*

--- a/src/xcb/xcb-handler.h
+++ b/src/xcb/xcb-handler.h
@@ -18,10 +18,10 @@ typedef uint8_t XCBEventType;
  * Handler structure - stores registration info
  */
 typedef struct XCBHandler {
-  XCBEventType        event_type;
-  HubComponent*       component;
+  XCBEventType  event_type;
+  HubComponent* component;
   void (*handler)(void* event);
-  struct XCBHandler*  next;
+  struct XCBHandler* next;
 } XCBHandler;
 
 /*

--- a/test-registry.c
+++ b/test-registry.c
@@ -15,17 +15,17 @@
  *   });
  */
 
+#include "test-registry.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include "test-registry.h"
 
 /*
  * Include all test headers to register their test groups
  */
-#include "test-wm.h"
-#include "test-wm-window-list.h"
 #include "test-wm-hub.h"
+#include "test-wm-window-list.h"
 #include "test-wm-xcb-handler.h"
+#include "test-wm.h"
 
 /*
  * Registry linked list

--- a/test-registry.h
+++ b/test-registry.h
@@ -26,9 +26,9 @@
  * Test group structure
  */
 typedef struct TestGroup {
-  const char*          name;
+  const char* name;
   void (*run)(void);
-  struct TestGroup*    next;
+  struct TestGroup* next;
 } TestGroup;
 
 /*
@@ -40,22 +40,24 @@ extern TestGroup* test_registry_tail;
 /*
  * Register a test group - use constructor attribute for auto-registration
  */
-#define TEST_GROUP(NAME, BODY)                                     \
-  static void test_group_##NAME##_runner(void) {                   \
-    BODY;                                                          \
-  }                                                                \
-  __attribute__((constructor)) void register_test_group_##NAME(void) { \
-    static TestGroup group = {                                     \
-      .name = #NAME,                                               \
-      .run  = test_group_##NAME##_runner,                           \
-      .next = NULL,                                                \
-    };                                                             \
-    if (test_registry_head == NULL) {                              \
-      test_registry_head = test_registry_tail = &group;           \
-    } else {                                                      \
-      test_registry_tail->next = &group;                           \
-      test_registry_tail = &group;                                 \
-    }                                                              \
+#define TEST_GROUP(NAME, BODY)                                       \
+  static void test_group_##NAME##_runner(void)                       \
+  {                                                                  \
+    BODY;                                                            \
+  }                                                                  \
+  __attribute__((constructor)) void register_test_group_##NAME(void) \
+  {                                                                  \
+    static TestGroup group = {                                       \
+      .name = #NAME,                                                 \
+      .run  = test_group_##NAME##_runner,                            \
+      .next = NULL,                                                  \
+    };                                                               \
+    if (test_registry_head == NULL) {                                \
+      test_registry_head = test_registry_tail = &group;              \
+    } else {                                                         \
+      test_registry_tail->next = &group;                             \
+      test_registry_tail       = &group;                             \
+    }                                                                \
   }
 
 /*

--- a/test-runner.c
+++ b/test-runner.c
@@ -15,7 +15,7 @@
 /*
  * Include all test headers to register their test groups
  */
-#include "test-wm.h"
-#include "test-wm-window-list.h"
 #include "test-wm-hub.h"
+#include "test-wm-window-list.h"
+#include "test-wm.h"
 /* Add more test headers as needed */

--- a/test-sm-standalone.c
+++ b/test-sm-standalone.c
@@ -20,7 +20,7 @@ sig_atomic_t running = 1;
   }
 
 #define LOG_ERROR(pFormat, ...)                             \
-  {                                                        \
+  {                                                         \
     fprintf(stderr, "ERROR: " pFormat "\n", ##__VA_ARGS__); \
   }
 
@@ -30,9 +30,9 @@ sig_atomic_t running = 1;
     running = 0;                                            \
   }
 
-#define LOG_WARN(pFormat, ...)                              \
-  {                                                         \
-    fprintf(stderr, "WARN: " pFormat "\n", ##__VA_ARGS__);  \
+#define LOG_WARN(pFormat, ...)                             \
+  {                                                        \
+    fprintf(stderr, "WARN: " pFormat "\n", ##__VA_ARGS__); \
   }
 
 #define assert(EXPRESSION)                                         \
@@ -43,53 +43,74 @@ sig_atomic_t running = 1;
     printf("%s:%d: %s - pass\n", __FILE__, __LINE__, #EXPRESSION); \
   }
 
-#include "src/sm/sm.h"
 #include "src/sm/sm-registry.h"
+#include "src/sm/sm.h"
 #include "wm-hub.h"
 
 /* ==================== TEST FIXTURE ==================== */
 
-static int g_raw_write_events = 0;
-static uint32_t g_last_event = 0;
+static int      g_raw_write_events = 0;
+static uint32_t g_last_event       = 0;
 
-static void event_catcher(Event e) {
+static void
+event_catcher(Event e)
+{
   g_raw_write_events++;
   g_last_event = e.type;
   LOG_DEBUG("Event caught: type=%u", e.type);
 }
 
-static void test_emitter(StateMachine* sm, uint32_t from, uint32_t to, void* ud) {
-  (void)sm; (void)from; (void)to; (void)ud;
+static void
+test_emitter(StateMachine* sm, uint32_t from, uint32_t to, void* ud)
+{
+  (void) sm;
+  (void) from;
+  (void) to;
+  (void) ud;
   LOG_DEBUG("Custom emitter called");
   g_raw_write_events++;
 }
 
 /* Guard / Action helpers */
-static bool guard_allow(StateMachine* sm, void* data) {
-  (void)sm; (void)data;
+static bool
+guard_allow(StateMachine* sm, void* data)
+{
+  (void) sm;
+  (void) data;
   return true;
 }
 
-static bool guard_deny(StateMachine* sm, void* data) {
-  (void)sm; (void)data;
+static bool
+guard_deny(StateMachine* sm, void* data)
+{
+  (void) sm;
+  (void) data;
   return false;
 }
 
-static bool guard_conditional(StateMachine* sm, void* data) {
-  (void)sm;
-  int* allow = (int*)data;
+static bool
+guard_conditional(StateMachine* sm, void* data)
+{
+  (void) sm;
+  int* allow = (int*) data;
   return allow && *allow;
 }
 
-static bool action_fail(StateMachine* sm, void* data) {
-  (void)sm; (void)data;
+static bool
+action_fail(StateMachine* sm, void* data)
+{
+  (void) sm;
+  (void) data;
   return false;
 }
 
-static bool action_track(StateMachine* sm, void* data) {
-  (void)sm;
-  int* count = (int*)data;
-  if (count) (*count)++;
+static bool
+action_track(StateMachine* sm, void* data)
+{
+  (void) sm;
+  int* count = (int*) data;
+  if (count)
+    (*count)++;
   return true;
 }
 
@@ -98,93 +119,137 @@ static int g_hook_calls[SM_HOOK_MAX];
 static int g_hook_order[SM_HOOK_MAX * 2];
 static int g_hook_order_count;
 
-static void reset_hook_tracking(void) {
+static void
+reset_hook_tracking(void)
+{
   memset(g_hook_calls, 0, sizeof(g_hook_calls));
   g_hook_order_count = 0;
 }
 
-static void hook_pre_guard(StateMachine* sm, void* ud) {
-  (void)sm; (void)ud;
+static void
+hook_pre_guard(StateMachine* sm, void* ud)
+{
+  (void) sm;
+  (void) ud;
   g_hook_calls[SM_HOOK_PRE_GUARD]++;
   g_hook_order[g_hook_order_count++] = SM_HOOK_PRE_GUARD;
 }
 
-static void hook_post_guard(StateMachine* sm, void* ud) {
-  (void)sm; (void)ud;
+static void
+hook_post_guard(StateMachine* sm, void* ud)
+{
+  (void) sm;
+  (void) ud;
   g_hook_calls[SM_HOOK_POST_GUARD]++;
   g_hook_order[g_hook_order_count++] = SM_HOOK_POST_GUARD;
 }
 
-static void hook_pre_action(StateMachine* sm, void* ud) {
-  (void)sm; (void)ud;
+static void
+hook_pre_action(StateMachine* sm, void* ud)
+{
+  (void) sm;
+  (void) ud;
   g_hook_calls[SM_HOOK_PRE_ACTION]++;
   g_hook_order[g_hook_order_count++] = SM_HOOK_PRE_ACTION;
 }
 
-static void hook_post_action(StateMachine* sm, void* ud) {
-  (void)sm; (void)ud;
+static void
+hook_post_action(StateMachine* sm, void* ud)
+{
+  (void) sm;
+  (void) ud;
   g_hook_calls[SM_HOOK_POST_ACTION]++;
   g_hook_order[g_hook_order_count++] = SM_HOOK_POST_ACTION;
 }
 
-static void hook_pre_emit(StateMachine* sm, void* ud) {
-  (void)sm; (void)ud;
+static void
+hook_pre_emit(StateMachine* sm, void* ud)
+{
+  (void) sm;
+  (void) ud;
   g_hook_calls[SM_HOOK_PRE_EMIT]++;
   g_hook_order[g_hook_order_count++] = SM_HOOK_PRE_EMIT;
 }
 
-static void hook_post_emit(StateMachine* sm, void* ud) {
-  (void)sm; (void)ud;
+static void
+hook_post_emit(StateMachine* sm, void* ud)
+{
+  (void) sm;
+  (void) ud;
   g_hook_calls[SM_HOOK_POST_EMIT]++;
   g_hook_order[g_hook_order_count++] = SM_HOOK_POST_EMIT;
 }
 
 static int g_hook_removal_count = 0;
-static void hook_removal_fn(StateMachine* sm, void* ud) {
-  (void)sm; (void)ud;
+static void
+hook_removal_fn(StateMachine* sm, void* ud)
+{
+  (void) sm;
+  (void) ud;
   g_hook_removal_count++;
 }
 
-static void hook_with_userdata(StateMachine* sm, void* userdata) {
-  (void)sm;
-  int* counter = (int*)userdata;
-  if (counter) (*counter)++;
+static void
+hook_with_userdata(StateMachine* sm, void* userdata)
+{
+  (void) sm;
+  int* counter = (int*) userdata;
+  if (counter)
+    (*counter)++;
 }
 
 /* Hook for test_hooks_basic */
 static int g_hook_remove_count = 0;
-static void hook_remove_test(StateMachine* sm, void* ud) {
-  (void)sm; (void)ud;
+static void
+hook_remove_test(StateMachine* sm, void* ud)
+{
+  (void) sm;
+  (void) ud;
   g_hook_remove_count++;
 }
 
 static int g_hook_basic_count = 0;
-static void hook_basic_fn(StateMachine* sm, void* ud) {
-  (void)sm; (void)ud;
+static void
+hook_basic_fn(StateMachine* sm, void* ud)
+{
+  (void) sm;
+  (void) ud;
   g_hook_basic_count++;
 }
 
 /* ==================== TEST HELPERS ==================== */
 
 /* Simple state enum for most tests */
-enum { S0 = 0, S1 = 1, S2 = 2 };
+enum { S0 = 0,
+       S1 = 1,
+       S2 = 2,
+};
 
-static SMTemplate* make_tmpl(const char* name, uint32_t* states, int nstates,
-                             SMTransition* trans, int ntrans, uint32_t init) {
+static SMTemplate*
+make_tmpl(const char* name, uint32_t* states, int nstates,
+          SMTransition* trans, int ntrans, uint32_t init)
+{
   return sm_template_create(name, states, nstates, trans, ntrans, init);
 }
 
 /* Create SM with custom emitter (no hub needed) */
-static StateMachine* make_sm(void* owner, SMTemplate* tmpl) {
+static StateMachine*
+make_sm(void* owner, SMTemplate* tmpl)
+{
   return sm_create(owner, tmpl, test_emitter, NULL);
 }
 
 /* ==================== TESTS ==================== */
 
-void test_tmpl_create_destroy(void) {
+void
+test_tmpl_create_destroy(void)
+{
   LOG_CLEAN("== SMTemplate create/destroy");
-  uint32_t states[] = { S0, S1 };
-  SMTransition trans[] = { { S0, S1, NULL, NULL, 10 }, { S1, S0, NULL, NULL, 11 } };
+  uint32_t     states[] = { S0, S1 };
+  SMTransition trans[]  = {
+    { S0, S1, NULL, NULL, 10 },
+    { S1, S0, NULL, NULL, 11 }
+  };
 
   SMTemplate* t = make_tmpl("test", states, 2, trans, 2, S0);
   assert(t != NULL);
@@ -194,14 +259,18 @@ void test_tmpl_create_destroy(void) {
   sm_template_destroy(t);
 }
 
-void test_sm_create_destroy(void) {
+void
+test_sm_create_destroy(void)
+{
   LOG_CLEAN("== StateMachine create/destroy");
-  uint32_t states[] = { S0, S1 };
-  SMTransition trans[] = { { S0, S1, NULL, NULL, 10 } };
+  uint32_t     states[] = { S0, S1 };
+  SMTransition trans[]  = {
+    { S0, S1, NULL, NULL, 10 }
+  };
 
-  SMTemplate* t = make_tmpl("test", states, 2, trans, 1, S0);
-  int owner = 42;
-  StateMachine* sm = make_sm(&owner, t);
+  SMTemplate*   t     = make_tmpl("test", states, 2, trans, 1, S0);
+  int           owner = 42;
+  StateMachine* sm    = make_sm(&owner, t);
 
   assert(sm != NULL);
   assert(sm_get_state(sm) == S0);
@@ -213,10 +282,14 @@ void test_sm_create_destroy(void) {
   sm_template_destroy(t);
 }
 
-void test_sm_create_requires_params(void) {
+void
+test_sm_create_requires_params(void)
+{
   LOG_CLEAN("== sm_create requires owner and template");
-  uint32_t states[] = { S0, S1 };
-  SMTransition trans[] = { { S0, S1, NULL, NULL, 10 } };
+  uint32_t     states[] = { S0, S1 };
+  SMTransition trans[]  = {
+    { S0, S1, NULL, NULL, 10 }
+  };
   SMTemplate* t = make_tmpl("test", states, 2, trans, 1, S0);
 
   /* NULL owner fails */
@@ -229,14 +302,19 @@ void test_sm_create_requires_params(void) {
   sm_template_destroy(t);
 }
 
-void test_sm_set_emitter(void) {
+void
+test_sm_set_emitter(void)
+{
   LOG_CLEAN("== sm_set_emitter after creation");
-  uint32_t states[] = { S0, S1 };
-  SMTransition trans[] = { { S0, S1, NULL, NULL, 10 }, { S1, S0, NULL, NULL, 11 } };
+  uint32_t     states[] = { S0, S1 };
+  SMTransition trans[]  = {
+    { S0, S1, NULL, NULL, 10 },
+    { S1, S0, NULL, NULL, 11 }
+  };
   SMTemplate* t = make_tmpl("test", states, 2, trans, 2, S0);
 
-  int owner = 0;
-  StateMachine* sm = sm_create(&owner, t, NULL, NULL);
+  int           owner = 0;
+  StateMachine* sm    = sm_create(&owner, t, NULL, NULL);
   assert(sm != NULL);
   assert(sm->emit == NULL);
 
@@ -248,14 +326,19 @@ void test_sm_set_emitter(void) {
   sm_template_destroy(t);
 }
 
-void test_raw_write(void) {
+void
+test_raw_write(void)
+{
   LOG_CLEAN("== sm_raw_write");
-  uint32_t states[] = { S0, S1 };
-  SMTransition trans[] = { { S0, S1, NULL, NULL, 10 }, { S1, S0, NULL, NULL, 11 } };
+  uint32_t     states[] = { S0, S1 };
+  SMTransition trans[]  = {
+    { S0, S1, NULL, NULL, 10 },
+    { S1, S0, NULL, NULL, 11 }
+  };
   SMTemplate* t = make_tmpl("raw", states, 2, trans, 2, S0);
 
-  int owner = 0;
-  StateMachine* sm = make_sm(&owner, t);
+  int           owner = 0;
+  StateMachine* sm    = make_sm(&owner, t);
 
   assert(sm_get_state(sm) == S0);
   sm_raw_write(sm, S1);
@@ -267,13 +350,20 @@ void test_raw_write(void) {
   sm_template_destroy(t);
 }
 
-void test_raw_write_emits_via_hub(void) {
+void
+test_raw_write_emits_via_hub(void)
+{
   LOG_CLEAN("== sm_raw_write emits via hub");
   hub_init();
 
-  enum { OFF = 20, ON = 21 };
-  uint32_t states[] = { OFF, ON };
-  SMTransition trans[] = { { OFF, ON, NULL, NULL, OFF }, { ON, OFF, NULL, NULL, ON } };
+  enum { OFF = 20,
+         ON  = 21,
+  };
+  uint32_t     states[] = { OFF, ON };
+  SMTransition trans[]  = {
+    { OFF, ON,  NULL, NULL, OFF },
+    { ON,  OFF, NULL, NULL, ON  }
+  };
   SMTemplate* t = make_tmpl("raw-emit", states, 2, trans, 2, OFF);
 
   HubTarget target = { .id = 42, .type = TARGET_TYPE_CLIENT, .registered = false };
@@ -283,7 +373,7 @@ void test_raw_write_emits_via_hub(void) {
   hub_subscribe(ON, event_catcher, NULL);
 
   g_raw_write_events = 0;
-  StateMachine* sm = sm_create(&target, t, NULL, NULL);
+  StateMachine* sm   = sm_create(&target, t, NULL, NULL);
 
   sm_raw_write(sm, ON);
   assert(sm_get_state(sm) == ON);
@@ -304,14 +394,19 @@ void test_raw_write_emits_via_hub(void) {
   hub_shutdown();
 }
 
-void test_raw_write_with_custom_emitter(void) {
+void
+test_raw_write_with_custom_emitter(void)
+{
   LOG_CLEAN("== sm_raw_write with custom emitter");
-  uint32_t states[] = { S0, S1 };
-  SMTransition trans[] = { { S0, S1, NULL, NULL, 10 }, { S1, S0, NULL, NULL, 11 } };
+  uint32_t     states[] = { S0, S1 };
+  SMTransition trans[]  = {
+    { S0, S1, NULL, NULL, 10 },
+    { S1, S0, NULL, NULL, 11 }
+  };
   SMTemplate* t = make_tmpl("custom-emit", states, 2, trans, 2, S0);
 
-  int owner = 0;
-  StateMachine* sm = make_sm(&owner, t);
+  int           owner = 0;
+  StateMachine* sm    = make_sm(&owner, t);
 
   g_raw_write_events = 0;
   sm_raw_write(sm, S1);
@@ -321,14 +416,19 @@ void test_raw_write_with_custom_emitter(void) {
   sm_template_destroy(t);
 }
 
-void test_transition(void) {
+void
+test_transition(void)
+{
   LOG_CLEAN("== sm_transition");
-  uint32_t states[] = { S0, S1 };
-  SMTransition trans[] = { { S0, S1, NULL, NULL, 100 }, { S1, S0, NULL, NULL, 101 } };
+  uint32_t     states[] = { S0, S1 };
+  SMTransition trans[]  = {
+    { S0, S1, NULL, NULL, 100 },
+    { S1, S0, NULL, NULL, 101 }
+  };
   SMTemplate* t = make_tmpl("trans", states, 2, trans, 2, S0);
 
-  int owner = 0;
-  StateMachine* sm = make_sm(&owner, t);
+  int           owner = 0;
+  StateMachine* sm    = make_sm(&owner, t);
 
   assert(sm_transition(sm, S1) == true);
   assert(sm_get_state(sm) == S1);
@@ -343,17 +443,19 @@ void test_transition(void) {
   sm_template_destroy(t);
 }
 
-void test_can_transition(void) {
+void
+test_can_transition(void)
+{
   LOG_CLEAN("== sm_can_transition");
-  uint32_t states[] = { S0, S1, S2 };
-  SMTransition trans[] = {
+  uint32_t     states[] = { S0, S1, S2 };
+  SMTransition trans[]  = {
     { S0, S1, NULL, NULL, 0 },
     { S1, S2, NULL, NULL, 0 },
   };
   SMTemplate* t = make_tmpl("can-trans", states, 3, trans, 2, S0);
 
-  int owner = 0;
-  StateMachine* sm = make_sm(&owner, t);
+  int           owner = 0;
+  StateMachine* sm    = make_sm(&owner, t);
 
   /* From S0: can go to S1, but not to S2 */
   assert(sm_can_transition(sm, S1) == true);
@@ -363,15 +465,17 @@ void test_can_transition(void) {
   sm_template_destroy(t);
 }
 
-void test_transition_with_guards(void) {
+void
+test_transition_with_guards(void)
+{
   LOG_CLEAN("== sm_transition with guards");
   sm_registry_init();
   sm_register_guard("allow", guard_allow);
   sm_register_guard("deny", guard_deny);
   sm_register_guard("cond", guard_conditional);
 
-  uint32_t states[] = { S0, S1 };
-  SMTransition trans[] = {
+  uint32_t     states[] = { S0, S1 };
+  SMTransition trans[]  = {
     { S0, S1, "allow", NULL, 40 },
     { S1, S0, "deny",  NULL, 41 },
   };
@@ -381,33 +485,35 @@ void test_transition_with_guards(void) {
 
   /* Test 1: allowing guard */
   g_raw_write_events = 0;
-  StateMachine* sm1 = make_sm(&owner, t);
+  StateMachine* sm1  = make_sm(&owner, t);
   assert(sm_transition(sm1, S1) == true);
   assert(sm_get_state(sm1) == S1);
   sm_destroy(sm1);
 
   /* Test 2: denying guard blocks transition */
   StateMachine* sm2 = make_sm(&owner, t);
-  assert(sm_transition(sm2, S1) == true); /* S0 -> S1 with "allow" */
+  assert(sm_transition(sm2, S1) == true);  /* S0 -> S1 with "allow" */
   g_raw_write_events = 0;
   assert(sm_transition(sm2, S0) == false); /* blocked by "deny" */
   assert(sm_get_state(sm2) == S1);
-  assert(g_raw_write_events == 0); /* no event emitted */
+  assert(g_raw_write_events == 0);         /* no event emitted */
   sm_destroy(sm2);
 
   /* Test 3: conditional guard based on data */
-  SMTransition ctrans[] = { { S0, S1, "cond", NULL, 42 } };
+  SMTransition ctrans[] = {
+    { S0, S1, "cond", NULL, 42 }
+  };
   SMTemplate* ct = make_tmpl("cond", states, 2, ctrans, 1, S0);
 
-  int allow_true = 1;
-  StateMachine* sm_allow = make_sm(&owner, ct);
-  sm_allow->data = &allow_true;
+  int           allow_true = 1;
+  StateMachine* sm_allow   = make_sm(&owner, ct);
+  sm_allow->data           = &allow_true;
   assert(sm_transition(sm_allow, S1) == true);
   sm_destroy(sm_allow);
 
-  int allow_false = 0;
-  StateMachine* sm_deny = make_sm(&owner, ct);
-  sm_deny->data = &allow_false;
+  int           allow_false = 0;
+  StateMachine* sm_deny     = make_sm(&owner, ct);
+  sm_deny->data             = &allow_false;
   assert(sm_transition(sm_deny, S1) == false);
   sm_destroy(sm_deny);
 
@@ -416,14 +522,16 @@ void test_transition_with_guards(void) {
   sm_registry_shutdown();
 }
 
-void test_transition_with_actions(void) {
+void
+test_transition_with_actions(void)
+{
   LOG_CLEAN("== sm_transition with actions");
   sm_registry_init();
   sm_register_action("track", action_track);
   sm_register_action("fail", action_fail);
 
-  uint32_t states[] = { S0, S1, S2 };
-  SMTransition trans[] = {
+  uint32_t     states[] = { S0, S1, S2 };
+  SMTransition trans[]  = {
     { S0, S1, NULL, "track", 30 },
     { S1, S2, NULL, "track", 31 },
     { S0, S2, NULL, "fail",  32 },
@@ -433,10 +541,10 @@ void test_transition_with_actions(void) {
   int owner = 0;
 
   /* Action runs on successful transition */
-  int count = 0;
-  StateMachine* sm1 = make_sm(&owner, t);
-  sm1->data = &count;
-  g_raw_write_events = 0;
+  int           count = 0;
+  StateMachine* sm1   = make_sm(&owner, t);
+  sm1->data           = &count;
+  g_raw_write_events  = 0;
 
   assert(sm_transition(sm1, S1) == true);
   assert(count == 1);
@@ -444,9 +552,9 @@ void test_transition_with_actions(void) {
   sm_destroy(sm1);
 
   /* Chain of actions */
-  count = 0;
+  count             = 0;
   StateMachine* sm2 = make_sm(&owner, t);
-  sm2->data = &count;
+  sm2->data         = &count;
   assert(sm_transition(sm2, S1) == true);
   assert(sm_transition(sm2, S2) == true);
   assert(count == 2);
@@ -462,23 +570,25 @@ void test_transition_with_actions(void) {
   sm_registry_shutdown();
 }
 
-void test_complete_flow(void) {
+void
+test_complete_flow(void)
+{
   LOG_CLEAN("== sm_transition complete flow");
   sm_registry_init();
   sm_register_guard("can_work", guard_allow);
   sm_register_action("do_work", action_track);
 
-  uint32_t states[] = { S0, S1, S2 };
-  SMTransition trans[] = {
+  uint32_t     states[] = { S0, S1, S2 };
+  SMTransition trans[]  = {
     { S0, S1, "can_work", "do_work", 35 },
     { S1, S2, NULL,       "do_work", 36 },
   };
   SMTemplate* t = make_tmpl("flow", states, 3, trans, 2, S0);
 
-  int owner = 0;
-  int count = 0;
-  StateMachine* sm = make_sm(&owner, t);
-  sm->data = &count;
+  int           owner = 0;
+  int           count = 0;
+  StateMachine* sm    = make_sm(&owner, t);
+  sm->data            = &count;
 
   /* Valid transition with guard + action */
   g_raw_write_events = 0;
@@ -496,7 +606,7 @@ void test_complete_flow(void) {
 
   /* get_available_transitions */
   sm_raw_write(sm, S0);
-  uint32_t n = 0;
+  uint32_t  n     = 0;
   uint32_t* avail = sm_get_available_transitions(sm, &n);
   assert(avail != NULL);
   assert(n == 1);
@@ -508,14 +618,19 @@ void test_complete_flow(void) {
   sm_registry_shutdown();
 }
 
-void test_invalid_transition_rejected(void) {
+void
+test_invalid_transition_rejected(void)
+{
   LOG_CLEAN("== invalid transition rejected");
   sm_registry_init();
   sm_register_guard("can_open", guard_allow);
 
-  enum { LOCKED = 0, OPEN = 1, BROKEN = 2 };
-  uint32_t states[] = { LOCKED, OPEN, BROKEN };
-  SMTransition trans[] = {
+  enum { LOCKED = 0,
+         OPEN   = 1,
+         BROKEN = 2,
+  };
+  uint32_t     states[] = { LOCKED, OPEN, BROKEN };
+  SMTransition trans[]  = {
     { LOCKED, OPEN,   "can_open", NULL, 50 },
     { OPEN,   LOCKED, NULL,       NULL, 51 },
     { OPEN,   BROKEN, NULL,       NULL, 52 },
@@ -523,8 +638,8 @@ void test_invalid_transition_rejected(void) {
   };
   SMTemplate* t = make_tmpl("invalid", states, 3, trans, 4, LOCKED);
 
-  int owner = 0;
-  StateMachine* sm = make_sm(&owner, t);
+  int           owner = 0;
+  StateMachine* sm    = make_sm(&owner, t);
 
   /* No path LOCKED -> BROKEN */
   assert(sm_transition(sm, BROKEN) == false);
@@ -541,15 +656,19 @@ void test_invalid_transition_rejected(void) {
   sm_registry_shutdown();
 }
 
-void test_hooks_basic(void) {
+void
+test_hooks_basic(void)
+{
   LOG_CLEAN("== sm hooks basic");
-  uint32_t states[] = { S0, S1 };
-  SMTransition trans[] = { { S0, S1, NULL, NULL, 0 } };
+  uint32_t     states[] = { S0, S1 };
+  SMTransition trans[]  = {
+    { S0, S1, NULL, NULL, 0 }
+  };
   SMTemplate* t = make_tmpl("hooks", states, 2, trans, 1, S0);
 
-  g_hook_basic_count = 0;
-  int owner = 0;
-  StateMachine* sm = make_sm(&owner, t);
+  g_hook_basic_count  = 0;
+  int           owner = 0;
+  StateMachine* sm    = make_sm(&owner, t);
   sm_add_hook(sm, SM_HOOK_POST_ACTION, hook_basic_fn, NULL);
   sm_transition(sm, S1);
   assert(g_hook_basic_count == 1);
@@ -558,30 +677,35 @@ void test_hooks_basic(void) {
   sm_template_destroy(t);
 }
 
-void test_hooks_all_phases(void) {
+void
+test_hooks_all_phases(void)
+{
   LOG_CLEAN("== sm hooks all phases");
   sm_registry_init();
   sm_register_guard("allow_all", guard_allow);
   sm_register_action("track", action_track);
 
-  enum { IDLE = 0, WORK = 1, DONE = 2 };
-  uint32_t states[] = { IDLE, WORK, DONE };
-  SMTransition trans[] = {
+  enum { IDLE = 0,
+         WORK = 1,
+         DONE = 2,
+  };
+  uint32_t     states[] = { IDLE, WORK, DONE };
+  SMTransition trans[]  = {
     { IDLE, WORK, "allow_all", "track", 35 },
     { WORK, DONE, NULL,        "track", 36 },
   };
   SMTemplate* t = make_tmpl("all-hooks", states, 3, trans, 2, IDLE);
 
-  int owner = 0;
-  StateMachine* sm = make_sm(&owner, t);
+  int           owner = 0;
+  StateMachine* sm    = make_sm(&owner, t);
 
   /* Add hooks for all phases */
-  sm_add_hook(sm, SM_HOOK_PRE_GUARD,   hook_pre_guard,   NULL);
-  sm_add_hook(sm, SM_HOOK_POST_GUARD,  hook_post_guard,  NULL);
-  sm_add_hook(sm, SM_HOOK_PRE_ACTION,  hook_pre_action,  NULL);
+  sm_add_hook(sm, SM_HOOK_PRE_GUARD, hook_pre_guard, NULL);
+  sm_add_hook(sm, SM_HOOK_POST_GUARD, hook_post_guard, NULL);
+  sm_add_hook(sm, SM_HOOK_PRE_ACTION, hook_pre_action, NULL);
   sm_add_hook(sm, SM_HOOK_POST_ACTION, hook_post_action, NULL);
-  sm_add_hook(sm, SM_HOOK_PRE_EMIT,    hook_pre_emit,    NULL);
-  sm_add_hook(sm, SM_HOOK_POST_EMIT,   hook_post_emit,   NULL);
+  sm_add_hook(sm, SM_HOOK_PRE_EMIT, hook_pre_emit, NULL);
+  sm_add_hook(sm, SM_HOOK_POST_EMIT, hook_post_emit, NULL);
 
   hub_init();
   hub_subscribe(35, event_catcher, NULL);
@@ -618,15 +742,19 @@ void test_hooks_all_phases(void) {
   sm_registry_shutdown();
 }
 
-void test_hooks_userdata(void) {
+void
+test_hooks_userdata(void)
+{
   LOG_CLEAN("== sm hooks userdata");
-  uint32_t states[] = { S0, S1 };
-  SMTransition trans[] = { { S0, S1, NULL, NULL, 0 } };
+  uint32_t     states[] = { S0, S1 };
+  SMTransition trans[]  = {
+    { S0, S1, NULL, NULL, 0 }
+  };
   SMTemplate* t = make_tmpl("ud", states, 2, trans, 1, S0);
 
-  int counter = 0;
-  int owner = 0;
-  StateMachine* sm = make_sm(&owner, t);
+  int           counter = 0;
+  int           owner   = 0;
+  StateMachine* sm      = make_sm(&owner, t);
 
   sm_add_hook(sm, SM_HOOK_POST_ACTION, hook_with_userdata, &counter);
   sm_add_hook(sm, SM_HOOK_POST_ACTION, hook_with_userdata, &counter);
@@ -638,19 +766,23 @@ void test_hooks_userdata(void) {
   sm_template_destroy(t);
 }
 
-void test_hooks_removal(void) {
+void
+test_hooks_removal(void)
+{
   LOG_CLEAN("== sm hooks removal");
-  uint32_t states[] = { S0, S1 };
-  SMTransition trans[] = { { S0, S1, NULL, NULL, 0 } };
+  uint32_t     states[] = { S0, S1 };
+  SMTransition trans[]  = {
+    { S0, S1, NULL, NULL, 0 }
+  };
   SMTemplate* t = make_tmpl("removal", states, 2, trans, 1, S0);
 
-  int owner = 0;
-  StateMachine* sm = make_sm(&owner, t);
+  int           owner = 0;
+  StateMachine* sm    = make_sm(&owner, t);
 
   sm_add_hook(sm, SM_HOOK_POST_ACTION, hook_basic_fn, NULL);
   sm_add_hook(sm, SM_HOOK_POST_ACTION, hook_remove_test, NULL);
 
-  g_hook_basic_count = 0;
+  g_hook_basic_count  = 0;
   g_hook_remove_count = 0;
   sm_transition(sm, S1);
   assert(g_hook_basic_count == 1);
@@ -658,7 +790,7 @@ void test_hooks_removal(void) {
 
   /* Remove one hook */
   sm_remove_hook(sm, SM_HOOK_POST_ACTION, hook_remove_test);
-  g_hook_basic_count = 0;
+  g_hook_basic_count  = 0;
   g_hook_remove_count = 0;
   sm_raw_write(sm, S0);
   sm_transition(sm, S1);
@@ -669,7 +801,9 @@ void test_hooks_removal(void) {
   sm_template_destroy(t);
 }
 
-int main(void) {
+int
+main(void)
+{
   test_tmpl_create_destroy();
   test_sm_create_destroy();
   test_sm_create_requires_params();

--- a/test-wm-hub.c
+++ b/test-wm-hub.c
@@ -753,6 +753,292 @@ test_unsubscribe_nonexistent_handler(void)
   assert(handler_a_calls == 1);              // handler_a still works
 }
 
+/*
+ * Request Routing Tests
+ */
+
+/* Track executor calls */
+static int      executor_call_count  = 0;
+static RequestType last_exec_type  = 0;
+static TargetID    last_exec_target = TARGET_ID_NONE;
+static void*      last_exec_data    = NULL;
+static uint64_t    last_exec_cid     = 0;
+
+/* Test executors - must be static at file scope */
+static void
+exec_fullscreen(struct HubRequest* req)
+{
+  executor_call_count++;
+  last_exec_type   = req->type;
+  last_exec_target = req->target;
+  last_exec_data   = req->data;
+  last_exec_cid    = req->correlation_id;
+  LOG_CLEAN("  exec_fullscreen: type=%u target=%lu cid=%lu",
+            req->type, (unsigned long) req->target, (unsigned long) req->correlation_id);
+}
+
+static void
+exec_focus(struct HubRequest* req)
+{
+  executor_call_count++;
+  last_exec_type   = req->type;
+  last_exec_target = req->target;
+  last_exec_data   = req->data;
+  last_exec_cid    = req->correlation_id;
+  LOG_CLEAN("  exec_focus: type=%u target=%lu cid=%lu",
+            req->type, (unsigned long) req->target, (unsigned long) req->correlation_id);
+}
+
+static void
+exec_monitor(struct HubRequest* req)
+{
+  executor_call_count++;
+  last_exec_type   = req->type;
+  last_exec_target = req->target;
+  last_exec_data   = req->data;
+  last_exec_cid    = req->correlation_id;
+  LOG_CLEAN("  exec_monitor: type=%u target=%lu cid=%lu",
+            req->type, (unsigned long) req->target, (unsigned long) req->correlation_id);
+}
+
+/* Components with executors */
+static HubComponent routing_fullscreen = {
+  .name       = "routing-fullscreen",
+  .requests   = (RequestType[]) { 1, 2, 0 }, /* Request types 1, 2 */
+  .targets    = client_targets,
+  .executor   = exec_fullscreen,
+  .registered = false,
+};
+
+static HubComponent routing_focus = {
+  .name       = "routing-focus",
+  .requests   = (RequestType[]) { 3, 0 }, /* Request type 3 */
+  .targets    = client_targets,
+  .executor   = exec_focus,
+  .registered = false,
+};
+
+static HubComponent routing_monitor = {
+  .name       = "routing-monitor",
+  .requests   = (RequestType[]) { 4, 5, 0 }, /* Request types 4, 5 */
+  .targets    = monitor_targets,
+  .executor   = exec_monitor,
+  .registered = false,
+};
+
+static HubComponent routing_no_exec = {
+  .name       = "routing-no-exec",
+  .requests   = (RequestType[]) { 99, 0 }, /* Request type 99 */
+  .targets    = client_targets,
+  .executor   = NULL, /* No executor - should not be called */
+  .registered = false,
+};
+
+void
+test_routing_basic_request(void)
+{
+  LOG_CLEAN("== Testing basic request routing");
+  hub_init();
+
+  hub_register_component(&routing_fullscreen);
+
+  executor_call_count = 0;
+  hub_send_request(1, 100); /* Send request type 1 to target 100 */
+
+  assert(executor_call_count == 1);
+  assert(last_exec_type == 1);
+  assert(last_exec_target == 100);
+
+  hub_shutdown();
+}
+
+void
+test_routing_target_id_passed(void)
+{
+  LOG_CLEAN("== Testing target ID is passed to executor");
+  hub_init();
+
+  hub_register_component(&routing_focus);
+
+  executor_call_count = 0;
+  hub_send_request(3, 999);
+
+
+  assert(executor_call_count == 1);
+  assert(last_exec_target == 999);
+
+  hub_shutdown();
+}
+
+void
+test_routing_data_passed(void)
+{
+  LOG_CLEAN("== Testing request data is passed to executor");
+  hub_init();
+
+  hub_register_component(&routing_fullscreen);
+
+  executor_call_count = 0;
+  int test_data = 42;
+  hub_send_request_data(1, 100, &test_data);
+
+  assert(executor_call_count == 1);
+  assert(last_exec_data == &test_data);
+
+  hub_shutdown();
+}
+
+void
+test_routing_correlation_id(void)
+{
+  LOG_CLEAN("== Testing correlation ID is passed to executor");
+  hub_init();
+
+  hub_register_component(&routing_fullscreen);
+
+
+  executor_call_count = 0;
+  hub_send_request_with_cid(1, 100, 0xDEADBEEF);
+
+  assert(executor_call_count == 1);
+  assert(last_exec_cid == 0xDEADBEEF);
+
+  hub_shutdown();
+}
+
+void
+test_routing_to_correct_component(void)
+{
+  LOG_CLEAN("== Testing request routes to correct component");
+  hub_init();
+
+  hub_register_component(&routing_fullscreen);
+  hub_register_component(&routing_focus);
+
+  hub_register_component(&routing_monitor);
+
+  executor_call_count = 0;
+  hub_send_request(3, 100); /* Request type 3 - focus component */
+  assert(executor_call_count == 1);
+  assert(last_exec_type == 3); /* Focus should handle type 3 */
+
+  executor_call_count = 0;
+  hub_send_request(4, 200); /* Request type 4 - monitor component */
+  assert(executor_call_count == 1);
+  assert(last_exec_type == 4); /* Monitor should handle type 4 */
+
+  hub_shutdown();
+}
+
+void
+test_routing_no_handler(void)
+{
+  LOG_CLEAN("== Testing routing to non-existent handler is safe");
+  hub_init();
+
+  /* Don't register any component */
+  executor_call_count = 0;
+  hub_send_request(999, 100);
+
+  assert(executor_call_count == 0); /* No executor called */
+
+  hub_shutdown();
+}
+
+void
+test_routing_no_executor(void)
+{
+  LOG_CLEAN("== Testing routing to component without executor");
+  hub_init();
+
+  hub_register_component(&routing_no_exec);
+
+  executor_call_count = 0;
+  hub_send_request(99, 100);
+
+  assert(executor_call_count == 0); /* Executor is NULL, should not be called */
+
+  hub_shutdown();
+}
+
+void
+test_get_executor_for_request(void)
+{
+  LOG_CLEAN("== Testing get executor for request type");
+  hub_init();
+
+
+  hub_register_component(&routing_fullscreen);
+  hub_register_component(&routing_focus);
+
+  assert(hub_get_executor_for_request(1) == exec_fullscreen);
+  assert(hub_get_executor_for_request(3) == exec_focus);
+  assert(hub_get_executor_for_request(99) == NULL); /* Not registered */
+
+  hub_shutdown();
+}
+
+void
+test_get_executor_after_unregister(void)
+{
+  LOG_CLEAN("== Testing get executor returns NULL after unregister");
+  hub_init();
+
+  hub_register_component(&routing_fullscreen);
+  assert(hub_get_executor_for_request(1) == exec_fullscreen);
+
+  hub_unregister_component("routing-fullscreen");
+  assert(hub_get_executor_for_request(1) == NULL);
+
+
+  hub_shutdown();
+}
+
+void
+test_simple_request_flow(void)
+{
+  LOG_CLEAN("== Testing simple request flow (keybinding -> hub -> component)");
+  hub_init();
+
+  /* Simulate: keybinding component sends REQ_CLIENT_FOCUS */
+  hub_register_component(&routing_focus);
+
+  /* Simulate: user presses keybinding */
+  executor_call_count = 0;
+  hub_send_request(3, 100);
+
+  assert(executor_call_count == 1);
+  assert(last_exec_type == 3);
+  assert(last_exec_target == 100);
+
+  hub_shutdown();
+}
+
+void
+test_fullscreen_toggle_flow(void)
+{
+  LOG_CLEAN("== Testing fullscreen toggle flow");
+  hub_init();
+
+  hub_register_component(&routing_fullscreen);
+
+  /* Toggle fullscreen on */
+  executor_call_count = 0;
+  hub_send_request(1, 100);
+
+  assert(executor_call_count == 1);
+  assert(last_exec_type == 1);
+
+  /* Toggle fullscreen off */
+  executor_call_count = 0;
+  hub_send_request(2, 100);
+
+  assert(executor_call_count == 1);
+  assert(last_exec_type == 2);
+
+  hub_shutdown();
+}
+
 TEST_GROUP(HubRegistry, {
   test_hub_init_shutdown();
   test_register_unregister_component();
@@ -788,4 +1074,18 @@ TEST_GROUP(HubEventBus, {
   test_userdata_in_subscribe();
   test_duplicate_subscribe_rejected();
   test_unsubscribe_nonexistent_handler();
+});
+
+TEST_GROUP(HubRouting, {
+  test_routing_basic_request();
+  test_routing_target_id_passed();
+  test_routing_data_passed();
+  test_routing_correlation_id();
+  test_routing_to_correct_component();
+  test_routing_no_handler();
+  test_routing_no_executor();
+  test_get_executor_for_request();
+  test_get_executor_after_unregister();
+  test_simple_request_flow();
+  test_fullscreen_toggle_flow();
 });

--- a/test-wm-hub.c
+++ b/test-wm-hub.c
@@ -1,6 +1,7 @@
 #include "test-registry.h"
 #include "test-wm.h"
 #include "wm-hub.h"
+#include <inttypes.h>
 
 /* Test component definitions - use TARGET_TYPE_NONE for proper termination */
 static RequestType fullscreen_requests[] = { 1, 2, 0 }; /* REQ_FULLSCREEN_ENTER = 1, REQ_FULLSCREEN_EXIT = 2 */
@@ -773,8 +774,8 @@ exec_fullscreen(struct HubRequest* req)
   last_exec_target = req->target;
   last_exec_data   = req->data;
   last_exec_cid    = req->correlation_id;
-  LOG_CLEAN("  exec_fullscreen: type=%u target=%lu cid=%lu",
-            req->type, (unsigned long) req->target, (unsigned long) req->correlation_id);
+  LOG_CLEAN("  exec_fullscreen: type=%" PRIu32 " target=%" PRIu64 " cid=%" PRIu64,
+            req->type, req->target, req->correlation_id);
 }
 
 static void
@@ -785,8 +786,8 @@ exec_focus(struct HubRequest* req)
   last_exec_target = req->target;
   last_exec_data   = req->data;
   last_exec_cid    = req->correlation_id;
-  LOG_CLEAN("  exec_focus: type=%u target=%lu cid=%lu",
-            req->type, (unsigned long) req->target, (unsigned long) req->correlation_id);
+  LOG_CLEAN("  exec_focus: type=%" PRIu32 " target=%" PRIu64 " cid=%" PRIu64,
+            req->type, req->target, req->correlation_id);
 }
 
 static void
@@ -797,8 +798,8 @@ exec_monitor(struct HubRequest* req)
   last_exec_target = req->target;
   last_exec_data   = req->data;
   last_exec_cid    = req->correlation_id;
-  LOG_CLEAN("  exec_monitor: type=%u target=%lu cid=%lu",
-            req->type, (unsigned long) req->target, (unsigned long) req->correlation_id);
+  LOG_CLEAN("  exec_monitor: type=%" PRIu32 " target=%" PRIu64 " cid=%" PRIu64,
+            req->type, req->target, req->correlation_id);
 }
 
 /* Components with executors */

--- a/test-wm-hub.c
+++ b/test-wm-hub.c
@@ -1,5 +1,5 @@
-#include "test-wm.h"
 #include "test-registry.h"
+#include "test-wm.h"
 #include "wm-hub.h"
 
 /* Test component definitions - use TARGET_TYPE_NONE for proper termination */
@@ -758,11 +758,11 @@ test_unsubscribe_nonexistent_handler(void)
  */
 
 /* Track executor calls */
-static int      executor_call_count  = 0;
-static RequestType last_exec_type  = 0;
-static TargetID    last_exec_target = TARGET_ID_NONE;
-static void*      last_exec_data    = NULL;
-static uint64_t    last_exec_cid     = 0;
+static int         executor_call_count = 0;
+static RequestType last_exec_type      = 0;
+static TargetID    last_exec_target    = TARGET_ID_NONE;
+static void*       last_exec_data      = NULL;
+static uint64_t    last_exec_cid       = 0;
 
 /* Test executors - must be static at file scope */
 static void
@@ -879,7 +879,7 @@ test_routing_data_passed(void)
   hub_register_component(&routing_fullscreen);
 
   executor_call_count = 0;
-  int test_data = 42;
+  int test_data       = 42;
   hub_send_request_data(1, 100, &test_data);
 
   assert(executor_call_count == 1);
@@ -918,12 +918,12 @@ test_routing_to_correct_component(void)
   hub_register_component(&routing_monitor);
 
   executor_call_count = 0;
-  hub_send_request(3, 100); /* Request type 3 - focus component */
+  hub_send_request(3, 100);    /* Request type 3 - focus component */
   assert(executor_call_count == 1);
   assert(last_exec_type == 3); /* Focus should handle type 3 */
 
   executor_call_count = 0;
-  hub_send_request(4, 200); /* Request type 4 - monitor component */
+  hub_send_request(4, 200);    /* Request type 4 - monitor component */
   assert(executor_call_count == 1);
   assert(last_exec_type == 4); /* Monitor should handle type 4 */
 

--- a/test-wm-window-list.c
+++ b/test-wm-window-list.c
@@ -1,5 +1,5 @@
-#include "test-wm.h"
 #include "test-registry.h"
+#include "test-wm.h"
 #include "wm-window-list.h"
 
 static int         count = 0;
@@ -8,7 +8,7 @@ static wnd_node_t* sentinel;
 void
 count_callback(wnd_node_t* wnd)
 {
-  (void)wnd;
+  (void) wnd;
   count++;
 }
 

--- a/test-wm-xcb-handler.c
+++ b/test-wm-xcb-handler.c
@@ -1,6 +1,6 @@
-#include "test-wm.h"
-#include "test-registry.h"
 #include "src/xcb/xcb-handler.h"
+#include "test-registry.h"
+#include "test-wm.h"
 #include "wm-hub.h"
 
 /* Mock component for testing */
@@ -19,7 +19,7 @@ static HubComponent mock_component2 = {
 };
 
 /* Track handler calls */
-static int handler_call_count    = 0;
+static int   handler_call_count = 0;
 static void* last_handler_event = NULL;
 
 static void
@@ -38,8 +38,8 @@ test_handler2(void* event)
 static void
 reset_handler_state(void)
 {
-  handler_call_count    = 0;
-  last_handler_event    = NULL;
+  handler_call_count = 0;
+  last_handler_event = NULL;
 }
 
 void
@@ -276,7 +276,7 @@ test_xcb_handler_unregister_nonexistent(void)
 
   /* Unregister a component that has no handlers - should be safe */
   xcb_handler_unregister_component(&mock_component2);
-  assert(xcb_handler_count() == 1);  /* mock_component still registered */
+  assert(xcb_handler_count() == 1); /* mock_component still registered */
 
   xcb_handler_shutdown();
   hub_shutdown();
@@ -295,7 +295,7 @@ test_unregister_null_component(void)
 
   /* Unregister NULL - should be safe */
   xcb_handler_unregister_component(NULL);
-  assert(xcb_handler_count() == 1);  /* handler still registered */
+  assert(xcb_handler_count() == 1); /* handler still registered */
 
   xcb_handler_shutdown();
   hub_shutdown();
@@ -330,7 +330,7 @@ test_next_returns_null_at_end(void)
   XCBHandler* h2 = xcb_handler_next(h);
 
   assert(h != NULL);
-  assert(h2 == NULL);  /* Only one handler, next should be NULL */
+  assert(h2 == NULL); /* Only one handler, next should be NULL */
 
   xcb_handler_shutdown();
   hub_shutdown();
@@ -382,7 +382,7 @@ test_dispatch_null_event(void)
 
   xcb_handler_dispatch(NULL);
 
-  assert(handler_call_count == 0);  /* Should not call handler */
+  assert(handler_call_count == 0); /* Should not call handler */
 
   xcb_handler_shutdown();
   hub_shutdown();

--- a/test-wm-xcb-handler.h
+++ b/test-wm-xcb-handler.h
@@ -13,8 +13,8 @@ extern HubComponent mock_component;
 extern HubComponent mock_component2;
 
 /* Track handler calls */
-extern int      handler_call_count;
-extern void*    last_handler_event;
+extern int   handler_call_count;
+extern void* last_handler_event;
 
 typedef void (*test_handler_fn)(void*);
 

--- a/test-wm.h
+++ b/test-wm.h
@@ -14,15 +14,15 @@
 extern int tests_passed;
 extern int tests_failed;
 
-#define assert(EXPRESSION)                                          \
-  do {                                                               \
-    if (!(EXPRESSION)) {                                             \
+#define assert(EXPRESSION)                                            \
+  do {                                                                \
+    if (!(EXPRESSION)) {                                              \
       LOG_CLEAN("%s:%d: %s - FAIL", __FILE__, __LINE__, #EXPRESSION); \
       tests_failed++;                                                 \
-    } else {                                                         \
+    } else {                                                          \
       LOG_CLEAN("%s:%d: %s - pass", __FILE__, __LINE__, #EXPRESSION); \
       tests_passed++;                                                 \
-    }                                                                \
+    }                                                                 \
   } while (0)
 
 

--- a/wm-hub.c
+++ b/wm-hub.c
@@ -1,5 +1,6 @@
 #include "wm-hub.h"
 
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -239,7 +240,7 @@ hub_register_target(HubTarget* target)
   }
 
   if (target->registered) {
-    LOG_ERROR("Target %lu is already registered", (unsigned long) target->id);
+    LOG_ERROR("Target %" PRIu64 " is already registered", target->id);
     return;
   }
 
@@ -260,7 +261,7 @@ hub_register_target(HubTarget* target)
 
   /* Check for duplicate ID */
   if (hub_get_target_by_id(target->id) != NULL) {
-    LOG_ERROR("Target with ID %lu already registered", (unsigned long) target->id);
+    LOG_ERROR("Target with ID %" PRIu64 " already registered", target->id);
     return;
   }
 
@@ -280,7 +281,7 @@ hub_register_target(HubTarget* target)
     }
   }
 
-  LOG_DEBUG("Registered target: id=%lu, type=%u", (unsigned long) target->id, target->type);
+  LOG_DEBUG("Registered target: id=%" PRIu64 ", type=%u", target->id, target->type);
 }
 
 void
@@ -293,7 +294,7 @@ hub_unregister_target(TargetID id)
 
   HubTarget* target = hub_get_target_by_id(id);
   if (target == NULL) {
-    LOG_ERROR("Target %lu not found", (unsigned long) id);
+    LOG_ERROR("Target %" PRIu64 " not found", id);
     return;
   }
 
@@ -322,7 +323,7 @@ hub_unregister_target(TargetID id)
   }
 
   target->registered = false;
-  LOG_DEBUG("Unregistered target: id=%lu", (unsigned long) id);
+  LOG_DEBUG("Unregistered target: id=%" PRIu64, id);
 }
 
 HubTarget*
@@ -531,6 +532,7 @@ hub_send_request_data(RequestType type, TargetID target, void* data)
   };
 
 
+
   LOG_DEBUG("Routing request type=%u to component '%s' for target %lu",
             type, comp->name, (unsigned long) target);
 
@@ -563,6 +565,7 @@ hub_send_request_with_cid(RequestType type, TargetID target, uint64_t correlatio
 
   LOG_DEBUG("Routing request type=%u to component '%s' for target %lu (cid=%lu)",
             type, comp->name, (unsigned long) target, (unsigned long) correlation_id);
+
 
   comp->executor(&req);
 }

--- a/wm-hub.c
+++ b/wm-hub.c
@@ -103,27 +103,6 @@ hub_init(void)
 }
 
 void
-hub_shutdown(void)
-{
-  LOG_DEBUG("Shutting down hub registry");
-
-  /* Unregister all components */
-  while (component_count > 0) {
-    component_count--;
-    components[component_count]->registered = false;
-  }
-
-  /* Unregister all targets */
-  while (target_count > 0) {
-    target_count--;
-    targets[target_count]->registered = false;
-  }
-
-  /* Clear all registry state including indexes */
-  clear_registry_state();
-}
-
-void
 hub_register_component(HubComponent* comp)
 {
   if (comp == NULL) {
@@ -511,6 +490,131 @@ hub_subscribe(EventType type, EventHandler handler, void* userdata)
   subscribers[type].count++;
 }
 
+/*
+ * Request Routing
+ *
+ * Routes requests to the appropriate component executor.
+ * Components register which request types they handle via the
+ * requests[] array. The hub maintains a lookup index for efficient routing.
+ */
+
+/* Forward declaration for hub_shutdown cleanup */
+static void clear_routing_indexes(void);
+
+void
+hub_send_request(RequestType type, TargetID target)
+{
+  hub_send_request_data(type, target, NULL);
+}
+
+void
+hub_send_request_data(RequestType type, TargetID target, void* data)
+{
+  HubComponent* comp = hub_get_component_by_request_type(type);
+  if (comp == NULL) {
+    LOG_DEBUG("No component handles request type %u for target %lu",
+              type, (unsigned long) target);
+    return;
+  }
+
+  if (comp->executor == NULL) {
+    LOG_DEBUG("Component '%s' has no executor for request type %u",
+              comp->name, type);
+    return;
+  }
+
+  struct HubRequest req = {
+    .type           = type,
+    .target         = target,
+    .data           = data,
+    .correlation_id = 0,
+  };
+
+
+  LOG_DEBUG("Routing request type=%u to component '%s' for target %lu",
+            type, comp->name, (unsigned long) target);
+
+  comp->executor(&req);
+}
+
+void
+hub_send_request_with_cid(RequestType type, TargetID target, uint64_t correlation_id)
+{
+  HubComponent* comp = hub_get_component_by_request_type(type);
+  if (comp == NULL) {
+    LOG_DEBUG("No component handles request type %u for target %lu",
+              type, (unsigned long) target);
+    return;
+  }
+
+  if (comp->executor == NULL) {
+    LOG_DEBUG("Component '%s' has no executor for request type %u",
+              comp->name, type);
+    return;
+  }
+
+
+  struct HubRequest req = {
+    .type           = type,
+    .target         = target,
+    .data           = NULL,
+    .correlation_id = correlation_id,
+  };
+
+  LOG_DEBUG("Routing request type=%u to component '%s' for target %lu (cid=%lu)",
+            type, comp->name, (unsigned long) target, (unsigned long) correlation_id);
+
+  comp->executor(&req);
+}
+
+/*
+ * Get the executor function for a request type.
+ * Used for testing purposes.
+ */
+RequestExecutor
+hub_get_executor_for_request(RequestType type)
+{
+  HubComponent* comp = hub_get_component_by_request_type(type);
+  if (comp == NULL) {
+    return NULL;
+  }
+  return comp->executor;
+}
+
+/*
+ * Clear routing indexes when shutting down.
+ * Components are responsible for clearing their executors.
+ */
+static void
+clear_routing_indexes(void)
+{
+  memset(component_by_request_type, 0, sizeof(component_by_request_type));
+}
+
+void
+hub_shutdown(void)
+{
+  LOG_DEBUG("Shutting down hub registry");
+
+  /* Clear routing indexes first */
+  clear_routing_indexes();
+
+  /* Unregister all components */
+  while (component_count > 0) {
+    component_count--;
+    components[component_count]->registered = false;
+  }
+
+  /* Unregister all targets */
+  while (target_count > 0) {
+    target_count--;
+    targets[target_count]->registered = false;
+  }
+
+  /* Clear all registry state including indexes */
+  clear_registry_state();
+}
+
 void
 hub_unsubscribe(EventType type, EventHandler handler)
 {
@@ -521,6 +625,7 @@ hub_unsubscribe(EventType type, EventHandler handler)
   if (handler == NULL) {
     return;
   }
+
 
   int count = subscribers[type].count;
   for (int i = 0; i < count; i++) {

--- a/wm-hub.h
+++ b/wm-hub.h
@@ -32,12 +32,24 @@ enum {
 /* Invalid ID sentinel */
 #define TARGET_ID_NONE   ((TargetID) 0)
 
+/* Request structure - passed to component executors */
+struct HubRequest {
+  RequestType type;
+  TargetID    target;
+  void*       data;
+  uint64_t    correlation_id; /* for async response correlation */
+};
+
+/* Forward declaration for executor type */
+typedef void (*RequestExecutor)(struct HubRequest* req);
+
 /* Component structure */
 struct HubComponent {
-  const char*  name;
-  RequestType* requests; /* NULL-terminated array of request types handled */
-  TargetType*  targets;  /* TARGET_TYPE_NONE-terminated array of accepted types */
-  bool         registered;
+  const char*      name;
+  RequestType*     requests;      /* NULL-terminated array of request types handled */
+  TargetType*      targets;       /* TARGET_TYPE_NONE-terminated array of accepted types */
+  RequestExecutor  executor;      /* called when this component receives a request */
+  bool             registered;
 };
 
 /* Target structure */
@@ -73,6 +85,37 @@ struct Subscriber {
 /* Hub initialization */
 void hub_init(void);
 void hub_shutdown(void);
+
+/* Request routing */
+
+/*
+ * Send a request to the hub for routing to the appropriate component.
+ * The hub will find the component that handles this request type
+ * and call its executor with the request.
+ *
+ * @param type    The request type (e.g., REQ_CLIENT_FULLSCREEN)
+ * @param target  The target ID to pass to the executor
+ */
+void hub_send_request(RequestType type, TargetID target);
+
+/*
+ * Send a request with data payload.
+ * The data is passed to the component executor.
+ *
+ * @param type    The request type
+ * @param target  The target ID
+ * @param data    Arbitrary data to pass to the executor
+ */
+void hub_send_request_data(RequestType type, TargetID target, void* data);
+
+/*
+ * Send a request with correlation ID for async response tracking.
+ *
+ * @param type           The request type
+ * @param target         The target ID
+ * @param correlation_id Caller-provided ID to match with response events
+ */
+void hub_send_request_with_cid(RequestType type, TargetID target, uint64_t correlation_id);
 
 /* Component registration */
 void          hub_register_component(HubComponent* comp);
@@ -111,5 +154,8 @@ void hub_unsubscribe(EventType type, EventHandler handler);
 /* Utility */
 uint32_t hub_component_count(void);
 uint32_t hub_target_count(void);
+
+/* Request routing (for testing) */
+RequestExecutor hub_get_executor_for_request(RequestType type);
 
 #endif

--- a/wm-hub.h
+++ b/wm-hub.h
@@ -45,11 +45,11 @@ typedef void (*RequestExecutor)(struct HubRequest* req);
 
 /* Component structure */
 struct HubComponent {
-  const char*      name;
-  RequestType*     requests;      /* NULL-terminated array of request types handled */
-  TargetType*      targets;       /* TARGET_TYPE_NONE-terminated array of accepted types */
-  RequestExecutor  executor;      /* called when this component receives a request */
-  bool             registered;
+  const char*     name;
+  RequestType*    requests; /* NULL-terminated array of request types handled */
+  TargetType*     targets;  /* TARGET_TYPE_NONE-terminated array of accepted types */
+  RequestExecutor executor; /* called when this component receives a request */
+  bool            registered;
 };
 
 /* Target structure */

--- a/wm-hub.h
+++ b/wm-hub.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <inttypes.h>
 
 /* Forward declarations */
 typedef struct HubComponent HubComponent;
@@ -32,12 +33,18 @@ enum {
 /* Invalid ID sentinel */
 #define TARGET_ID_NONE   ((TargetID) 0)
 
-/* Request structure - passed to component executors */
+/*
+ * Request structure - passed to component executors
+ *
+ * Note: The request is passed by pointer. The executor must not store
+ * a pointer to the request beyond the duration of the callback.
+ * For async operations, copy any needed data before returning.
+ */
 struct HubRequest {
   RequestType type;
-  TargetID    target;
-  void*       data;
-  uint64_t    correlation_id; /* for async response correlation */
+  TargetID   target;
+  void*      data;
+  uint64_t   correlation_id; /* for async response correlation */
 };
 
 /* Forward declaration for executor type */
@@ -45,11 +52,11 @@ typedef void (*RequestExecutor)(struct HubRequest* req);
 
 /* Component structure */
 struct HubComponent {
-  const char*     name;
-  RequestType*    requests; /* NULL-terminated array of request types handled */
-  TargetType*     targets;  /* TARGET_TYPE_NONE-terminated array of accepted types */
-  RequestExecutor executor; /* called when this component receives a request */
-  bool            registered;
+  const char*      name;
+  RequestType*     requests; /* 0-terminated array of request types handled */
+  TargetType*      targets;  /* TARGET_TYPE_NONE-terminated array of accepted types */
+  RequestExecutor  executor; /* called when this component receives a request */
+  bool             registered;
 };
 
 /* Target structure */
@@ -155,7 +162,9 @@ void hub_unsubscribe(EventType type, EventHandler handler);
 uint32_t hub_component_count(void);
 uint32_t hub_target_count(void);
 
+#ifdef WM_HUB_TESTING
 /* Request routing (for testing) */
 RequestExecutor hub_get_executor_for_request(RequestType type);
+#endif
 
 #endif

--- a/wm-log.h
+++ b/wm-log.h
@@ -23,9 +23,9 @@ void logger(FILE* io, const char* fmt, ...);
   {                                                   \
     logger(stderr, "ERROR: " pFormat, ##__VA_ARGS__); \
   }
-#define LOG_WARN(pFormat, ...)                        \
-  {                                                   \
-    logger(stderr, "WARN: " pFormat, ##__VA_ARGS__);  \
+#define LOG_WARN(pFormat, ...)                       \
+  {                                                  \
+    logger(stderr, "WARN: " pFormat, ##__VA_ARGS__); \
   }
 #define LOG_FATAL(pFormat, ...)                       \
   {                                                   \


### PR DESCRIPTION
- Add hub_send_request() - routes requests to the component handling the request type
- Add hub_send_request_data() - sends requests with arbitrary data payload
- Add hub_send_request_with_cid() - sends requests with correlation ID for async tracking
- Add RequestExecutor function pointer to HubComponent
- Add HubRequest struct for passing request data
- Add hub_get_executor_for_request() for testing
- Add 11 comprehensive tests for request routing logic

Implements: https://github.com/kesor/wm-xcb/issues/4
