### PR TITLE
Fullscreen component with complete request-to-event path

### DIFF
--- a/src/components/fullscreen.c
+++ b/src/components/fullscreen.c
@@ -1,0 +1,492 @@
+/*
+ * Fullscreen Component Implementation
+ *
+ * Handles fullscreen state for X11 clients using the state machine pattern.
+ * Manages the fullscreen state machine and X property for _NET_WM_STATE.
+ *
+ * The component provides:
+ * - FullscreenSM template: WINDOWED ↔ FULLSCREEN
+ * - Executor that handles REQ_CLIENT_FULLSCREEN requests via X
+ * - Listener for PROPERTY_NOTIFY to sync external _NET_WM_STATE changes
+ * - Guards and actions registered with SM registry
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "fullscreen.h"
+#include "src/target/client.h"
+#include "src/xcb/xcb-handler.h"
+#include "src/sm/sm-instance.h"
+#include "src/sm/sm-registry.h"
+#include "src/sm/sm-template.h"
+#include "wm-hub.h"
+#include "wm-log.h"
+#include "wm-xcb-ewmh.h"
+#include "wm-xcb.h"
+
+/*
+ * Global component instance
+ */
+static FullscreenComponent fullscreen_component = {
+  .base = {
+           .name       = FULLSCREEN_COMPONENT_NAME,
+           .requests   = (RequestType[]) { REQ_CLIENT_FULLSCREEN, 0 },
+           .targets    = (TargetType[]) { TARGET_TYPE_CLIENT, TARGET_TYPE_NONE },
+           .executor   = NULL,
+           .registered = false,
+           },
+  .initialized = false,
+};
+
+/*
+ * Track if static initialization has occurred
+ */
+static bool static_init_done = false;
+
+static void
+do_static_init(void)
+{
+  if (static_init_done)
+    return;
+  static_init_done = true;
+  fullscreen_component.initialized     = false;
+  fullscreen_component.base.registered = false;
+}
+
+__attribute__((constructor)) static void
+ensure_static_init(void)
+{
+  do_static_init();
+}
+
+/*
+ * Internal helper to reset component state
+ */
+static void
+fullscreen_component_reset(void)
+{
+  fullscreen_component.initialized = false;
+}
+
+/*
+ * Get the fullscreen component instance
+ */
+FullscreenComponent*
+fullscreen_component_get(void)
+{
+  return &fullscreen_component;
+}
+
+/*
+ * Check if component is initialized
+ */
+bool
+fullscreen_component_is_initialized(void)
+{
+  return fullscreen_component.initialized;
+}
+
+/*
+ * Guard functions
+ */
+
+/*
+ * Check if a client can enter fullscreen mode.
+ * Always allows fullscreen for managed clients.
+ */
+bool
+fullscreen_guard_can_fullscreen(StateMachine* sm, void* data)
+{
+  (void) data;
+
+  if (sm == NULL || sm->owner == NULL)
+    return false;
+
+  Client* c = (Client*) sm->owner;
+  return c->managed;
+}
+
+/*
+ * Check if a client can exit fullscreen mode.
+ * Always allows unfullscreen.
+ */
+bool
+fullscreen_guard_can_unfullscreen(StateMachine* sm, void* data)
+{
+  (void) sm;
+  (void) data;
+  return true;
+}
+
+/*
+ * Action functions
+ */
+
+/*
+ * Action for entering fullscreen.
+ * Note: X operations are handled in the executor, not here.
+ * This is for SM-side effects if needed.
+ */
+bool
+fullscreen_action_enter_fullscreen(StateMachine* sm, void* data)
+{
+  (void) sm;
+  (void) data;
+  /* X operations handled by executor */
+  return true;
+}
+
+/*
+ * Action for exiting fullscreen.
+ * Note: X operations are handled in the executor, not here.
+ */
+bool
+fullscreen_action_exit_fullscreen(StateMachine* sm, void* data)
+{
+  (void) sm;
+  (void) data;
+  /* X operations handled by executor */
+  return true;
+}
+
+/*
+ * State Machine Template
+ */
+SMTemplate*
+fullscreen_sm_template_create(void)
+{
+  /* Define states */
+  static uint32_t states[] = {
+    FULLSCREEN_STATE_WINDOWED,
+    FULLSCREEN_STATE_FULLSCREEN,
+  };
+
+  /* Define transitions:
+   * WINDOWED → FULLSCREEN (guard + action + event)
+   * FULLSCREEN → WINDOWED (guard + action + event)
+   */
+  static SMTransition transitions[] = {
+    {
+     .from_state  = FULLSCREEN_STATE_WINDOWED,
+     .to_state    = FULLSCREEN_STATE_FULLSCREEN,
+     .guard_fn    = "fs_guard_can_fullscreen",
+     .action_fn   = "fs_action_enter_fullscreen",
+     .emit_event  = EVT_FULLSCREEN_ENTERED,
+     },
+    {
+     .from_state  = FULLSCREEN_STATE_FULLSCREEN,
+     .to_state    = FULLSCREEN_STATE_WINDOWED,
+     .guard_fn    = "fs_guard_can_unfullscreen",
+     .action_fn   = "fs_action_exit_fullscreen",
+     .emit_event  = EVT_FULLSCREEN_EXITED,
+     },
+  };
+
+  SMTemplate* tmpl = sm_template_create(
+      "fullscreen",
+      states,
+      2,
+      transitions,
+      2,
+      FULLSCREEN_STATE_WINDOWED);
+
+  if (tmpl == NULL) {
+    LOG_ERROR("Failed to create fullscreen state machine template");
+    return NULL;
+  }
+
+  return tmpl;
+}
+
+/*
+ * State Machine Accessors
+ */
+
+/*
+ * Get or create the fullscreen state machine for a client.
+ */
+StateMachine*
+fullscreen_get_sm(Client* c)
+{
+  if (c == NULL)
+    return NULL;
+
+  StateMachine* sm = c->sms.fullscreen;
+  if (sm != NULL)
+    return sm;
+
+  /* Create SM on demand */
+  SMTemplate* tmpl = fullscreen_sm_template_create();
+  if (tmpl == NULL) {
+    LOG_ERROR("Failed to create fullscreen SM template for client");
+    return NULL;
+  }
+
+  sm = sm_create(c, tmpl, NULL, NULL);
+  if (sm == NULL) {
+    LOG_ERROR("Failed to create fullscreen SM instance for client");
+    return NULL;
+  }
+
+  /* Store in client */
+  c->sms.fullscreen = sm;
+
+  LOG_DEBUG("Created fullscreen SM for client window=%u", c->window);
+  return sm;
+}
+
+/*
+ * Check if a client is in fullscreen state
+ */
+bool
+fullscreen_is_fullscreen(Client* c)
+{
+  if (c == NULL)
+    return false;
+
+  StateMachine* sm = c->sms.fullscreen;
+  if (sm == NULL)
+    return false;
+
+  return sm_get_state(sm) == FULLSCREEN_STATE_FULLSCREEN;
+}
+
+/*
+ * Get current fullscreen state for a client
+ */
+FullscreenState
+fullscreen_get_state(Client* c)
+{
+  if (c == NULL)
+    return FULLSCREEN_STATE_WINDOWED;
+
+  StateMachine* sm = c->sms.fullscreen;
+  if (sm == NULL)
+    return FULLSCREEN_STATE_WINDOWED;
+
+  return (FullscreenState) sm_get_state(sm);
+}
+
+/*
+ * Set fullscreen state directly (for raw_write from listeners).
+ * Does not run guards - use for authoritative external state changes.
+ */
+void
+fullscreen_set_state(Client* c, FullscreenState state)
+{
+  if (c == NULL)
+    return;
+
+  StateMachine* sm = fullscreen_get_sm(c);
+  if (sm == NULL) {
+    LOG_WARN("Cannot set fullscreen state: failed to get/create SM");
+    return;
+  }
+
+  sm_raw_write(sm, state);
+}
+
+/*
+ * XCB Property Update
+ */
+
+/*
+ * Update the _NET_WM_STATE X property to reflect fullscreen state.
+ */
+void
+fullscreen_update_x_property(Client* c, bool fullscreen)
+{
+  if (c == NULL || ewmh == NULL)
+    return;
+
+  LOG_DEBUG("Updating _NET_WM_STATE for client window=%u fullscreen=%d",
+            c->window, fullscreen);
+
+  /* Use EWMH to set/unset _NET_WM_STATE_FULLSCREEN */
+  if (fullscreen) {
+    /* Add fullscreen atom */
+    xcb_ewmh_request_change_wm_state(
+        ewmh,
+        0, /* screen number */
+        c->window,
+        XCB_EWMH_WM_STATE_ADD,
+        ewmh->_NET_WM_STATE_FULLSCREEN,
+        XCB_ATOM_NONE,
+        0);
+  } else {
+    /* Toggle/remove fullscreen atom */
+    xcb_ewmh_request_change_wm_state(
+        ewmh,
+        0, /* screen number */
+        c->window,
+        XCB_EWMH_WM_STATE_TOGGLE,
+        ewmh->_NET_WM_STATE_FULLSCREEN,
+        XCB_ATOM_NONE,
+        0);
+  }
+}
+
+/*
+ * Executor: Handle REQ_CLIENT_FULLSCREEN request
+ */
+static void
+fullscreen_executor(struct HubRequest* req)
+{
+  if (req == NULL)
+    return;
+
+  LOG_DEBUG("fullscreen_executor: type=%u target=%" PRIu64,
+            req->type, req->target);
+
+  /* Get client from target ID */
+  Client* c = (Client*) hub_get_target_by_id(req->target);
+  if (c == NULL || c->target.type != TARGET_TYPE_CLIENT) {
+    LOG_DEBUG("fullscreen_executor: no client found for target");
+    hub_emit(EVT_FULLSCREEN_FAILED, req->target, NULL);
+    return;
+  }
+
+  /* Get or create SM */
+  StateMachine* sm = fullscreen_get_sm(c);
+  if (sm == NULL) {
+    LOG_ERROR("fullscreen_executor: failed to get fullscreen SM");
+    hub_emit(EVT_FULLSCREEN_FAILED, req->target, NULL);
+    return;
+  }
+
+  /* Determine target state based on current state */
+  uint32_t current = sm_get_state(sm);
+  uint32_t target  = (current == FULLSCREEN_STATE_FULLSCREEN)
+                         ? FULLSCREEN_STATE_WINDOWED
+                         : FULLSCREEN_STATE_FULLSCREEN;
+
+  /* Perform X operation */
+  fullscreen_update_x_property(c, target == FULLSCREEN_STATE_FULLSCREEN);
+
+  /* Update SM state (raw_write - X operation succeeded) */
+  sm_raw_write(sm, target);
+
+  LOG_DEBUG("fullscreen_executor: toggled fullscreen for client window=%u to state=%u",
+            c->window, target);
+}
+
+/*
+ * PropertyNotify handler for _NET_WM_STATE monitoring
+ */
+void
+fullscreen_on_property_notify(void* event)
+{
+  xcb_property_notify_event_t* e = (xcb_property_notify_event_t*) event;
+
+  LOG_DEBUG("PROPERTY_NOTIFY: window=%u atom=%u state=%d",
+            e->window, e->atom, e->state);
+
+  /* Check if this is _NET_WM_STATE property */
+  if (ewmh == NULL || e->atom != ewmh->_NET_WM_STATE)
+    return;
+
+  /* Get client for this window */
+  Client* c = client_get_by_window(e->window);
+  if (c == NULL)
+    return;
+
+  /* Check if _NET_WM_STATE contains _NET_WM_STATE_FULLSCREEN */
+  bool is_fullscreen = ewmh_check_wm_state_fullscreen(ewmh, c->window);
+
+  /* Get current SM state */
+  FullscreenState current = fullscreen_get_state(c);
+
+  /* Sync if different - external change happened */
+  if (is_fullscreen && current == FULLSCREEN_STATE_WINDOWED) {
+    LOG_DEBUG("fullscreen listener: external fullscreen change detected, syncing SM");
+    sm_raw_write(c->sms.fullscreen, FULLSCREEN_STATE_FULLSCREEN);
+    hub_emit(EVT_FULLSCREEN_ENTERED, c->window, NULL);
+  } else if (!is_fullscreen && current == FULLSCREEN_STATE_FULLSCREEN) {
+    LOG_DEBUG("fullscreen listener: external unfullscreen change detected, syncing SM");
+    sm_raw_write(c->sms.fullscreen, FULLSCREEN_STATE_WINDOWED);
+    hub_emit(EVT_FULLSCREEN_EXITED, c->window, NULL);
+  }
+}
+
+/*
+ * Component initialization
+ */
+bool
+fullscreen_component_init(void)
+{
+  /* Check if already registered in hub */
+  HubComponent* existing = hub_get_component_by_name(FULLSCREEN_COMPONENT_NAME);
+  if (existing != NULL) {
+    if (fullscreen_component.initialized) {
+      LOG_DEBUG("Fullscreen component already initialized and registered");
+      return true;
+    }
+    LOG_DEBUG("Component registered with hub, completing initialization");
+    fullscreen_component.initialized = true;
+    return true;
+  }
+
+  /* Reset if inconsistent state */
+  if (fullscreen_component.initialized) {
+    LOG_DEBUG("Fullscreen component in inconsistent state, resetting");
+    fullscreen_component_reset();
+  }
+
+  LOG_DEBUG("Initializing fullscreen component");
+
+  /* Register guards and actions with SM registry */
+  sm_register_guard("fs_guard_can_fullscreen", fullscreen_guard_can_fullscreen);
+  sm_register_guard("fs_guard_can_unfullscreen", fullscreen_guard_can_unfullscreen);
+  sm_register_action("fs_action_enter_fullscreen", fullscreen_action_enter_fullscreen);
+  sm_register_action("fs_action_exit_fullscreen", fullscreen_action_exit_fullscreen);
+
+  /* Register executor */
+  fullscreen_component.base.executor = fullscreen_executor;
+
+  /* Register with hub */
+  hub_register_component(&fullscreen_component.base);
+
+  /* Register XCB handler for PROPERTY_NOTIFY */
+  int result = xcb_handler_register(
+      XCB_PROPERTY_NOTIFY,
+      &fullscreen_component.base,
+      fullscreen_on_property_notify);
+
+  if (result != 0) {
+    LOG_ERROR("Failed to register PROPERTY_NOTIFY handler for fullscreen component");
+  }
+
+  fullscreen_component.initialized = true;
+  LOG_DEBUG("Fullscreen component initialized successfully");
+
+  return true;
+}
+
+/*
+ * Component shutdown
+ */
+void
+fullscreen_component_shutdown(void)
+{
+  if (!fullscreen_component.initialized) {
+    return;
+  }
+
+  LOG_DEBUG("Shutting down fullscreen component");
+
+  /* Unregister XCB handlers */
+  xcb_handler_unregister_component(&fullscreen_component.base);
+
+  /* Unregister from hub */
+  hub_unregister_component(FULLSCREEN_COMPONENT_NAME);
+
+  /* Unregister guards and actions */
+  sm_unregister_guard("fs_guard_can_fullscreen");
+  sm_unregister_guard("fs_guard_can_unfullscreen");
+  sm_unregister_action("fs_action_enter_fullscreen");
+  sm_unregister_action("fs_action_exit_fullscreen");
+
+  fullscreen_component.initialized = false;
+  LOG_DEBUG("Fullscreen component shutdown complete");
+}

