### PR TITLE
Remove mock stubs from Client target

### DIFF
--- a/pr-body.md
+++ b/pr-body.md
@@ -1,0 +1,55 @@
+# Remove mock stubs from Client target
+
+## Summary
+
+Refactored the Client target's state machine storage from hardcoded fields to a dynamic, extensible array-based storage. This removes the mock stubs pattern where Client had explicit fields for each state machine type.
+
+## Changes
+
+### Architecture
+
+**Before:** Client had hardcoded `sms.fullscreen`, `sms.floating`, `sms.urgency`, `sms.focus` fields
+**After:** Client has dynamic `sms.sms[]` (array of pointers) and `sms.names[]` (corresponding names)
+
+### Files Modified
+
+1. **src/target/client.h**
+   - Changed `sms` struct from fixed fields to dynamic storage:
+     ```c
+     struct {
+       StateMachine** sms;     /* array of SM pointers */
+       char**         names;   /* corresponding SM names */
+       uint32_t       count;   /* number of SMs */
+       uint32_t       capacity; /* allocated capacity */
+     } sms;
+     ```
+
+2. **src/target/client.c**
+   - Added `client_sm_find()` helper to look up SM by name
+   - Added `client_sm_set_internal()` helper to add/update SMs
+   - Updated `client_destroy()` to iterate and clean up dynamic arrays
+   - Updated `client_get_sm()` and `client_set_sm()` to use the new helpers
+
+3. **src/components/focus.c**
+   - Updated all `c->sms.focus` accesses to use `client_get_sm(c, "focus")`
+   - Updated all `c->sms.focus = sm` to use `client_set_sm(c, "focus", sm)`
+
+4. **src/components/fullscreen.c**
+   - Updated all `c->sms.fullscreen` accesses to use `client_get_sm(c, "fullscreen")`
+   - Updated all `c->sms.fullscreen = sm` to use `client_set_sm(c, "fullscreen", sm)`
+
+5. **test-focus-component.c**
+   - Updated test assertions to use `client_get_sm(c, "focus")` instead of `c->sms.focus`
+
+## Acceptance Criteria
+
+- ✅ No mock stubs in Client target - state machines are stored by name, not by type
+- ✅ Client only contains core target functionality - the storage is generic
+- ✅ Features are implemented as separate components - focus and fullscreen components now store their SMs by name
+
+## Benefits
+
+1. **Extensibility**: New state machines can be added without modifying Client structure
+2. **Decoupling**: Client no longer has knowledge of specific feature types (focus, fullscreen, etc.)
+3. **Clean API**: Components use `client_get_sm()` and `client_set_sm()` with string names
+4. **Proper memory management**: SM names are properly freed on client destruction

--- a/pr-body.md
+++ b/pr-body.md
@@ -17,9 +17,9 @@ Refactored the Client target's state machine storage from hardcoded fields to a 
    - Changed `sms` struct from fixed fields to dynamic storage:
      ```c
      struct {
-       StateMachine** sms;     /* array of SM pointers */
-       char**         names;   /* corresponding SM names */
-       uint32_t       count;   /* number of SMs */
+       StateMachine** machines; /* array of SM pointers */
+       char**         names;    /* corresponding SM names */
+       uint32_t       count;    /* number of SMs */
        uint32_t       capacity; /* allocated capacity */
      } sms;
      ```

--- a/src/components/focus.c
+++ b/src/components/focus.c
@@ -212,7 +212,7 @@ focus_get_sm(Client* c)
   if (c == NULL)
     return NULL;
 
-  StateMachine* sm = client_get_sm(c, "focus");
+  StateMachine* sm = client_get_sm(c, FOCUS_COMPONENT_NAME);
   if (sm != NULL)
     return sm;
 
@@ -233,7 +233,7 @@ focus_get_sm(Client* c)
   }
 
   /* Store in client */
-  client_set_sm(c, "focus", sm);
+  client_set_sm(c, FOCUS_COMPONENT_NAME, sm);
 
   LOG_DEBUG("Created focus SM for client window=%u", c->window);
   return sm;
@@ -264,7 +264,7 @@ focus_get_state(Client* c)
   if (c == NULL)
     return FOCUS_STATE_UNFOCUSED;
 
