### PR TITLE
Focus component with ENTER_NOTIFY handler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ TEST_SRC = \
 	test-wm-tag.c \
 	test-target-client.c \
 	test-client-list-component.c \
+	test-focus-component.c \
 	test-wm-keybinding.c \
 	test-wm-monitor-manager.c
 

--- a/src/components/focus.c
+++ b/src/components/focus.c
@@ -1,0 +1,555 @@
+/*
+ * Focus Component Implementation
+ *
+ * Handles focus state for X11 clients using the state machine pattern.
+ * Manages the focus state machine and XCB events for focus tracking.
+ *
+ * The component provides:
+ * - FocusSM template: UNFOCUSED ↔ FOCUSED
+ * - XCB listener for ENTER_NOTIFY and LEAVE_NOTIFY
+ * - raw_write to SM on mouse enter/leave events
+ * - Guards for transition validation
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "src/sm/sm-instance.h"
+#include "src/sm/sm-registry.h"
+#include "src/sm/sm-template.h"
+#include "src/target/client.h"
+#include "src/xcb/xcb-handler.h"
+#include "wm-hub.h"
+#include "wm-log.h"
+
+#include "focus.h"
+
+/*
+ * Cached FocusSM template - created once at init, reused for all clients.
+ * Avoids repeated malloc/free per client.
+ */
+static SMTemplate* cached_focus_template = NULL;
+
+/*
+ * Global component instance
+ */
+static FocusComponent focus_component = {
+  .base = {
+           .name       = FOCUS_COMPONENT_NAME,
+           .requests   = NULL, /* Focus is driven by XCB events, not requests */
+      .targets    = (TargetType[]) { TARGET_TYPE_CLIENT, TARGET_TYPE_NONE },
+           .executor   = NULL,
+           .registered = false,
+           },
+  .initialized    = false,
+  .focused_window = 0,
+};
+
+/*
+ * Track if static initialization has occurred
+ */
+static bool static_init_done = false;
+
+static void
+do_static_init(void)
+{
+  if (static_init_done)
+    return;
+  static_init_done                = true;
+  focus_component.initialized     = false;
+  focus_component.base.registered = false;
+  focus_component.focused_window  = 0;
+}
+
+__attribute__((constructor)) static void
+ensure_static_init(void)
+{
+  do_static_init();
+}
+
+/*
+ * Internal helper to reset component state
+ */
+static void
+focus_component_reset(void)
+{
+  focus_component.initialized    = false;
+  focus_component.focused_window = 0;
+}
+
+/*
+ * Get the focus component instance
+ */
+FocusComponent*
+focus_component_get(void)
+{
+  return &focus_component;
+}
+
+/*
+ * Check if component is initialized
+ */
+bool
+focus_component_is_initialized(void)
+{
+  return focus_component.initialized;
+}
+
+/*
+ * SM Event Emitter
+ *
+ * This function is passed to sm_create() to handle event emission.
+ * It emits events with the correct target (client window ID).
+ */
+static void
+focus_sm_emit(StateMachine* sm, uint32_t from_state, uint32_t to_state, void* userdata)
+{
+  (void) sm;
+  (void) from_state;
+
+  Client* c = (Client*) userdata;
+  if (c == NULL)
+    return;
+
+  EventType event = (to_state == FOCUS_STATE_FOCUSED)
+                        ? EVT_CLIENT_FOCUSED
+                        : EVT_CLIENT_UNFOCUSED;
+
+  hub_emit(event, c->window, NULL);
+}
+
+/*
+ * Guard functions
+ */
+
+/*
+ * Check if a client can receive focus.
+ * Returns true for managed, focusable clients.
+ */
+bool
+focus_guard_can_focus(StateMachine* sm, void* data)
+{
+  (void) data;
+
+  if (sm == NULL || sm->owner == NULL)
+    return false;
+
+  Client* c = (Client*) sm->owner;
+  return c->managed && c->focusable;
+}
+
+/*
+ * Check if a client can lose focus.
+ * Always returns true.
+ */
+bool
+focus_guard_can_unfocus(StateMachine* sm, void* data)
+{
+  (void) sm;
+  (void) data;
+  return true;
+}
+
+/*
+ * State Machine Template
+ */
+SMTemplate*
+focus_sm_template_create(void)
+{
+  /* Define states */
+  static uint32_t states[] = {
+    FOCUS_STATE_UNFOCUSED,
+    FOCUS_STATE_FOCUSED,
+  };
+
+  /* Define transitions:
+   * UNFOCUSED → FOCUSED (on ENTER_NOTIFY, emit: EVT_CLIENT_FOCUSED)
+   * FOCUSED → UNFOCUSED (on LEAVE_NOTIFY, emit: EVT_CLIENT_UNFOCUSED)
+   */
+  static SMTransition transitions[] = {
+    {
+     .from_state = FOCUS_STATE_UNFOCUSED,
+     .to_state   = FOCUS_STATE_FOCUSED,
+     .guard_fn   = "focus_guard_can_focus",
+     .action_fn  = NULL,                  /* X operations handled by listener */
+        .emit_event = EVT_CLIENT_FOCUSED,
+     },
+    {
+     .from_state = FOCUS_STATE_FOCUSED,
+     .to_state   = FOCUS_STATE_UNFOCUSED,
+     .guard_fn   = "focus_guard_can_unfocus",
+     .action_fn  = NULL, /* X operations handled by listener */
+        .emit_event = EVT_CLIENT_UNFOCUSED,
+     },
+  };
+
+  SMTemplate* tmpl = sm_template_create(
+      "focus",
+      states,
+      2,
+      transitions,
+      2,
+      FOCUS_STATE_UNFOCUSED);
+
+  if (tmpl == NULL) {
+    LOG_ERROR("Failed to create focus state machine template");
+    return NULL;
+  }
+
+  return tmpl;
+}
+
+/*
+ * State Machine Accessors
+ */
+
+/*
+ * Get or create the focus state machine for a client.
+ */
+StateMachine*
+focus_get_sm(Client* c)
+{
+  if (c == NULL)
+    return NULL;
+
+  StateMachine* sm = c->sms.focus;
+  if (sm != NULL)
+    return sm;
+
+  /* Use cached template if available, otherwise create one */
+  SMTemplate* tmpl = cached_focus_template;
+  if (tmpl == NULL) {
+    tmpl = focus_sm_template_create();
+    if (tmpl == NULL) {
+      LOG_ERROR("Failed to create focus SM template for client");
+      return NULL;
+    }
+  }
+
+  sm = sm_create(c, tmpl, focus_sm_emit, c);
+  if (sm == NULL) {
+    LOG_ERROR("Failed to create focus SM instance for client");
+    return NULL;
+  }
+
+  /* Store in client */
+  c->sms.focus = sm;
+
+  LOG_DEBUG("Created focus SM for client window=%u", c->window);
+  return sm;
+}
+
+/*
+ * Check if a client is in focus state
+ */
+bool
+focus_is_focused(Client* c)
+{
+  if (c == NULL)
+    return false;
+
+  StateMachine* sm = c->sms.focus;
+  if (sm == NULL)
+    return false;
+
+  return sm_get_state(sm) == FOCUS_STATE_FOCUSED;
+}
+
+/*
+ * Get current focus state for a client
+ */
+FocusState
+focus_get_state(Client* c)
+{
+  if (c == NULL)
+    return FOCUS_STATE_UNFOCUSED;
+
+  StateMachine* sm = c->sms.focus;
+  if (sm == NULL)
+    return FOCUS_STATE_UNFOCUSED;
+
+  return (FocusState) sm_get_state(sm);
+}
+
+/*
+ * Set focus state directly (for raw_write from listeners).
+ * Does not run guards - use for authoritative external state changes.
+ */
+void
+focus_set_state(Client* c, FocusState state)
+{
+  if (c == NULL)
+    return;
+
+  StateMachine* sm = focus_get_sm(c);
+  if (sm == NULL) {
+    LOG_WARN("Cannot set focus state: failed to get/create SM");
+    return;
+  }
+
+  sm_raw_write(sm, state);
+
+  /* Keep focused_window in sync with SM state */
+  if (state == FOCUS_STATE_FOCUSED) {
+    /* Unfocus any previously focused client */
+    if (focus_component.focused_window != 0 &&
+        focus_component.focused_window != c->window) {
+      Client* prev = client_get_by_window(focus_component.focused_window);
+      if (prev != NULL && prev != c && prev->sms.focus != NULL) {
+        sm_raw_write(prev->sms.focus, FOCUS_STATE_UNFOCUSED);
+      }
+    }
+    focus_component.focused_window = c->window;
+  } else if (focus_component.focused_window == c->window) {
+    focus_component.focused_window = 0;
+  }
+}
+
+/*
+ * Get the currently focused client
+ */
+Client*
+focus_get_focused_client(void)
+{
+  if (focus_component.focused_window == 0)
+    return NULL;
+
+  return client_get_by_window(focus_component.focused_window);
+}
+
+/*
+ * Get the currently focused window
+ */
+xcb_window_t
+focus_get_focused_window(void)
+{
+  return focus_component.focused_window;
+}
+
+/*
+ * XCB Event Handlers
+ */
+
+/*
+ * Handle XCB_ENTER_NOTIFY event.
+ * Sets focus to the entered client window.
+ */
+void
+focus_on_enter_notify(void* event)
+{
+  xcb_enter_notify_event_t* e = (xcb_enter_notify_event_t*) event;
+
+  LOG_DEBUG("ENTER_NOTIFY: window=%u, mode=%d, detail=%d",
+            e->event, e->mode, e->detail);
+
+  /* Skip if this is not a normal enter (e.g., pointer grab) */
+  if (e->mode != XCB_NOTIFY_MODE_NORMAL)
+    return;
+
+  /* Skip if detail indicates different focus reason */
+  if (e->detail == XCB_NOTIFY_DETAIL_INFERIOR)
+    return;
+
+  /* Get client for this window */
+  Client* c = client_get_by_window(e->event);
+  if (c == NULL) {
+    LOG_DEBUG("No client for enter notify window=%u", e->event);
+    return;
+  }
+
+  /* Check if client is focusable */
+  if (!c->focusable || !c->managed) {
+    LOG_DEBUG("Client window=%u is not focusable or not managed", e->event);
+    return;
+  }
+
+  /* Get or create the SM (on-demand) */
+  StateMachine* sm = focus_get_sm(c);
+  if (sm == NULL) {
+    LOG_WARN("Focus listener: failed to get SM for client window=%u", c->window);
+    return;
+  }
+
+  /* Get current SM state */
+  FocusState current = (FocusState) sm_get_state(sm);
+
+  /* Only transition if not already focused */
+  if (current == FOCUS_STATE_UNFOCUSED) {
+    /* First, unfocus the previously focused client if any */
+    if (focus_component.focused_window != 0 &&
+        focus_component.focused_window != c->window) {
+      Client* prev = client_get_by_window(focus_component.focused_window);
+      if (prev != NULL && prev != c) {
+        StateMachine* prev_sm = prev->sms.focus;
+        if (prev_sm != NULL) {
+          FocusState prev_state = (FocusState) sm_get_state(prev_sm);
+          if (prev_state == FOCUS_STATE_FOCUSED) {
+            LOG_DEBUG("Focus: unfocusing previous client window=%u",
+                      focus_component.focused_window);
+            sm_raw_write(prev_sm, FOCUS_STATE_UNFOCUSED);
+          }
+        }
+      }
+    }
+
+    /* Now focus the new client */
+    LOG_DEBUG("Focus: setting focus to client window=%u", c->window);
+    sm_raw_write(sm, FOCUS_STATE_FOCUSED);
+    focus_component.focused_window = c->window;
+  } else {
+    /* Already focused, just update the tracked window */
+    focus_component.focused_window = c->window;
+  }
+}
+
+/*
+ * Handle XCB_LEAVE_NOTIFY event.
+ * Clears focus when mouse leaves a client window.
+ */
+void
+focus_on_leave_notify(void* event)
+{
+  xcb_leave_notify_event_t* e = (xcb_leave_notify_event_t*) event;
+
+  LOG_DEBUG("LEAVE_NOTIFY: window=%u, mode=%d, detail=%d",
+            e->event, e->mode, e->detail);
+
+  /* Skip if this is not a normal leave (e.g., pointer grab) */
+  if (e->mode != XCB_NOTIFY_MODE_NORMAL)
+    return;
+
+  /* Skip if detail indicates different focus reason */
+  if (e->detail == XCB_NOTIFY_DETAIL_INFERIOR)
+    return;
+
+  /* Get client for this window */
+  Client* c = client_get_by_window(e->event);
+  if (c == NULL) {
+    LOG_DEBUG("No client for leave notify window=%u", e->event);
+    return;
+  }
+
+  /* Get the SM */
+  StateMachine* sm = c->sms.focus;
+  if (sm == NULL) {
+    /* SM not yet created, nothing to unfocus */
+    return;
+  }
+
+  /* Get current SM state */
+  FocusState current = (FocusState) sm_get_state(sm);
+
+  /* Only transition if currently focused */
+  if (current == FOCUS_STATE_FOCUSED) {
+    LOG_DEBUG("Focus: clearing focus for client window=%u", c->window);
+    sm_raw_write(sm, FOCUS_STATE_UNFOCUSED);
+
+    /* Clear focused window if this was the focused client */
+    if (focus_component.focused_window == c->window) {
+      focus_component.focused_window = 0;
+    }
+  }
+}
+
+/*
+ * Component initialization
+ */
+bool
+focus_component_init(void)
+{
+  /* Check if already registered in hub */
+  HubComponent* existing = hub_get_component_by_name(FOCUS_COMPONENT_NAME);
+  if (existing != NULL) {
+    if (focus_component.initialized) {
+      LOG_DEBUG("Focus component already initialized and registered");
+      return true;
+    }
+    LOG_DEBUG("Component registered with hub, completing initialization");
+    focus_component.initialized = true;
+    return true;
+  }
+
+  /* Reset if inconsistent state */
+  if (focus_component.initialized) {
+    LOG_DEBUG("Focus component in inconsistent state, resetting");
+    focus_component_reset();
+  }
+
+  LOG_DEBUG("Initializing focus component");
+
+  /* Register guards with SM registry */
+  sm_register_guard("focus_guard_can_focus", focus_guard_can_focus);
+  sm_register_guard("focus_guard_can_unfocus", focus_guard_can_unfocus);
+
+  /* Register with hub */
+  hub_register_component(&focus_component.base);
+
+  /* Register XCB handlers for ENTER_NOTIFY and LEAVE_NOTIFY */
+  int result = 0;
+
+  result |= xcb_handler_register(
+      XCB_ENTER_NOTIFY,
+      &focus_component.base,
+      focus_on_enter_notify);
+
+  result |= xcb_handler_register(
+      XCB_LEAVE_NOTIFY,
+      &focus_component.base,
+      focus_on_leave_notify);
+
+  if (result != 0) {
+    LOG_ERROR("Failed to register some XCB handlers for focus component");
+    /* Clean up any handlers that were already registered */
+    xcb_handler_unregister_component(&focus_component.base);
+    /* Unregister guards that were registered before the failure */
+    sm_unregister_guard("focus_guard_can_focus");
+    sm_unregister_guard("focus_guard_can_unfocus");
+    /* Unregister from hub since we're not fully initialized */
+    hub_unregister_component(FOCUS_COMPONENT_NAME);
+    focus_component_reset();
+    return false;
+  }
+
+  /* Cache the template for future clients */
+  cached_focus_template = focus_sm_template_create();
+
+  focus_component.initialized = true;
+  LOG_DEBUG("Focus component initialized successfully");
+
+  return true;
+}
+
+/*
+ * Component shutdown
+ */
+void
+focus_component_shutdown(void)
+{
+  if (!focus_component.initialized) {
+    return;
+  }
+
+  LOG_DEBUG("Shutting down focus component");
+
+  /* Unregister XCB handlers */
+  xcb_handler_unregister_component(&focus_component.base);
+
+  /* Unregister from hub */
+  hub_unregister_component(FOCUS_COMPONENT_NAME);
+
+  /* Unregister guards */
+  sm_unregister_guard("focus_guard_can_focus");
+  sm_unregister_guard("focus_guard_can_unfocus");
+
+  /* Free cached template */
+  if (cached_focus_template != NULL) {
+    sm_template_destroy(cached_focus_template);
+    cached_focus_template = NULL;
+  }
+
+  /* Clear focused window */
+  focus_component.focused_window = 0;
+
+  focus_component.initialized = false;
+  LOG_DEBUG("Focus component shutdown complete");
+}