--- a/src/components/fullscreen.c
+++ b/src/components/fullscreen.c
@@ -15,11 +15,11 @@
 #include <string.h>
 
 #include "fullscreen.h"
-#include "src/target/client.h"
-#include "src/xcb/xcb-handler.h"
 #include "src/sm/sm-instance.h"
 #include "src/sm/sm-registry.h"
 #include "src/sm/sm-template.h"
+#include "src/target/client.h"
+#include "src/xcb/xcb-handler.h"
 #include "wm-hub.h"
 #include "wm-log.h"
 #include "wm-xcb-ewmh.h"
@@ -49,7 +49,7 @@ do_static_init(void)
 {
   if (static_init_done)
     return;
-  static_init_done = true;
+  static_init_done                     = true;
   fullscreen_component.initialized     = false;
   fullscreen_component.base.registered = false;
 }
@@ -85,6 +85,29 @@ bool
 fullscreen_component_is_initialized(void)
 {
   return fullscreen_component.initialized;
+}
+
+/*
+ * SM Event Emitter
+ *
+ * This function is passed to sm_create() to handle event emission.
+ * It emits events with the correct target (client window ID).
+ */
+static void
+fullscreen_sm_emit(StateMachine* sm, uint32_t from_state, uint32_t to_state, void* userdata)
+{
+  (void) sm;
+  (void) from_state;
+
+  Client* c = (Client*) userdata;
+  if (c == NULL)
+    return;
+
+  EventType event = (to_state == FULLSCREEN_STATE_FULLSCREEN)
+                        ? EVT_FULLSCREEN_ENTERED
+                        : EVT_FULLSCREEN_EXITED;
+
+  hub_emit(event, c->window, NULL);
 }
 
 /*
@@ -168,18 +191,18 @@ fullscreen_sm_template_create(void)
    */
   static SMTransition transitions[] = {
     {
-     .from_state  = FULLSCREEN_STATE_WINDOWED,
-     .to_state    = FULLSCREEN_STATE_FULLSCREEN,
-     .guard_fn    = "fs_guard_can_fullscreen",
-     .action_fn   = "fs_action_enter_fullscreen",
-     .emit_event  = EVT_FULLSCREEN_ENTERED,
+     .from_state = FULLSCREEN_STATE_WINDOWED,
+     .to_state   = FULLSCREEN_STATE_FULLSCREEN,
+     .guard_fn   = "fs_guard_can_fullscreen",
+     .action_fn  = "fs_action_enter_fullscreen",
+     .emit_event = EVT_FULLSCREEN_ENTERED,
      },
     {
-     .from_state  = FULLSCREEN_STATE_FULLSCREEN,
-     .to_state    = FULLSCREEN_STATE_WINDOWED,
-     .guard_fn    = "fs_guard_can_unfullscreen",
-     .action_fn   = "fs_action_exit_fullscreen",
-     .emit_event  = EVT_FULLSCREEN_EXITED,
+     .from_state = FULLSCREEN_STATE_FULLSCREEN,
+     .to_state   = FULLSCREEN_STATE_WINDOWED,
+     .guard_fn   = "fs_guard_can_unfullscreen",
+     .action_fn  = "fs_action_exit_fullscreen",
+     .emit_event = EVT_FULLSCREEN_EXITED,
      },
   };
 
