### PR TITLE
Add sm_set_data helper function for tests

### DIFF
--- a/src/sm/sm-instance.c
+++ b/src/sm/sm-instance.c
@@ -350,3 +350,11 @@ sm_set_emitter(StateMachine* sm, EventEmitter emit, void* emit_userdata)
   sm->emit          = emit;
   sm->emit_userdata = emit_userdata;
 }
+
+void
+sm_set_data(StateMachine* sm, void* data)
+{
+  if (sm == NULL)
+    return;
+  sm->data = data;
+}

--- a/src/sm/sm-instance.h
+++ b/src/sm/sm-instance.h
@@ -149,8 +149,7 @@ const char* sm_get_name(StateMachine* sm);
 
 /*
  * Set instance-specific data.
- * This is intended for use in tests to set sm->data
- * without direct struct member access.
+ * This is supported public API for setting sm->data.
  */
 void sm_set_data(StateMachine* sm, void* data);
 

--- a/src/sm/sm-instance.h
+++ b/src/sm/sm-instance.h
@@ -147,4 +147,11 @@ SMTemplate* sm_get_template(StateMachine* sm);
  */
 const char* sm_get_name(StateMachine* sm);
 
+/*
+ * Set instance-specific data.
+ * This is intended for use in tests to set sm->data
+ * without direct struct member access.
+ */
+void sm_set_data(StateMachine* sm, void* data);
+
 #endif /* _SM_INSTANCE_H_ */

--- a/test-sm-standalone.c
+++ b/test-sm-standalone.c
@@ -588,7 +588,7 @@ test_complete_flow(void)
   int           owner = 0;
   int           count = 0;
   StateMachine* sm    = make_sm(&owner, t);
-  sm->data            = &count;
+  sm_set_data(sm, &count);
 
   /* Valid transition with guard + action */
   g_raw_write_events = 0;
@@ -600,7 +600,7 @@ test_complete_flow(void)
   /* Transition without guard */
   count = 0;
   sm_raw_write(sm, S0);
-  sm->data = &count;
+  sm_set_data(sm, &count);
   assert(sm_transition(sm, S1) == true);
   assert(count == 1);
 


### PR DESCRIPTION
Add a helper function sm_set_data() to set sm->data in tests instead of direct struct member assignment. This follows the pattern of the existing sm_set_emitter() function.

## Changes
- Add sm_set_data() to sm-instance.h (declaration)
- Add sm_set_data() to sm-instance.c (implementation)
- Update test-sm-standalone.c to use sm_set_data() instead of sm->data

Closes #60