-  StateMachine* sm = client_get_sm(c, "focus");
+  StateMachine* sm = client_get_sm(c, FOCUS_COMPONENT_NAME);
   if (sm == NULL)
     return FOCUS_STATE_UNFOCUSED;
 
@@ -433,7 +433,7 @@ focus_on_leave_notify(void* event)
   }
 
   /* Get the SM */
-  StateMachine* sm = client_get_sm(c, "focus");
+  StateMachine* sm = client_get_sm(c, FOCUS_COMPONENT_NAME);
   if (sm == NULL) {
     /* SM not yet created, nothing to unfocus */
     return;

--- a/src/components/focus.c
+++ b/src/components/focus.c
@@ -212,7 +212,7 @@ focus_get_sm(Client* c)
   if (c == NULL)
     return NULL;
 
-  StateMachine* sm = c->sms.focus;
+  StateMachine* sm = client_get_sm(c, "focus");
   if (sm != NULL)
     return sm;
 
@@ -233,7 +233,7 @@ focus_get_sm(Client* c)
   }
 
   /* Store in client */
-  c->sms.focus = sm;
+  client_set_sm(c, "focus", sm);
 
   LOG_DEBUG("Created focus SM for client window=%u", c->window);
   return sm;
@@ -248,7 +248,7 @@ focus_is_focused(Client* c)
   if (c == NULL)
     return false;
 
-  StateMachine* sm = c->sms.focus;
+  StateMachine* sm = client_get_sm(c, "focus");
   if (sm == NULL)
     return false;
 
@@ -264,7 +264,7 @@ focus_get_state(Client* c)
   if (c == NULL)
     return FOCUS_STATE_UNFOCUSED;
 
-  StateMachine* sm = c->sms.focus;
+  StateMachine* sm = client_get_sm(c, "focus");
   if (sm == NULL)
     return FOCUS_STATE_UNFOCUSED;
 