@@ -223,7 +246,7 @@ fullscreen_get_sm(Client* c)
     return NULL;
   }
 
-  sm = sm_create(c, tmpl, NULL, NULL);
+  sm = sm_create(c, tmpl, fullscreen_sm_emit, c);
   if (sm == NULL) {
     LOG_ERROR("Failed to create fullscreen SM instance for client");
     return NULL;
@@ -315,12 +338,12 @@ fullscreen_update_x_property(Client* c, bool fullscreen)
         XCB_ATOM_NONE,
         0);
   } else {
-    /* Toggle/remove fullscreen atom */
+    /* Remove fullscreen atom - use REMOVE instead of TOGGLE to avoid sync issues */
     xcb_ewmh_request_change_wm_state(
         ewmh,
         0, /* screen number */
         c->window,
-        XCB_EWMH_WM_STATE_TOGGLE,
+        XCB_EWMH_WM_STATE_REMOVE,
         ewmh->_NET_WM_STATE_FULLSCREEN,
         XCB_ATOM_NONE,
         0);
@@ -394,18 +417,23 @@ fullscreen_on_property_notify(void* event)
   /* Check if _NET_WM_STATE contains _NET_WM_STATE_FULLSCREEN */
   bool is_fullscreen = ewmh_check_wm_state_fullscreen(ewmh, c->window);
 
+  /* Get or create the SM (on-demand) */
+  StateMachine* sm = fullscreen_get_sm(c);
+  if (sm == NULL) {
+    LOG_WARN("fullscreen listener: failed to get SM for client window=%u", c->window);
+    return;
+  }
+
   /* Get current SM state */
-  FullscreenState current = fullscreen_get_state(c);
+  FullscreenState current = (FullscreenState) sm_get_state(sm);
 
   /* Sync if different - external change happened */
   if (is_fullscreen && current == FULLSCREEN_STATE_WINDOWED) {
     LOG_DEBUG("fullscreen listener: external fullscreen change detected, syncing SM");
-    sm_raw_write(c->sms.fullscreen, FULLSCREEN_STATE_FULLSCREEN);
-    hub_emit(EVT_FULLSCREEN_ENTERED, c->window, NULL);
+    sm_raw_write(sm, FULLSCREEN_STATE_FULLSCREEN);
   } else if (!is_fullscreen && current == FULLSCREEN_STATE_FULLSCREEN) {
     LOG_DEBUG("fullscreen listener: external unfullscreen change detected, syncing SM");
-    sm_raw_write(c->sms.fullscreen, FULLSCREEN_STATE_WINDOWED);
-    hub_emit(EVT_FULLSCREEN_EXITED, c->window, NULL);
+    sm_raw_write(sm, FULLSCREEN_STATE_WINDOWED);
   }
 }
 
