### PR TITLE
Cleanup duplicate hook removal test code

### DIFF
--- a/test-sm-standalone.c
+++ b/test-sm-standalone.c
@@ -180,15 +180,6 @@ hook_post_emit(StateMachine* sm, void* ud)
   g_hook_order[g_hook_order_count++] = SM_HOOK_POST_EMIT;
 }
 
-static int g_hook_removal_count = 0;
-static void
-hook_removal_fn(StateMachine* sm, void* ud)
-{
-  (void) sm;
-  (void) ud;
-  g_hook_removal_count++;
-}
-
 static void
 hook_with_userdata(StateMachine* sm, void* userdata)
 {


### PR DESCRIPTION
Remove duplicate hook removal test code in test-sm-standalone.c.

There were two almost-identical hook functions (hook_removal_fn and hook_remove_test) and two counters (g_hook_removal_count and g_hook_remove_count).

Changes:
- Removed g_hook_removal_count variable
- Removed hook_removal_fn function
- Kept g_hook_remove_count and hook_remove_test (used in test_hooks_removal)

Acceptance Criteria:
- [x] Test still passes after cleanup
- [x] No duplicate code remaining

Closes #58 