--- a/src/components/focus.h
+++ b/src/components/focus.h
@@ -1,0 +1,195 @@
+/*
+ * Focus Component
+ *
+ * Handles focus state for X11 clients using the state machine pattern.
+ * Manages the focus state machine for tracking which client has focus.
+ *
+ * Component lifecycle:
+ * - on_init(): register ENTER_NOTIFY handler
+ * - on_adopt(): create SM instance for client
+ * - listener: raw-write to SM on XCB events
+ *
+ * XCB Events Handled:
+ * - XCB_ENTER_NOTIFY - mouse entered client window (focus gained)
+ * - XCB_LEAVE_NOTIFY - mouse left client window (focus lost)
+ *
+ * Events Emitted:
+ * - EVT_CLIENT_FOCUSED - client gained focus
+ * - EVT_CLIENT_UNFOCUSED - client lost focus
+ *
+ * Acceptance Criteria:
+ * [x] Mouse entering client window triggers focus
+ * [x] Mouse leaving client window unfocuses it
+ * [x] State machine transitions correctly
+ * [x] Event is emitted on focus change
+ */
+
+#ifndef _COMPONENT_FOCUS_H_
+#define _COMPONENT_FOCUS_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <xcb/xcb.h>
+
+#include "src/sm/sm-instance.h"
+#include "src/sm/sm-registry.h"
+#include "src/sm/sm-template.h"
+#include "src/target/client.h"
+#include "src/xcb/xcb-handler.h"
+#include "wm-hub.h"
+
+/*
+ * Component name
+ */
+#define FOCUS_COMPONENT_NAME "focus"
+
+/*
+ * Focus State Machine states
+ */
+typedef enum FocusState {
+  FOCUS_STATE_UNFOCUSED = 0,
+  FOCUS_STATE_FOCUSED   = 1,
+} FocusState;
+
+/*
+ * Focus events emitted on state transitions
+ */
+typedef enum FocusEvent {
+  EVT_CLIENT_UNFOCUSED = 30, /* Client lost focus */
+  EVT_CLIENT_FOCUSED   = 31, /* Client gained focus */
+} FocusEvent;
+
+/*
+ * Focus component structure
+ * Tracks the focus state machine and manages focus state.
+ */
+typedef struct FocusComponent {
+  /* Base component interface */
+  HubComponent base;
+
+  /* Component-specific state */
+  bool initialized;
+
+  /* Currently focused client window (0 if none) */
+  xcb_window_t focused_window;
+} FocusComponent;
+
+/*
+ * Get the focus component instance.
+ */
+FocusComponent* focus_component_get(void);
+
+/*
+ * Check if component is initialized (for testing)
+ */
+bool focus_component_is_initialized(void);
+
+/*
+ * Component initialization and shutdown
+ */
+
+/*
+ * Initialize the focus component.
+ * Registers:
+ * - XCB handler for ENTER_NOTIFY and LEAVE_NOTIFY
+ */
+bool focus_component_init(void);
+
+/*
+ * Shutdown the focus component.
+ */
+void focus_component_shutdown(void);
+
+/*
+ * State Machine Template
+ */
+
+/*
+ * Create the Focus State Machine template.
+ * Returns a template that can be used to create FocusSM instances.
+ *
+ * Template states:
+ *   FOCUS_STATE_UNFOCUSED (initial)
+ *   FOCUS_STATE_FOCUSED
+ *
+ * Transitions:
+ *   UNFOCUSED → FOCUSED (raw_write on ENTER_NOTIFY, emit: EVT_CLIENT_FOCUSED)
+ *   FOCUSED → UNFOCUSED (raw_write on LEAVE_NOTIFY, emit: EVT_CLIENT_UNFOCUSED)
+ */
+SMTemplate* focus_sm_template_create(void);
+
+/*
+ * State Machine Accessors
+ * These functions manage SM instances for clients.
+ */
+
+/*
+ * Get the focus state machine for a client.
+ * Creates the SM on first access (on-demand allocation).
+ */
+StateMachine* focus_get_sm(Client* c);
+
+/*
+ * Check if a client is in focus state.
+ */
+bool focus_is_focused(Client* c);
+
+/*
+ * Get current focus state for a client.
+ * Returns FOCUS_STATE_UNFOCUSED if no SM exists.
+ */
+FocusState focus_get_state(Client* c);
+
+/*
+ * Set focus state directly (for raw_write from listeners).
+ * Does not run guards - use for authoritative external state changes.
+ */
+void focus_set_state(Client* c, FocusState state);
+
+/*
+ * Get the currently focused client.
+ * Returns NULL if no client has focus.
+ */
+Client* focus_get_focused_client(void);
+
+/*
+ * Get the currently focused window.
+ * Returns 0 if no window has focus.
+ */
+xcb_window_t focus_get_focused_window(void);
+
+/*
+ * XCB Event Handlers
+ * Called by the xcb_handler dispatch system.
+ */
+
+/*
+ * Handle XCB_ENTER_NOTIFY event.
+ * Sets focus to the entered client.
+ */
+void focus_on_enter_notify(void* event);
+
+/*
+ * Handle XCB_LEAVE_NOTIFY event.
+ * Clears focus from the left client.
+ */
+void focus_on_leave_notify(void* event);
+
+/*
+ * Guard Functions (for SM transitions)
+ * Registered with the SM registry.
+ */
+
+/*
+ * Check if a client can receive focus.
+ * Returns true for managed, focusable clients.
+ */
+bool focus_guard_can_focus(StateMachine* sm, void* data);
+
+/*
+ * Check if a client can lose focus.
+ * Always returns true.
+ */
+bool focus_guard_can_unfocus(StateMachine* sm, void* data);
+
+#endif /* _COMPONENT_FOCUS_H_ */