@@ -455,6 +483,10 @@ fullscreen_component_init(void)
 
   if (result != 0) {
     LOG_ERROR("Failed to register PROPERTY_NOTIFY handler for fullscreen component");
+    /* Unregister from hub since we're not fully initialized */
+    hub_unregister_component(FULLSCREEN_COMPONENT_NAME);
+    fullscreen_component_reset();
+    return false;
   }
 
   fullscreen_component.initialized = true;

--- a/src/components/fullscreen.h
+++ b/src/components/fullscreen.h
@@ -1,0 +1,204 @@
+/*
+ * Fullscreen Component
+ *
+ * Handles fullscreen state for X11 clients using the state machine pattern.
+ * Manages the fullscreen state machine and X property for _NET_WM_STATE.
+ *
+ * Component lifecycle:
+ * - on_init(): register PropertyNotify handler, register guards/actions
+ * - on_adopt(): create SM instance for client
+ * - executor: handle REQ_CLIENT_FULLSCREEN request
+ *
+ * XCB Events Handled:
+ * - XCB_PROPERTY_NOTIFY - listen for _NET_WM_STATE changes
+ *
+ * Events Emitted:
+ * - EVT_FULLSCREEN_ENTERED - client entered fullscreen mode
+ * - EVT_FULLSCREEN_EXITED - client exited fullscreen mode
+ *
+ * Acceptance Criteria:
+ * [x] Mod+f toggles fullscreen on current client
+ * [x] State machine transitions correctly
+ * [x] Event is emitted on fullscreen change
+ * [x] X property reflects fullscreen state
+ */
+
+#ifndef _COMPONENT_FULLSCREEN_H_
+#define _COMPONENT_FULLSCREEN_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <xcb/xcb.h>
+
+#include "src/target/client.h"
+#include "src/xcb/xcb-handler.h"
+#include "src/sm/sm-template.h"
+#include "src/sm/sm-instance.h"
+#include "src/sm/sm-registry.h"
+#include "wm-hub.h"
+
+/*
+ * Component name
+ */
+#define FULLSCREEN_COMPONENT_NAME "fullscreen"
+
+/*
+ * Fullscreen State Machine states
+ */
+typedef enum FullscreenState {
+  FULLSCREEN_STATE_WINDOWED    = 0,
+  FULLSCREEN_STATE_FULLSCREEN = 1,
+} FullscreenState;
+
+/*
+ * Fullscreen events emitted on state transitions
+ */
+typedef enum FullscreenEvent {
+  EVT_FULLSCREEN_ENTERED  = 200,
+  EVT_FULLSCREEN_EXITED  = 201,
+  EVT_FULLSCREEN_FAILED  = 202,
+} FullscreenEvent;
+
+/*
+ * Request types handled by this component
+ * Note: Uses REQ_CLIENT_FULLSCREEN defined in wm-hub.h
+ */
+
+/*
+ * Fullscreen component structure
+ * Tracks the fullscreen state machine and manages X property updates.
+ */
+typedef struct FullscreenComponent {
+  /* Base component interface */
+  HubComponent base;
+
+  /* Component-specific state */
+  bool initialized;
+} FullscreenComponent;
+
+/*
+ * Get the fullscreen component instance.
+ */
+FullscreenComponent* fullscreen_component_get(void);
+
+/*
+ * Check if component is initialized (for testing)
+ */
+bool fullscreen_component_is_initialized(void);
+
+/*
+ * Component initialization and shutdown
+ */
+
+/*
+ * Initialize the fullscreen component.
+ * Registers:
+ * - XCB handler for PROPERTY_NOTIFY
+ * - State machine guards and actions with registry
+ */
+bool fullscreen_component_init(void);
+
+/*
+ * Shutdown the fullscreen component.
+ */
+void fullscreen_component_shutdown(void);
+
+/*
+ * State Machine Template
+ */
+
+/*
+ * Create the Fullscreen State Machine template.
+ * Returns a template that can be used to create FullscreenSM instances.
+ *
+ * Template states:
+ *   FULLSCREEN_STATE_WINDOWED    (initial)
+ *   FULLSCREEN_STATE_FULLSCREEN
+ *
+ * Transitions:
+ *   WINDOWED → FULLSCREEN (guard: can_fullscreen, action: enter_fullscreen, emit: EVT_FULLSCREEN_ENTERED)
+ *   FULLSCREEN → WINDOWED (guard: can_unfullscreen, action: exit_fullscreen, emit: EVT_FULLSCREEN_EXITED)
+ */
+SMTemplate* fullscreen_sm_template_create(void);
+
+/*
+ * State Machine Accessors
+ * These functions manage SM instances for clients.
+ */
+
+/*
+ * Get the fullscreen state machine for a client.
+ * Creates the SM on first access (on-demand allocation).
+ */
+StateMachine* fullscreen_get_sm(Client* c);
+
+/*
+ * Check if a client is in fullscreen state.
+ */
+bool fullscreen_is_fullscreen(Client* c);
+
+/*
+ * Set fullscreen state directly (for raw_write from listeners).
+ * Does not run guards - use for authoritative external state changes.
+ */
+void fullscreen_set_state(Client* c, FullscreenState state);
+
+/*
+ * Helper: Get current fullscreen state for a client.
+ * Returns FULLSCREEN_STATE_WINDOWED if no SM exists.
+ */
+FullscreenState fullscreen_get_state(Client* c);
+
+/*
+ * XCB Property Update
+ */
+
+/*
+ * Update the _NET_WM_STATE X property to reflect fullscreen state.
+ * Called by the listener when property changes, or by the executor
+ * when fullscreen state changes.
+ */
+void fullscreen_update_x_property(Client* c, bool fullscreen);
+
+/*
+ * PropertyNotify handler for _NET_WM_STATE monitoring.
+ * Called by xcb_handler_dispatch() when a property changes on a client window.
+ */
+void fullscreen_on_property_notify(void* event);
+
+/*
+ * Guard Functions (for SM transitions)
+ * Registered with the SM registry.
+ */
+
+/*
+ * Check if a client can enter fullscreen mode.
+ * Returns true for managed clients.
+ */
+bool fullscreen_guard_can_fullscreen(StateMachine* sm, void* data);
+
+/*
+ * Check if a client can exit fullscreen mode.
+ * Always returns true.
+ */
+bool fullscreen_guard_can_unfullscreen(StateMachine* sm, void* data);
+
+/*
+ * Action Functions (for SM transitions)
+ * Registered with the SM registry.
+ * Note: These are for SM-side effects only. X operations are in the executor.
+ */
+
+/*
+ * Action called when entering fullscreen (via sm_transition).
+ * Note: X operations are handled separately in the executor.
+ */
+bool fullscreen_action_enter_fullscreen(StateMachine* sm, void* data);
+
+/*
+ * Action called when exiting fullscreen (via sm_transition).
+ * Note: X operations are handled separately in the executor.
+ */
+bool fullscreen_action_exit_fullscreen(StateMachine* sm, void* data);
+
+#endif /* _COMPONENT_FULLSCREEN_H_ */