@@ -295,8 +295,11 @@ focus_set_state(Client* c, FocusState state)
     if (focus_component.focused_window != 0 &&
         focus_component.focused_window != c->window) {
       Client* prev = client_get_by_window(focus_component.focused_window);
-      if (prev != NULL && prev != c && prev->sms.focus != NULL) {
-        sm_raw_write(prev->sms.focus, FOCUS_STATE_UNFOCUSED);
+      if (prev != NULL && prev != c) {
+        StateMachine* prev_sm = client_get_sm(prev, "focus");
+        if (prev_sm != NULL) {
+          sm_raw_write(prev_sm, FOCUS_STATE_UNFOCUSED);
+        }
       }
     }
     focus_component.focused_window = c->window;
@@ -380,7 +383,7 @@ focus_on_enter_notify(void* event)
         focus_component.focused_window != c->window) {
       Client* prev = client_get_by_window(focus_component.focused_window);
       if (prev != NULL && prev != c) {
-        StateMachine* prev_sm = prev->sms.focus;
+        StateMachine* prev_sm = client_get_sm(prev, "focus");
         if (prev_sm != NULL) {
           FocusState prev_state = (FocusState) sm_get_state(prev_sm);
           if (prev_state == FOCUS_STATE_FOCUSED) {
@@ -430,7 +433,7 @@ focus_on_leave_notify(void* event)
   }
 
   /* Get the SM */
-  StateMachine* sm = c->sms.focus;
+  StateMachine* sm = client_get_sm(c, "focus");
   if (sm == NULL) {
     /* SM not yet created, nothing to unfocus */
     return;

--- a/src/components/focus.c
+++ b/src/components/focus.c
@@ -233,7 +233,11 @@ focus_get_sm(Client* c)
   }
 
   /* Store in client */
-  client_set_sm(c, FOCUS_COMPONENT_NAME, sm);
+  if (!client_set_sm(c, FOCUS_COMPONENT_NAME, sm)) {
+    LOG_ERROR("Failed to store focus SM for client");
+    sm_destroy(sm);
+    return NULL;
+  }
 
   LOG_DEBUG("Created focus SM for client window=%u", c->window);
   return sm;
@@ -248,7 +252,7 @@ focus_is_focused(Client* c)
   if (c == NULL)
     return false;
 
-  StateMachine* sm = client_get_sm(c, "focus");
+  StateMachine* sm = client_get_sm(c, FOCUS_COMPONENT_NAME);
   if (sm == NULL)
     return false;
 
@@ -296,7 +300,7 @@ focus_set_state(Client* c, FocusState state)
         focus_component.focused_window != c->window) {
       Client* prev = client_get_by_window(focus_component.focused_window);
       if (prev != NULL && prev != c) {
-        StateMachine* prev_sm = client_get_sm(prev, "focus");
+        StateMachine* prev_sm = client_get_sm(prev, FOCUS_COMPONENT_NAME);
         if (prev_sm != NULL) {
           sm_raw_write(prev_sm, FOCUS_STATE_UNFOCUSED);
         }
@@ -383,7 +387,7 @@ focus_on_enter_notify(void* event)
         focus_component.focused_window != c->window) {
       Client* prev = client_get_by_window(focus_component.focused_window);
       if (prev != NULL && prev != c) {
-        StateMachine* prev_sm = client_get_sm(prev, "focus");
+        StateMachine* prev_sm = client_get_sm(prev, FOCUS_COMPONENT_NAME);
         if (prev_sm != NULL) {
           FocusState prev_state = (FocusState) sm_get_state(prev_sm);
           if (prev_state == FOCUS_STATE_FOCUSED) {

--- a/src/components/fullscreen.c
+++ b/src/components/fullscreen.c
@@ -235,7 +235,7 @@ fullscreen_get_sm(Client* c)
   if (c == NULL)
     return NULL;
 
-  StateMachine* sm = c->sms.fullscreen;
+  StateMachine* sm = client_get_sm(c, "fullscreen");
   if (sm != NULL)
     return sm;
 
@@ -253,7 +253,7 @@ fullscreen_get_sm(Client* c)
   }
 
   /* Store in client */
-  c->sms.fullscreen = sm;
+  client_set_sm(c, "fullscreen", sm);
 
   LOG_DEBUG("Created fullscreen SM for client window=%u", c->window);
   return sm;
@@ -268,7 +268,7 @@ fullscreen_is_fullscreen(Client* c)
   if (c == NULL)
     return false;
 
-  StateMachine* sm = c->sms.fullscreen;
+  StateMachine* sm = client_get_sm(c, "fullscreen");
   if (sm == NULL)
     return false;
 
@@ -284,7 +284,7 @@ fullscreen_get_state(Client* c)
   if (c == NULL)
     return FULLSCREEN_STATE_WINDOWED;
 
-  StateMachine* sm = c->sms.fullscreen;
+  StateMachine* sm = client_get_sm(c, "fullscreen");
   if (sm == NULL)
     return FULLSCREEN_STATE_WINDOWED;
 

--- a/src/components/fullscreen.c
+++ b/src/components/fullscreen.c
@@ -235,7 +235,7 @@ fullscreen_get_sm(Client* c)
   if (c == NULL)
     return NULL;
 
-  StateMachine* sm = client_get_sm(c, "fullscreen");
+  StateMachine* sm = client_get_sm(c, FULLSCREEN_COMPONENT_NAME);
   if (sm != NULL)
     return sm;
 
@@ -253,7 +253,7 @@ fullscreen_get_sm(Client* c)
   }
 
   /* Store in client */
-  client_set_sm(c, "fullscreen", sm);
+  client_set_sm(c, FULLSCREEN_COMPONENT_NAME, sm);
 
   LOG_DEBUG("Created fullscreen SM for client window=%u", c->window);
   return sm;
@@ -268,7 +268,7 @@ fullscreen_is_fullscreen(Client* c)
   if (c == NULL)
     return false;
 
-  StateMachine* sm = client_get_sm(c, "fullscreen");
+  StateMachine* sm = client_get_sm(c, FULLSCREEN_COMPONENT_NAME);
   if (sm == NULL)
     return false;
 
@@ -284,7 +284,7 @@ fullscreen_get_state(Client* c)
   if (c == NULL)
     return FULLSCREEN_STATE_WINDOWED;
 
-  StateMachine* sm = client_get_sm(c, "fullscreen");
+  StateMachine* sm = client_get_sm(c, FULLSCREEN_COMPONENT_NAME);
   if (sm == NULL)
     return FULLSCREEN_STATE_WINDOWED;
 

--- a/src/components/fullscreen.c
+++ b/src/components/fullscreen.c
@@ -253,7 +253,11 @@ fullscreen_get_sm(Client* c)
   }
 
   /* Store in client */
-  client_set_sm(c, FULLSCREEN_COMPONENT_NAME, sm);
+  if (!client_set_sm(c, FULLSCREEN_COMPONENT_NAME, sm)) {
+    LOG_ERROR("Failed to store fullscreen SM for client");
+    sm_destroy(sm);
+    return NULL;
+  }
 
   LOG_DEBUG("Created fullscreen SM for client window=%u", c->window);
   return sm;

--- a/src/target/client.c
+++ b/src/target/client.c
@@ -75,50 +75,66 @@ client_sm_find(const Client* c, const char* sm_name)
 /*
  * Helper: add or update SM for a name.
  * Takes ownership of `sm` - any previously registered SM for this name
- * will be destroyed. The sm_name string is copied internally.
+ * will be destroyed (unless it's the same pointer to avoid self-destruction).
+ * The sm_name string is copied internally.
+ *
+ * Returns true on success, false on failure (OOM).
+ * On failure, the caller should handle cleanup of the passed SM.
  */
-static void
+static bool
 client_sm_set_internal(Client* c, const char* sm_name, StateMachine* sm)
 {
   int32_t idx = client_sm_find(c, sm_name);
 
   if (idx >= 0) {
-    /* Update existing - destroy old SM */
-    if (c->sms.machines[idx] != NULL) {
+    /* Update existing - destroy old SM if different from new one */
+    if (c->sms.machines[idx] != NULL && c->sms.machines[idx] != sm) {
       sm_destroy(c->sms.machines[idx]);
     }
     c->sms.machines[idx] = sm;
-    return;
+    return true;
   }
 
   /* Add new SM */
   if (c->sms.count >= c->sms.capacity) {
     uint32_t       new_capacity = c->sms.capacity == 0 ? 4 : c->sms.capacity * 2;
-    StateMachine** new_machines = realloc(c->sms.machines, new_capacity * sizeof(StateMachine*));
+    StateMachine** new_machines = NULL;
     char**         new_names    = NULL;
 
-    /* Check machines allocation first */
+    /* Reallocate machines first */
+    new_machines = realloc(c->sms.machines, new_capacity * sizeof(StateMachine*));
     if (new_machines == NULL) {
-      LOG_ERROR("Failed to expand SM storage for client");
-      return;
+      LOG_ERROR("Failed to expand SM machines storage for client");
+      return false;
     }
 
+    /* Reallocate names */
     new_names = realloc(c->sms.names, new_capacity * sizeof(char*));
     if (new_names == NULL) {
       free(new_machines);
       LOG_ERROR("Failed to expand SM names storage for client");
-      return;
+      return false;
     }
 
-    /* Both allocations succeeded, update both atomically */
-    c->sms.machines      = new_machines;
+    /* Both allocations succeeded, update atomically */
+    c->sms.machines = new_machines;
     c->sms.names    = new_names;
     c->sms.capacity = new_capacity;
   }
 
-  c->sms.machines[c->sms.count]   = sm;
-  c->sms.names[c->sms.count] = sm_name ? strdup(sm_name) : NULL;
+  /* strdup the name - check for failure */
+  char* copied_name = sm_name ? strdup(sm_name) : NULL;
+  if (sm_name != NULL && copied_name == NULL) {
+    LOG_ERROR("Failed to copy SM name for client");
+    /* Don't add the SM if we can't store the name */
+    return false;
+  }
+
+  c->sms.machines[c->sms.count] = sm;
+  c->sms.names[c->sms.count]    = copied_name;
   c->sms.count++;
+
+  return true;
 }
 
 /*
@@ -333,7 +349,7 @@ client_destroy(Client* c)
   }
   free(c->sms.machines);
   free(c->sms.names);
-  c->sms.machines      = NULL;
+  c->sms.machines = NULL;
   c->sms.names    = NULL;
   c->sms.count    = 0;
   c->sms.capacity = 0;
@@ -471,14 +487,17 @@ client_get_sm(Client* c, const char* sm_name)
 /*
  * Set a state machine for this client.
  * The SM is stored by name - components can retrieve it later via client_get_sm().
+ *
+ * Returns true on success, false on failure (OOM).
+ * On failure, the caller should destroy the SM to avoid leaks.
  */
-void
+bool
 client_set_sm(Client* c, const char* sm_name, StateMachine* sm)
 {
   if (c == NULL || sm_name == NULL)
-    return;
+    return false;
 
-  client_sm_set_internal(c, sm_name, sm);
+  return client_sm_set_internal(c, sm_name, sm);
 }
 
 /*

--- a/src/target/client.c
+++ b/src/target/client.c
@@ -32,23 +32,23 @@ static Client client_sentinel;
 static void
 client_properties_init(Client* c)
 {
-  c->title          = NULL;
-  c->class_name     = NULL;
-  c->x              = 0;
-  c->y              = 0;
-  c->width          = 0;
-  c->height         = 0;
-  c->border_width   = 0;
-  c->tags           = 0;
-  c->monitor        = NULL;
-  c->managed        = false;
-  c->urgent         = false;
-  c->focusable      = true;
-  c->mapped         = false;
-  c->stack_mode     = XCB_STACK_MODE_ABOVE;
+  c->title        = NULL;
+  c->class_name   = NULL;
+  c->x            = 0;
+  c->y            = 0;
+  c->width        = 0;
+  c->height       = 0;
+  c->border_width = 0;
+  c->tags         = 0;
+  c->monitor      = NULL;
+  c->managed      = false;
+  c->urgent       = false;
+  c->focusable    = true;
+  c->mapped       = false;
+  c->stack_mode   = XCB_STACK_MODE_ABOVE;
 
   /* Initialize SM storage */
-  c->sms.sms      = NULL;
+  c->sms.machines = NULL;
   c->sms.names    = NULL;
   c->sms.count    = 0;
   c->sms.capacity = 0;
@@ -74,6 +74,8 @@ client_sm_find(const Client* c, const char* sm_name)
 
 /*
  * Helper: add or update SM for a name.
+ * Takes ownership of `sm` - any previously registered SM for this name
+ * will be destroyed. The sm_name string is copied internally.
  */
 static void
 client_sm_set_internal(Client* c, const char* sm_name, StateMachine* sm)
@@ -81,31 +83,40 @@ client_sm_set_internal(Client* c, const char* sm_name, StateMachine* sm)
   int32_t idx = client_sm_find(c, sm_name);
 
   if (idx >= 0) {
-    /* Update existing */
-    if (c->sms.sms[idx] != NULL) {
-      sm_destroy(c->sms.sms[idx]);
+    /* Update existing - destroy old SM */
+    if (c->sms.machines[idx] != NULL) {
+      sm_destroy(c->sms.machines[idx]);
     }
-    c->sms.sms[idx] = sm;
+    c->sms.machines[idx] = sm;
     return;
   }
 
   /* Add new SM */
   if (c->sms.count >= c->sms.capacity) {
-    uint32_t new_capacity = c->sms.capacity == 0 ? 4 : c->sms.capacity * 2;
-    StateMachine** new_sms = realloc(c->sms.sms, new_capacity * sizeof(StateMachine*));
-    char** new_names = realloc(c->sms.names, new_capacity * sizeof(char*));
-    if (new_sms == NULL || new_names == NULL) {
-      free(new_sms);
-      free(new_names);
+    uint32_t       new_capacity = c->sms.capacity == 0 ? 4 : c->sms.capacity * 2;
+    StateMachine** new_machines = realloc(c->sms.machines, new_capacity * sizeof(StateMachine*));
+    char**         new_names    = NULL;
+
+    /* Check machines allocation first */
+    if (new_machines == NULL) {
       LOG_ERROR("Failed to expand SM storage for client");
       return;
     }
-    c->sms.sms      = new_sms;
+
+    new_names = realloc(c->sms.names, new_capacity * sizeof(char*));
+    if (new_names == NULL) {
+      free(new_machines);
+      LOG_ERROR("Failed to expand SM names storage for client");
+      return;
+    }
+
+    /* Both allocations succeeded, update both atomically */
+    c->sms.machines      = new_machines;
     c->sms.names    = new_names;
     c->sms.capacity = new_capacity;
   }
 
-  c->sms.sms[c->sms.count]   = sm;
+  c->sms.machines[c->sms.count]   = sm;
   c->sms.names[c->sms.count] = sm_name ? strdup(sm_name) : NULL;
   c->sms.count++;
 }
@@ -313,16 +324,16 @@ client_destroy(Client* c)
 
   /* Destroy all state machines */
   for (uint32_t i = 0; i < c->sms.count; i++) {
-    if (c->sms.sms[i] != NULL) {
-      sm_destroy(c->sms.sms[i]);
+    if (c->sms.machines[i] != NULL) {
+      sm_destroy(c->sms.machines[i]);
     }
     if (c->sms.names[i] != NULL) {
       free(c->sms.names[i]);
     }
   }
-  free(c->sms.sms);
+  free(c->sms.machines);
   free(c->sms.names);
-  c->sms.sms      = NULL;
+  c->sms.machines      = NULL;
   c->sms.names    = NULL;
   c->sms.count    = 0;
   c->sms.capacity = 0;
@@ -454,7 +465,7 @@ client_get_sm(Client* c, const char* sm_name)
   if (idx < 0)
     return NULL;
 
-  return c->sms.sms[idx];
+  return c->sms.machines[idx];
 }
 
 /*

--- a/src/target/client.c
+++ b/src/target/client.c
@@ -46,10 +46,68 @@ client_properties_init(Client* c)
   c->focusable      = true;
   c->mapped         = false;
   c->stack_mode     = XCB_STACK_MODE_ABOVE;
-  c->sms.fullscreen = NULL;
-  c->sms.floating   = NULL;
-  c->sms.urgency    = NULL;
-  c->sms.focus      = NULL;
+
+  /* Initialize SM storage */
+  c->sms.sms      = NULL;
+  c->sms.names    = NULL;
+  c->sms.count    = 0;
+  c->sms.capacity = 0;
+}
+
+/*
+ * Helper: find SM index by name.
+ * Returns -1 if not found.
+ */
+static int32_t
+client_sm_find(const Client* c, const char* sm_name)
+{
+  if (c == NULL || sm_name == NULL)
+    return -1;
+
+  for (uint32_t i = 0; i < c->sms.count; i++) {
+    if (c->sms.names[i] != NULL && strcmp(c->sms.names[i], sm_name) == 0) {
+      return (int32_t) i;
+    }
+  }
+  return -1;
+}
+
+/*
+ * Helper: add or update SM for a name.
+ */
+static void
+client_sm_set_internal(Client* c, const char* sm_name, StateMachine* sm)
+{
+  int32_t idx = client_sm_find(c, sm_name);
+
+  if (idx >= 0) {
+    /* Update existing */
+    if (c->sms.sms[idx] != NULL) {
+      sm_destroy(c->sms.sms[idx]);
+    }
+    c->sms.sms[idx] = sm;
+    return;
+  }
+
+  /* Add new SM */
+  if (c->sms.count >= c->sms.capacity) {
+    uint32_t new_capacity = c->sms.capacity == 0 ? 4 : c->sms.capacity * 2;
+    StateMachine** new_sms = realloc(c->sms.sms, new_capacity * sizeof(StateMachine*));
+    char** new_names = realloc(c->sms.names, new_capacity * sizeof(char*));
+    if (new_sms == NULL || new_names == NULL) {
+      free(new_sms);
+      free(new_names);
+      LOG_ERROR("Failed to expand SM storage for client");
+      return;
+    }
+    c->sms.sms      = new_sms;
+    c->sms.names    = new_names;
+    c->sms.capacity = new_capacity;
+  }
+
+  c->sms.sms[c->sms.count]   = sm;
+  c->sms.names[c->sms.count] = sm_name ? strdup(sm_name) : NULL;
+  c->sms.count++;
 }
 
 /*
@@ -254,22 +312,20 @@ client_destroy(Client* c)
   client_list_remove(c);
 
   /* Destroy all state machines */
-  if (c->sms.fullscreen != NULL) {
-    sm_destroy(c->sms.fullscreen);
-    c->sms.fullscreen = NULL;
+  for (uint32_t i = 0; i < c->sms.count; i++) {
+    if (c->sms.sms[i] != NULL) {
+      sm_destroy(c->sms.sms[i]);
+    }
+    if (c->sms.names[i] != NULL) {
+      free(c->sms.names[i]);
+    }
   }
-  if (c->sms.floating != NULL) {
-    sm_destroy(c->sms.floating);
-    c->sms.floating = NULL;
-  }
-  if (c->sms.urgency != NULL) {
-    sm_destroy(c->sms.urgency);
-    c->sms.urgency = NULL;
-  }
-  if (c->sms.focus != NULL) {
-    sm_destroy(c->sms.focus);
-    c->sms.focus = NULL;
-  }
+  free(c->sms.sms);
+  free(c->sms.names);
+  c->sms.sms      = NULL;
+  c->sms.names    = NULL;
+  c->sms.count    = 0;
+  c->sms.capacity = 0;
 
   /* Free X properties */
   if (c->title != NULL) {
@@ -385,7 +441,8 @@ client_get_prev(const Client* c)
 }
 
 /*
- * Get state machine by name (on-demand allocation).
+ * Get state machine by name.
+ * Returns NULL if no SM is registered for this name.
  */
 StateMachine*
 client_get_sm(Client* c, const char* sm_name)
@@ -393,40 +450,16 @@ client_get_sm(Client* c, const char* sm_name)
   if (c == NULL || sm_name == NULL)
     return NULL;
 
-  if (strcmp(sm_name, "fullscreen") == 0) {
-    if (c->sms.fullscreen == NULL) {
-      LOG_DEBUG("Fullscreen SM requested but not yet implemented");
-    }
-    return c->sms.fullscreen;
-  }
+  int32_t idx = client_sm_find(c, sm_name);
+  if (idx < 0)
+    return NULL;
 
-  if (strcmp(sm_name, "floating") == 0) {
-    if (c->sms.floating == NULL) {
-      LOG_DEBUG("Floating SM requested but not yet implemented");
-    }
-    return c->sms.floating;
-  }
-
-  if (strcmp(sm_name, "urgency") == 0) {
-    if (c->sms.urgency == NULL) {
-      LOG_DEBUG("Urgency SM requested but not yet implemented");
-    }
-    return c->sms.urgency;
-  }
-
-  if (strcmp(sm_name, "focus") == 0) {
-    if (c->sms.focus == NULL) {
-      LOG_DEBUG("Focus SM requested but not yet implemented");
-    }
-    return c->sms.focus;
-  }
-
-  LOG_WARN("Unknown state machine requested: %s", sm_name);
-  return NULL;
+  return c->sms.sms[idx];
 }
 
 /*
  * Set a state machine for this client.
+ * The SM is stored by name - components can retrieve it later via client_get_sm().
  */
 void
 client_set_sm(Client* c, const char* sm_name, StateMachine* sm)
@@ -434,17 +467,7 @@ client_set_sm(Client* c, const char* sm_name, StateMachine* sm)
   if (c == NULL || sm_name == NULL)
     return;
 
-  if (strcmp(sm_name, "fullscreen") == 0) {
-    c->sms.fullscreen = sm;
-  } else if (strcmp(sm_name, "floating") == 0) {
-    c->sms.floating = sm;
-  } else if (strcmp(sm_name, "urgency") == 0) {
-    c->sms.urgency = sm;
-  } else if (strcmp(sm_name, "focus") == 0) {
-    c->sms.focus = sm;
-  } else {
-    LOG_WARN("Cannot set unknown state machine: %s", sm_name);
-  }
+  client_sm_set_internal(c, sm_name, sm);
 }
 
 /*

--- a/src/target/client.h
+++ b/src/target/client.h
@@ -62,10 +62,10 @@ typedef struct Client {
 
   /* Adopted state machines - dynamically allocated on demand */
   struct {
-    StateMachine* fullscreen;
-    StateMachine* floating;
-    StateMachine* urgency;
-    StateMachine* focus;
+    StateMachine** sms;     /* array of SM pointers */
+    char**         names;   /* corresponding SM names */
+    uint32_t       count;   /* number of SMs */
+    uint32_t       capacity; /* allocated capacity */
   } sms;
 
   /* Linked list links (sentinel-based circular list) */

--- a/src/target/client.h
+++ b/src/target/client.h
@@ -62,9 +62,9 @@ typedef struct Client {
 
   /* Adopted state machines - dynamically allocated on demand */
   struct {
-    StateMachine** sms;     /* array of SM pointers */
-    char**         names;   /* corresponding SM names */
-    uint32_t       count;   /* number of SMs */
+    StateMachine** machines; /* array of SM pointers */
+    char**         names;    /* corresponding SM names */
+    uint32_t       count;    /* number of SMs */
     uint32_t       capacity; /* allocated capacity */
   } sms;
 

--- a/src/target/client.h
+++ b/src/target/client.h
@@ -189,8 +189,11 @@ StateMachine* client_get_sm(Client* c, const char* sm_name);
 /*
  * Set a state machine for this client.
  * Used by components to attach their SM templates.
+ *
+ * Returns true on success, false on failure (OOM).
+ * On failure, the caller should destroy the SM to avoid leaks.
  */
-void client_set_sm(Client* c, const char* sm_name, StateMachine* sm);
+bool client_set_sm(Client* c, const char* sm_name, StateMachine* sm);
 
 /*
  * Client Property Accessors

--- a/test-focus-component.c
+++ b/test-focus-component.c
@@ -442,7 +442,7 @@ test_unmanaged_client_not_focusable(void)
   /* Create an un-managed client */
   Client* c = client_create(100);
   assert_or_abort(c != NULL);
-  client_set_managed(c, false); /* Not managed */
+  client_set_managed(c, false);  /* Not managed */
   client_set_focusable(c, true); /* But marked as focusable */
 
   /* Get focus SM */

--- a/test-focus-component.c
+++ b/test-focus-component.c
@@ -157,12 +157,12 @@ test_focus_sm_for_client(void)
   assert(c->window == 100);
 
   /* Initially no focus SM */
-  assert(c->sms.focus == NULL);
+  assert(client_get_sm(c, "focus") == NULL);
 
   /* Get focus SM - should create it on demand */
   StateMachine* sm = focus_get_sm(c);
   assert_or_abort(sm != NULL);
-  assert(c->sms.focus == sm);
+  assert(client_get_sm(c, "focus") == sm);
 
   /* Check initial state is UNFOCUSED */
   assert(focus_get_state(c) == FOCUS_STATE_UNFOCUSED);


### PR DESCRIPTION
# Remove mock stubs from Client target

## Summary

Refactored the Client target's state machine storage from hardcoded fields to a dynamic, extensible array-based storage. This removes the mock stubs pattern where Client had explicit fields for each state machine type.

## Changes

### Architecture

**Before:** Client had hardcoded `sms.fullscreen`, `sms.floating`, `sms.urgency`, `sms.focus` fields
**After:** Client has dynamic `sms.sms[]` (array of pointers) and `sms.names[]` (corresponding names)

### Files Modified

1. **src/target/client.h**
   - Changed `sms` struct from fixed fields to dynamic storage:
     ```c
     struct {
       StateMachine** sms;     /* array of SM pointers */
       char**         names;   /* corresponding SM names */
       uint32_t       count;   /* number of SMs */
       uint32_t       capacity; /* allocated capacity */
     } sms;
     ```

2. **src/target/client.c**
   - Added `client_sm_find()` helper to look up SM by name
   - Added `client_sm_set_internal()` helper to add/update SMs
   - Updated `client_destroy()` to iterate and clean up dynamic arrays
   - Updated `client_get_sm()` and `client_set_sm()` to use the new helpers

3. **src/components/focus.c**
   - Updated all `c->sms.focus` accesses to use `client_get_sm(c, "focus")`
   - Updated all `c->sms.focus = sm` to use `client_set_sm(c, "focus", sm)`

4. **src/components/fullscreen.c**
   - Updated all `c->sms.fullscreen` accesses to use `client_get_sm(c, "fullscreen")`
   - Updated all `c->sms.fullscreen = sm` to use `client_set_sm(c, "fullscreen", sm)`

5. **test-focus-component.c**
   - Updated test assertions to use `client_get_sm(c, "focus")` instead of `c->sms.focus`

## Acceptance Criteria

- ✅ No mock stubs in Client target - state machines are stored by name, not by type
- ✅ Client only contains core target functionality - the storage is generic
- ✅ Features are implemented as separate components - focus and fullscreen components now store their SMs by name

## Benefits

1. **Extensibility**: New state machines can be added without modifying Client structure
2. **Decoupling**: Client no longer has knowledge of specific feature types (focus, fullscreen, etc.)
3. **Clean API**: Components use `client_get_sm()` and `client_set_sm()` with string names
4. **Proper memory management**: SM names are properly freed on client destruction

Closes #69 