--- a/test-focus-component.c
+++ b/test-focus-component.c
@@ -1,0 +1,476 @@
+/*
+ * Focus Component Tests
+ *
+ * Tests for the focus component that handles XCB events
+ * for client focus management.
+ */
+
+#include <string.h>
+#include "src/components/client-list.h"
+#include "src/components/focus.h"
+#include "src/xcb/xcb-handler.h"
+#include "test-registry.h"
+#include "test-target-client.h"
+#include "test-wm.h"
+#include "wm-hub.h"
+
+/*
+ * Event tracking state for focus tests
+ */
+static struct {
+  bool     focused_received;
+  bool     unfocused_received;
+  TargetID focused_target;
+  TargetID unfocused_target;
+} focus_test_events;
+
+/*
+ * Event handler for focus tests - uses static tracking
+ */
+static void
+focus_test_event_handler(Event e)
+{
+  if (e.type == EVT_CLIENT_FOCUSED) {
+    focus_test_events.focused_received = true;
+    focus_test_events.focused_target   = e.target;
+  } else if (e.type == EVT_CLIENT_UNFOCUSED) {
+    focus_test_events.unfocused_received = true;
+    focus_test_events.unfocused_target   = e.target;
+  }
+}
+
+/*
+ * Test component initialization
+ */
+void
+test_focus_component_init(void)
+{
+  LOG_CLEAN("== Testing focus component init");
+
+  hub_init();
+  sm_registry_init();
+  xcb_handler_init();
+
+  /* Initially not initialized */
+  assert(focus_component_is_initialized() == false);
+
+  /* Initialize should succeed */
+  bool result = focus_component_init();
+  assert(result == true);
+  assert(focus_component_is_initialized() == true);
+
+  /* Re-init should be safe */
+  result = focus_component_init();
+  assert(result == true);
+
+  /* Should have registered XCB handlers */
+  assert(xcb_handler_count_for_type(XCB_ENTER_NOTIFY) >= 1);
+  assert(xcb_handler_count_for_type(XCB_LEAVE_NOTIFY) >= 1);
+
+  /* Should have registered with hub */
+  HubComponent* comp = hub_get_component_by_name(FOCUS_COMPONENT_NAME);
+  assert(comp != NULL);
+
+  /* Cleanup */
+  focus_component_shutdown();
+  xcb_handler_shutdown();
+  sm_registry_shutdown();
+  hub_shutdown();
+}
+
+/*
+ * Test component shutdown
+ */
+void
+test_focus_component_shutdown(void)
+{
+  LOG_CLEAN("== Testing focus component shutdown");
+
+  hub_init();
+  sm_registry_init();
+  xcb_handler_init();
+  client_list_init();
+  focus_component_init();
+
+  /* Verify handlers are registered */
+  assert(xcb_handler_count_for_type(XCB_ENTER_NOTIFY) >= 1);
+
+  focus_component_shutdown();
+
+  /* Handlers should be unregistered */
+  assert(xcb_handler_count_for_type(XCB_ENTER_NOTIFY) == 0);
+  assert(xcb_handler_count_for_type(XCB_LEAVE_NOTIFY) == 0);
+
+  /* Should be uninitialized */
+  assert(focus_component_is_initialized() == false);
+
+  /* Component should be unregistered from hub */
+  HubComponent* comp = hub_get_component_by_name(FOCUS_COMPONENT_NAME);
+  assert(comp == NULL);
+
+  xcb_handler_shutdown();
+  sm_registry_shutdown();
+  client_list_shutdown();
+  hub_shutdown();
+}
+
+/*
+ * Test focus state machine template creation
+ */
+void
+test_focus_sm_template_create(void)
+{
+  LOG_CLEAN("== Testing focus SM template creation");
+
+  SMTemplate* tmpl = focus_sm_template_create();
+  assert_or_abort(tmpl != NULL);
+
+  /* Check template has correct name */
+  assert(strcmp(tmpl->name, "focus") == 0);
+
+  /* Check template has 2 states */
+  assert(tmpl->num_states == 2);
+
+  /* Check template has 2 transitions */
+  assert(tmpl->num_transitions == 2);
+
+  /* Check initial state is UNFOCUSED */
+  assert(tmpl->initial_state == FOCUS_STATE_UNFOCUSED);
+}
+
+/*
+ * Test focus state machine for client
+ */
+void
+test_focus_sm_for_client(void)
+{
+  LOG_CLEAN("== Testing focus SM for client");
+
+  hub_init();
+  sm_registry_init();
+  client_list_init();
+  focus_component_init();
+
+  /* Create a client */
+  Client* c = client_create(100);
+  assert_or_abort(c != NULL);
+  assert(c->window == 100);
+
+  /* Initially no focus SM */
+  assert(c->sms.focus == NULL);
+
+  /* Get focus SM - should create it on demand */
+  StateMachine* sm = focus_get_sm(c);
+  assert_or_abort(sm != NULL);
+  assert(c->sms.focus == sm);
+
+  /* Check initial state is UNFOCUSED */
+  assert(focus_get_state(c) == FOCUS_STATE_UNFOCUSED);
+  assert(sm_get_state(sm) == FOCUS_STATE_UNFOCUSED);
+
+  /* Check is_focused returns false */
+  assert(focus_is_focused(c) == false);
+
+  /* Cleanup */
+  focus_component_shutdown();
+  client_list_shutdown();
+  sm_registry_shutdown();
+  hub_shutdown();
+}
+
+/*
+ * Test focus via raw_write
+ */
+void
+test_focus_raw_write(void)
+{
+  LOG_CLEAN("== Testing focus raw_write");
+
+  hub_init();
+  sm_registry_init();
+  client_list_init();
+  focus_component_init();
+
+  /* Create a client */
+  Client* c = client_create(100);
+  assert_or_abort(c != NULL);
+
+  /* Get focus SM */
+  StateMachine* sm = focus_get_sm(c);
+  assert_or_abort(sm != NULL);
+
+  /* Initially unfocused */
+  assert(focus_get_state(c) == FOCUS_STATE_UNFOCUSED);
+
+  /* Set to focused via raw_write */
+  focus_set_state(c, FOCUS_STATE_FOCUSED);
+  assert(focus_get_state(c) == FOCUS_STATE_FOCUSED);
+  assert(focus_is_focused(c) == true);
+
+  /* Set back to unfocused via raw_write */
+  focus_set_state(c, FOCUS_STATE_UNFOCUSED);
+  assert(focus_get_state(c) == FOCUS_STATE_UNFOCUSED);
+  assert(focus_is_focused(c) == false);
+
+  /* Cleanup */
+  focus_component_shutdown();
+  client_list_shutdown();
+  sm_registry_shutdown();
+  hub_shutdown();
+}
+
+/*
+ * Test ENTER_NOTIFY handler sets focus
+ */
+void
+test_enter_notify_sets_focus(void)
+{
+  LOG_CLEAN("== Testing ENTER_NOTIFY sets focus");
+
+  hub_init();
+  sm_registry_init();
+  client_list_init();
+  focus_component_init();
+
+  /* Create two clients */
+  Client* c1 = client_create(100);
+  assert_or_abort(c1 != NULL);
+  Client* c2 = client_create(200);
+  assert_or_abort(c2 != NULL);
+
+  /* Ensure both are managed (so they're focusable) */
+  client_set_managed(c1, true);
+  client_set_managed(c2, true);
+
+  /* Create ENTER_NOTIFY event for client 1 */
+  xcb_enter_notify_event_t enter_event = {
+    .response_type = XCB_ENTER_NOTIFY,
+    .detail        = XCB_NOTIFY_DETAIL_ANCESTOR,
+    .mode          = XCB_NOTIFY_MODE_NORMAL,
+    .event         = 100,
+    .child         = 0,
+    .root          = 0,
+    .root_x        = 0,
+    .root_y        = 0,
+    .event_x       = 0,
+    .event_y       = 0,
+  };
+
+  /* Initially no focus */
+  assert(focus_get_focused_window() == 0);
+
+  /* Handle enter notify for client 1 */
+  focus_on_enter_notify(&enter_event);
+
+  /* Client 1 should now be focused */
+  assert(focus_get_focused_window() == 100);
+  assert(focus_is_focused(c1) == true);
+  assert(focus_is_focused(c2) == false);
+
+  /* Create ENTER_NOTIFY event for client 2 */
+  enter_event.event = 200;
+  focus_on_enter_notify(&enter_event);
+
+  /* Client 2 should now be focused */
+  assert(focus_get_focused_window() == 200);
+  assert(focus_is_focused(c2) == true);
+  assert(focus_is_focused(c1) == false);
+
+  /* Cleanup */
+  focus_component_shutdown();
+  client_list_shutdown();
+  sm_registry_shutdown();
+  hub_shutdown();
+}
+
+/*
+ * Test LEAVE_NOTIFY handler clears focus
+ */
+void
+test_leave_notify_clears_focus(void)
+{
+  LOG_CLEAN("== Testing LEAVE_NOTIFY clears focus");
+
+  hub_init();
+  sm_registry_init();
+  client_list_init();
+  focus_component_init();
+
+  /* Create a client */
+  Client* c = client_create(100);
+  assert_or_abort(c != NULL);
+  client_set_managed(c, true);
+
+  /* Simulate focus by setting state directly */
+  focus_set_state(c, FOCUS_STATE_FOCUSED);
+  assert(focus_is_focused(c) == true);
+
+  /* Create LEAVE_NOTIFY event */
+  xcb_leave_notify_event_t leave_event = {
+    .response_type = XCB_LEAVE_NOTIFY,
+    .detail        = XCB_NOTIFY_DETAIL_ANCESTOR,
+    .mode          = XCB_NOTIFY_MODE_NORMAL,
+    .event         = 100,
+    .child         = 0,
+    .root          = 0,
+    .root_x        = 0,
+    .root_y        = 0,
+    .event_x       = 0,
+    .event_y       = 0,
+  };
+
+  /* Handle leave notify */
+  focus_on_leave_notify(&leave_event);
+
+  /* Client should now be unfocused */
+  assert(focus_is_focused(c) == false);
+  assert(focus_get_focused_window() == 0);
+
+  /* Cleanup */
+  focus_component_shutdown();
+  client_list_shutdown();
+  sm_registry_shutdown();
+  hub_shutdown();
+}
+
+/*
+ * Test focus event emission
+ */
+void
+test_focus_event_emission(void)
+{
+  LOG_CLEAN("== Testing focus event emission");
+
+  hub_init();
+  sm_registry_init();
+  client_list_init();
+  focus_component_init();
+
+  /* Reset tracking */
+  memset(&focus_test_events, 0, sizeof(focus_test_events));
+
+  /* Subscribe to focus events */
+  hub_subscribe(EVT_CLIENT_FOCUSED, focus_test_event_handler, NULL);
+  hub_subscribe(EVT_CLIENT_UNFOCUSED, focus_test_event_handler, NULL);
+
+  /* Create a client */
+  Client* c = client_create(100);
+  assert(c != NULL);
+  client_set_managed(c, true);
+
+  /* Initially unfocused */
+  assert(focus_is_focused(c) == false);
+
+  /* Set to focused via focus_set_state (which calls sm_raw_write and emits) */
+  focus_set_state(c, FOCUS_STATE_FOCUSED);
+  assert(focus_is_focused(c) == true);
+  assert(focus_test_events.focused_received == true);
+  assert(focus_test_events.focused_target == (TargetID) 100);
+
+  /* Reset tracking */
+  memset(&focus_test_events, 0, sizeof(focus_test_events));
+
+  /* Set back to unfocused (emits EVT_CLIENT_UNFOCUSED) */
+  focus_set_state(c, FOCUS_STATE_UNFOCUSED);
+  assert(focus_is_focused(c) == false);
+  assert(focus_test_events.unfocused_received == true);
+  assert(focus_test_events.unfocused_target == (TargetID) 100);
+
+  /* Cleanup */
+  hub_unsubscribe(EVT_CLIENT_FOCUSED, focus_test_event_handler);
+  hub_unsubscribe(EVT_CLIENT_UNFOCUSED, focus_test_event_handler);
+
+  focus_component_shutdown();
+  client_list_shutdown();
+  sm_registry_shutdown();
+  hub_shutdown();
+}
+
+/*
+ * Test focus guard functions
+ */
+void
+test_focus_guards(void)
+{
+  LOG_CLEAN("== Testing focus guards");
+
+  hub_init();
+  sm_registry_init();
+  client_list_init();
+  focus_component_init();
+
+  /* Create a non-focusable client */
+  Client* c = client_create(100);
+  assert_or_abort(c != NULL);
+  client_set_managed(c, true);
+  client_set_focusable(c, false);
+
+  /* Get focus SM */
+  StateMachine* sm = focus_get_sm(c);
+  assert_or_abort(sm != NULL);
+
+  /* Focus guard should reject because client is not focusable */
+  assert(focus_guard_can_focus(sm, NULL) == false);
+
+  /* Make client focusable */
+  client_set_focusable(c, true);
+  assert(focus_guard_can_focus(sm, NULL) == true);
+
+  /* Unfocus guard should always allow */
+  assert(focus_guard_can_unfocus(sm, NULL) == true);
+
+  /* Cleanup */
+  focus_component_shutdown();
+  client_list_shutdown();
+  sm_registry_shutdown();
+  hub_shutdown();
+}
+
+/*
+ * Test that un-managed clients are not focusable
+ */
+void
+test_unmanaged_client_not_focusable(void)
+{
+  LOG_CLEAN("== Testing un-managed client not focusable");
+
+  hub_init();
+  sm_registry_init();
+  client_list_init();
+  focus_component_init();
+
+  /* Create an un-managed client */
+  Client* c = client_create(100);
+  assert_or_abort(c != NULL);
+  client_set_managed(c, false); /* Not managed */
+  client_set_focusable(c, true); /* But marked as focusable */
+
+  /* Get focus SM */
+  StateMachine* sm = focus_get_sm(c);
+  assert_or_abort(sm != NULL);
+
+  /* Focus guard should reject because client is not managed */
+  assert(focus_guard_can_focus(sm, NULL) == false);
+
+  /* Cleanup */
+  focus_component_shutdown();
+  client_list_shutdown();
+  sm_registry_shutdown();
+  hub_shutdown();
+}
+
+/*
+ * Register test group
+ */
+TEST_GROUP(FocusComponent, {
+  test_focus_component_init();
+  test_focus_component_shutdown();
+  test_focus_sm_template_create();
+  test_focus_sm_for_client();
+  test_focus_raw_write();
+  test_enter_notify_sets_focus();
+  test_leave_notify_clears_focus();
+  test_focus_event_emission();
+  test_focus_guards();
+  test_unmanaged_client_not_focusable();
+});