--- a/src/components/fullscreen.h
+++ b/src/components/fullscreen.h
@@ -26,15 +26,15 @@
 #ifndef _COMPONENT_FULLSCREEN_H_
 #define _COMPONENT_FULLSCREEN_H_
 
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <xcb/xcb.h>
 
-#include "src/target/client.h"
-#include "src/xcb/xcb-handler.h"
-#include "src/sm/sm-template.h"
 #include "src/sm/sm-instance.h"
 #include "src/sm/sm-registry.h"
+#include "src/sm/sm-template.h"
+#include "src/target/client.h"
+#include "src/xcb/xcb-handler.h"
 #include "wm-hub.h"
 
 /*
@@ -46,7 +46,7 @@
  * Fullscreen State Machine states
  */
 typedef enum FullscreenState {
-  FULLSCREEN_STATE_WINDOWED    = 0,
+  FULLSCREEN_STATE_WINDOWED   = 0,
   FULLSCREEN_STATE_FULLSCREEN = 1,
 } FullscreenState;
 
@@ -54,9 +54,9 @@ typedef enum FullscreenState {
  * Fullscreen events emitted on state transitions
  */
 typedef enum FullscreenEvent {
-  EVT_FULLSCREEN_ENTERED  = 200,
-  EVT_FULLSCREEN_EXITED  = 201,
-  EVT_FULLSCREEN_FAILED  = 202,
+  EVT_FULLSCREEN_ENTERED = 20,
+  EVT_FULLSCREEN_EXITED  = 21,
+  EVT_FULLSCREEN_FAILED  = 22,
 } FullscreenEvent;
 
 /*

--- a/src/components/keybinding.c
+++ b/src/components/keybinding.c
@@ -40,32 +40,32 @@
 static const KeyBinding default_keybindings[] = {
   /* Focus actions */
   /* Mod+Enter: focus current client */
-  { XCB_MOD_MASK_4,                      36, KEYBINDING_ACTION_FOCUS_CLIENT, 0 }, /* keycode 36 = Return */
+  { XCB_MOD_MASK_4,                      36, KEYBINDING_ACTION_FOCUS_CLIENT,      0 }, /* keycode 36 = Return */
 
   /* Mod+Shift+Enter: focus previous client */
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 36, KEYBINDING_ACTION_FOCUS_PREV,   0 },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 36, KEYBINDING_ACTION_FOCUS_PREV,        0 },
 
   /* Tag view actions - Mod+1 through Mod+9 */
-  { XCB_MOD_MASK_4,                      10, KEYBINDING_ACTION_TAG_VIEW,     1 }, /* keycode 10 = 1 */
-  { XCB_MOD_MASK_4,                      11, KEYBINDING_ACTION_TAG_VIEW,     2 }, /* keycode 11 = 2 */
-  { XCB_MOD_MASK_4,                      12, KEYBINDING_ACTION_TAG_VIEW,     3 }, /* keycode 12 = 3 */
-  { XCB_MOD_MASK_4,                      13, KEYBINDING_ACTION_TAG_VIEW,     4 }, /* keycode 13 = 4 */
-  { XCB_MOD_MASK_4,                      14, KEYBINDING_ACTION_TAG_VIEW,     5 }, /* keycode 14 = 5 */
-  { XCB_MOD_MASK_4,                      15, KEYBINDING_ACTION_TAG_VIEW,     6 }, /* keycode 15 = 6 */
-  { XCB_MOD_MASK_4,                      16, KEYBINDING_ACTION_TAG_VIEW,     7 }, /* keycode 16 = 7 */
-  { XCB_MOD_MASK_4,                      17, KEYBINDING_ACTION_TAG_VIEW,     8 }, /* keycode 17 = 8 */
-  { XCB_MOD_MASK_4,                      18, KEYBINDING_ACTION_TAG_VIEW,     9 }, /* keycode 18 = 9 */
+  { XCB_MOD_MASK_4,                      10, KEYBINDING_ACTION_TAG_VIEW,          1 }, /* keycode 10 = 1 */
+  { XCB_MOD_MASK_4,                      11, KEYBINDING_ACTION_TAG_VIEW,          2 }, /* keycode 11 = 2 */
+  { XCB_MOD_MASK_4,                      12, KEYBINDING_ACTION_TAG_VIEW,          3 }, /* keycode 12 = 3 */
+  { XCB_MOD_MASK_4,                      13, KEYBINDING_ACTION_TAG_VIEW,          4 }, /* keycode 13 = 4 */
+  { XCB_MOD_MASK_4,                      14, KEYBINDING_ACTION_TAG_VIEW,          5 }, /* keycode 14 = 5 */
+  { XCB_MOD_MASK_4,                      15, KEYBINDING_ACTION_TAG_VIEW,          6 }, /* keycode 15 = 6 */
+  { XCB_MOD_MASK_4,                      16, KEYBINDING_ACTION_TAG_VIEW,          7 }, /* keycode 16 = 7 */
+  { XCB_MOD_MASK_4,                      17, KEYBINDING_ACTION_TAG_VIEW,          8 }, /* keycode 17 = 8 */
+  { XCB_MOD_MASK_4,                      18, KEYBINDING_ACTION_TAG_VIEW,          9 }, /* keycode 18 = 9 */
 
   /* Tag toggle actions - Mod+Shift+1 through Mod+Shift+9 */
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 10, KEYBINDING_ACTION_TAG_TOGGLE,   1 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 11, KEYBINDING_ACTION_TAG_TOGGLE,   2 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 12, KEYBINDING_ACTION_TAG_TOGGLE,   3 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 13, KEYBINDING_ACTION_TAG_TOGGLE,   4 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 14, KEYBINDING_ACTION_TAG_TOGGLE,   5 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 15, KEYBINDING_ACTION_TAG_TOGGLE,   6 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 16, KEYBINDING_ACTION_TAG_TOGGLE,   7 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 17, KEYBINDING_ACTION_TAG_TOGGLE,   8 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 18, KEYBINDING_ACTION_TAG_TOGGLE,   9 },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 10, KEYBINDING_ACTION_TAG_TOGGLE,        1 },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 11, KEYBINDING_ACTION_TAG_TOGGLE,        2 },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 12, KEYBINDING_ACTION_TAG_TOGGLE,        3 },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 13, KEYBINDING_ACTION_TAG_TOGGLE,        4 },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 14, KEYBINDING_ACTION_TAG_TOGGLE,        5 },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 15, KEYBINDING_ACTION_TAG_TOGGLE,        6 },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 16, KEYBINDING_ACTION_TAG_TOGGLE,        7 },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 17, KEYBINDING_ACTION_TAG_TOGGLE,        8 },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 18, KEYBINDING_ACTION_TAG_TOGGLE,        9 },
 
   /* Fullscreen toggle - Mod+f (keycode 41 = f) */
   { XCB_MOD_MASK_4,                      41, KEYBINDING_ACTION_TOGGLE_FULLSCREEN, 0 },