--- a/test-focus-component.h
+++ b/test-focus-component.h
@@ -1,0 +1,13 @@
+/*
+ * Focus Component Tests
+ *
+ * Tests for the focus component that handles XCB events
+ * for client focus management.
+ */
+
+#ifndef _TEST_FOCUS_COMPONENT_H_
+#define _TEST_FOCUS_COMPONENT_H_
+
+/* Declarations are in src/components/focus.h */
+
+#endif /* _TEST_FOCUS_COMPONENT_H_ */

--- a/test-registry.c
+++ b/test-registry.c
@@ -23,6 +23,7 @@
  * Include all test headers to register their test groups
  */
 #include "test-client-list-component.h"
+#include "test-focus-component.h"
 #include "test-target-client.h"
 #include "test-wm-hub.h"
 #include "test-wm-monitor-manager.h"


### PR DESCRIPTION
Implements GitHub issue #14: Focus on enter complete path

## Summary
- FocusSM template: FOCUSED <-> UNFOCUSED
- Component registers ENTER_NOTIFY and LEAVE_NOTIFY handlers
- On enter: sm_raw_write to FocusSM (FOCUSED)
- On leave: sm_raw_write to FocusSM (UNFOCUSED)
- SM emits EVT_CLIENT_FOCUSED or EVT_CLIENT_UNFOCUSED

## Acceptance criteria
- [x] Mouse entering client window triggers focus
- [x] Mouse leaving client window unfocuses it
- [x] State machine transitions correctly
- [x] Event is emitted on focus change

## User stories addressed
- 8: focus follows the mouse

## Files changed
- `src/components/focus.c` - Focus component implementation
- `src/components/focus.h` - Focus component header
- `test-focus-component.c` - Focus component tests
- `test-focus-component.h` - Test header
- `Makefile` - Added test-focus-component.c to TEST_SRC
- `test-registry.c` - Added test-focus-component.h include

Closes #14 