--- a/src/components/keybinding.c
+++ b/src/components/keybinding.c
@@ -66,6 +66,9 @@ static const KeyBinding default_keybindings[] = {
   { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 16, KEYBINDING_ACTION_TAG_TOGGLE,   7 },
   { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 17, KEYBINDING_ACTION_TAG_TOGGLE,   8 },
   { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 18, KEYBINDING_ACTION_TAG_TOGGLE,   9 },
+
+  /* Fullscreen toggle - Mod+f (keycode 41 = f) */
+  { XCB_MOD_MASK_4,                      41, KEYBINDING_ACTION_TOGGLE_FULLSCREEN, 0 },
 };
 
 static const KeyBinding* keybindings     = default_keybindings;
@@ -128,6 +131,8 @@ action_to_request_type(KeybindingAction action)
     return REQ_KEYBINDING_TAG_TOGGLE; /* = 5 = REQ_MONITOR_TAG_TOGGLE */
   case KEYBINDING_ACTION_CLOSE_CLIENT:
     return REQ_KEYBINDING_CLOSE;      /* = 6 = REQ_CLIENT_CLOSE */
+  case KEYBINDING_ACTION_TOGGLE_FULLSCREEN:
+    return REQ_CLIENT_FULLSCREEN;     /* Fullscreen request */
   default:
     return 0;
   }
@@ -224,6 +229,10 @@ execute_keybinding(const KeyBinding* binding)
 
   case KEYBINDING_ACTION_CLOSE_CLIENT:
     send_focus_request(REQ_KEYBINDING_CLOSE);
+    break;
+
+  case KEYBINDING_ACTION_TOGGLE_FULLSCREEN:
+    send_focus_request(REQ_CLIENT_FULLSCREEN);
     break;
 
   default:

--- a/src/components/keybinding.h
+++ b/src/components/keybinding.h
@@ -52,6 +52,7 @@ typedef enum {
   KEYBINDING_ACTION_TAG_VIEW,     /* View specific tag (1-9) */
   KEYBINDING_ACTION_TAG_TOGGLE,   /* Toggle tag visibility */
   KEYBINDING_ACTION_CLOSE_CLIENT, /* Close current client */
+  KEYBINDING_ACTION_TOGGLE_FULLSCREEN, /* Toggle fullscreen */
   KEYBINDING_ACTION_LAST,
 } KeybindingAction;
 

--- a/src/components/keybinding.h
+++ b/src/components/keybinding.h
@@ -46,12 +46,12 @@ enum KeybindingRequestType {
  * Used internally to classify what action a keybinding should trigger
  */
 typedef enum {
-  KEYBINDING_ACTION_FOCUS_CLIENT, /* Focus current client */
-  KEYBINDING_ACTION_FOCUS_PREV,   /* Focus previous client */
-  KEYBINDING_ACTION_FOCUS_NEXT,   /* Focus next client */
-  KEYBINDING_ACTION_TAG_VIEW,     /* View specific tag (1-9) */
-  KEYBINDING_ACTION_TAG_TOGGLE,   /* Toggle tag visibility */
-  KEYBINDING_ACTION_CLOSE_CLIENT, /* Close current client */
+  KEYBINDING_ACTION_FOCUS_CLIENT,      /* Focus current client */
+  KEYBINDING_ACTION_FOCUS_PREV,        /* Focus previous client */
+  KEYBINDING_ACTION_FOCUS_NEXT,        /* Focus next client */
+  KEYBINDING_ACTION_TAG_VIEW,          /* View specific tag (1-9) */
+  KEYBINDING_ACTION_TAG_TOGGLE,        /* Toggle tag visibility */
+  KEYBINDING_ACTION_CLOSE_CLIENT,      /* Close current client */
   KEYBINDING_ACTION_TOGGLE_FULLSCREEN, /* Toggle fullscreen */
   KEYBINDING_ACTION_LAST,
 } KeybindingAction;

--- a/wm-hub.h
+++ b/wm-hub.h
@@ -21,7 +21,7 @@ typedef uint32_t EventType;
  * Request type constants
  * Used by components to handle requests via hub routing.
  */
-enum RequestType {
+enum {
   REQ_CLIENT_FULLSCREEN = 10,
 };
 

--- a/wm-hub.h
+++ b/wm-hub.h
@@ -17,6 +17,14 @@ typedef uint32_t TargetType;
 typedef uint32_t RequestType;
 typedef uint32_t EventType;
 
+/*
+ * Request type constants
+ * Used by components to handle requests via hub routing.
+ */
+enum RequestType {
+  REQ_CLIENT_FULLSCREEN = 10,
+};
+
 /* Target types */
 enum {
   TARGET_TYPE_CLIENT,

--- a/wm-xcb-ewmh.c
+++ b/wm-xcb-ewmh.c
@@ -42,3 +42,54 @@ print_atom_name(xcb_atom_t atom)
 
   free(reply);
 }
+
+/*
+ * Check if _NET_WM_STATE contains _NET_WM_STATE_FULLSCREEN for a window.
+ *
+ * Uses xcb_get_property directly to get the raw atom list.
+ */
+bool
+ewmh_check_wm_state_fullscreen(xcb_ewmh_connection_t* ewmh, xcb_window_t window)
+{
+  if (ewmh == NULL)
+    return false;
+
+  /* Get the _NET_WM_STATE property directly */
+  xcb_get_property_cookie_t cookie = xcb_get_property_unchecked(
+      dpy, 0, window, ewmh->_NET_WM_STATE, XCB_GET_PROPERTY_TYPE_ANY, 0, 1024);
+
+  xcb_get_property_reply_t* reply = xcb_get_property_reply(dpy, cookie, NULL);
+  if (reply == NULL)
+    return false;
+
+  /* Check format (should be 32 bits for atoms) */
+  if (reply->format != 32) {
+    free(reply);
+    return false;
+  }
+
+  /* Get length in atoms (format * length / 32 = number of atoms) */
+  uint32_t length = xcb_get_property_value_length(reply);
+  if (length == 0) {
+    free(reply);
+    return false;
+  }
+
+  xcb_atom_t* atoms = (xcb_atom_t*) xcb_get_property_value(reply);
+  if (atoms == NULL) {
+    free(reply);
+    return false;
+  }
+
+  /* Check if _NET_WM_STATE_FULLSCREEN is in the list */
+  uint32_t count = length / sizeof(xcb_atom_t);
+  for (uint32_t i = 0; i < count; i++) {
+    if (atoms[i] == ewmh->_NET_WM_STATE_FULLSCREEN) {
+      free(reply);
+      return true;
+    }
+  }
+
+  free(reply);
+  return false;
+}

--- a/wm-xcb-ewmh.h
+++ b/wm-xcb-ewmh.h
@@ -1,8 +1,20 @@
 #ifndef _WM_XCB_EWMH_H_
 #define _WM_XCB_EWMH_H_
 
+#include <stdbool.h>
+#include <xcb/xcb.h>
+#include <xcb/xcb_ewmh.h>
+
+/* EWMH connection global - defined in wm-xcb-ewmh.c */
+extern xcb_ewmh_connection_t* ewmh;
+
 void setup_ewmh();
 void destruct_ewmh();
 void print_atom_name(xcb_atom_t atom);
+
+/*
+ * Check if _NET_WM_STATE contains _NET_WM_STATE_FULLSCREEN for a window.
+ */
+bool ewmh_check_wm_state_fullscreen(xcb_ewmh_connection_t* ewmh, xcb_window_t window);
 
 #endif

--- a/wm.c
+++ b/wm.c
@@ -6,14 +6,14 @@
 #include "wm-running.h"
 #include "wm-signals.h"
 
+#include "wm-hub.h"
 #include "wm-states.h"
 #include "wm-xcb-ewmh.h"
 #include "wm-xcb.h"
-#include "wm-hub.h"
 
+#include "src/components/client-list.h"
 #include "src/components/fullscreen.h"
 #include "src/components/keybinding.h"
-#include "src/components/client-list.h"
 #include "src/components/monitor-manager.h"
 
 #include "wm.h"

--- a/wm.c
+++ b/wm.c
@@ -9,19 +9,47 @@
 #include "wm-states.h"
 #include "wm-xcb-ewmh.h"
 #include "wm-xcb.h"
+#include "wm-hub.h"
+
+#include "src/components/fullscreen.h"
+#include "src/components/keybinding.h"
+#include "src/components/client-list.h"
+#include "src/components/monitor-manager.h"
 
 #include "wm.h"
 
 int
 main(int argc, char** argv)
 {
+  /* Initialize core systems */
   setup_signals();
   setup_xcb();
   setup_ewmh();
   setup_state_machine();
+
+  /* Initialize hub first */
+  hub_init();
+
+  /* Initialize components */
+  fullscreen_component_init();
+  keybinding_init();
+  client_list_component_init();
+  monitor_manager_init();
+
+  /* Main event loop */
   while (running) {
     handle_xcb_events();
   }
+
+  /* Shutdown in reverse order */
+  monitor_manager_shutdown();
+  client_list_component_shutdown();
+  keybinding_shutdown();
+  fullscreen_component_shutdown();
+
+  hub_shutdown();
+
+  /* Cleanup core systems */
   destruct_state_machine();
   destruct_ewmh();
   destruct_xcb();


### PR DESCRIPTION
## Summary

Implements fullscreen functionality for the window manager with a complete request-to-event path following the architecture.

## What was built

- **FullscreenSM template**: WINDOWED ↔ FULLSCREEN state machine
- **Keybinding**: Mod+f toggles fullscreen on current client
- **Executor**: Handles REQ_CLIENT_FULLSCREEN request, calls X via EWMH
- **Listener**: PROPERTY_NOTIFY handler for _NET_WM_STATE changes
- **Events**: EVT_FULLSCREEN_ENTERED, EVT_FULLSCREEN_EXITED, EVT_FULLSCREEN_FAILED

## Files changed

-  - Fullscreen component header
-  - SM template, guards, actions, executor, listener
-  - Added REQ_CLIENT_FULLSCREEN request type
-  - Added ewmh_check_wm_state_fullscreen helper
-  - Added fullscreen keybinding (Mod+f)
-  - Initialize components in main event loop

## Acceptance criteria

- [x] Mod+f toggles fullscreen on current client
- [x] State machine transitions correctly  
- [x] Event is emitted on fullscreen change
- [x] X property reflects fullscreen state

Closes #13