### PR TITLE
Implement tiling layout component

### DIFF
--- a/src/components/keybinding.c
+++ b/src/components/keybinding.c
@@ -83,6 +83,9 @@ static const KeyBinding default_keybindings[] = {
 
   /* Fullscreen toggle - Mod+f (keycode 41 = f) */
   { XCB_MOD_MASK_4,                      41, KEYBINDING_ACTION_TOGGLE_FULLSCREEN, 0 },
+
+  /* Tile toggle - Mod+i (keycode 31 = i) */
+  { XCB_MOD_MASK_4,                      31, KEYBINDING_ACTION_TILE_MONITOR,      0 },
 };
 
 static const KeyBinding* keybindings     = default_keybindings;
@@ -265,6 +268,17 @@ execute_keybinding(const KeyBinding* binding)
   case KEYBINDING_ACTION_TOGGLE_FULLSCREEN:
     send_focus_request(REQ_CLIENT_FULLSCREEN);
     break;
+
+  case KEYBINDING_ACTION_TILE_MONITOR: {
+    TargetID target = monitor_get_current_monitor();
+    if (target != TARGET_ID_NONE) {
+      hub_send_request(REQ_MONITOR_TILE, target);
+      LOG_DEBUG("Keybinding sent tile request to monitor target=%" PRIu64, target);
+    } else {
+      LOG_DEBUG("Keybinding: no selected monitor for tile request");
+    }
+  } break;
+
 
   default:
     LOG_DEBUG("Keybinding: unhandled action %d", binding->action);

--- a/src/components/keybinding.c
+++ b/src/components/keybinding.c
@@ -25,6 +25,7 @@
 #include "keybinding.h"
 #include "src/components/focus.h"
 #include "src/components/tag-manager.h"
+#include "src/components/tiling.h"
 #include "src/target/client.h"
 #include "src/target/monitor.h"
 #include "src/xcb/xcb-handler.h"
@@ -43,32 +44,32 @@
 static const KeyBinding default_keybindings[] = {
   /* Focus actions */
   /* Mod+Enter: focus current client */
-  { XCB_MOD_MASK_4,                      36, KEYBINDING_ACTION_FOCUS_CLIENT,      0 }, /* keycode 36 = Return */
+  { XCB_MOD_MASK_4,                                       36, KEYBINDING_ACTION_FOCUS_CLIENT,      0 }, /* keycode 36 = Return */
 
   /* Mod+Shift+Enter: focus previous client */
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 36, KEYBINDING_ACTION_FOCUS_PREV,        0 },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  36, KEYBINDING_ACTION_FOCUS_PREV,        0 },
 
   /* Tag view actions - Mod+1 through Mod+9 */
-  { XCB_MOD_MASK_4,                      10, KEYBINDING_ACTION_TAG_VIEW,          1 }, /* keycode 10 = 1 */
-  { XCB_MOD_MASK_4,                      11, KEYBINDING_ACTION_TAG_VIEW,          2 }, /* keycode 11 = 2 */
-  { XCB_MOD_MASK_4,                      12, KEYBINDING_ACTION_TAG_VIEW,          3 }, /* keycode 12 = 3 */
-  { XCB_MOD_MASK_4,                      13, KEYBINDING_ACTION_TAG_VIEW,          4 }, /* keycode 13 = 4 */
-  { XCB_MOD_MASK_4,                      14, KEYBINDING_ACTION_TAG_VIEW,          5 }, /* keycode 14 = 5 */
-  { XCB_MOD_MASK_4,                      15, KEYBINDING_ACTION_TAG_VIEW,          6 }, /* keycode 15 = 6 */
-  { XCB_MOD_MASK_4,                      16, KEYBINDING_ACTION_TAG_VIEW,          7 }, /* keycode 16 = 7 */
-  { XCB_MOD_MASK_4,                      17, KEYBINDING_ACTION_TAG_VIEW,          8 }, /* keycode 17 = 8 */
-  { XCB_MOD_MASK_4,                      18, KEYBINDING_ACTION_TAG_VIEW,          9 }, /* keycode 18 = 9 */
+  { XCB_MOD_MASK_4,                                       10, KEYBINDING_ACTION_TAG_VIEW,          1 }, /* keycode 10 = 1 */
+  { XCB_MOD_MASK_4,                                       11, KEYBINDING_ACTION_TAG_VIEW,          2 }, /* keycode 11 = 2 */
+  { XCB_MOD_MASK_4,                                       12, KEYBINDING_ACTION_TAG_VIEW,          3 }, /* keycode 12 = 3 */
+  { XCB_MOD_MASK_4,                                       13, KEYBINDING_ACTION_TAG_VIEW,          4 }, /* keycode 13 = 4 */
+  { XCB_MOD_MASK_4,                                       14, KEYBINDING_ACTION_TAG_VIEW,          5 }, /* keycode 14 = 5 */
+  { XCB_MOD_MASK_4,                                       15, KEYBINDING_ACTION_TAG_VIEW,          6 }, /* keycode 15 = 6 */
+  { XCB_MOD_MASK_4,                                       16, KEYBINDING_ACTION_TAG_VIEW,          7 }, /* keycode 16 = 7 */
+  { XCB_MOD_MASK_4,                                       17, KEYBINDING_ACTION_TAG_VIEW,          8 }, /* keycode 17 = 8 */
+  { XCB_MOD_MASK_4,                                       18, KEYBINDING_ACTION_TAG_VIEW,          9 }, /* keycode 18 = 9 */
 
   /* Tag toggle actions - Mod+Shift+1 through Mod+Shift+9 */
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 10, KEYBINDING_ACTION_TAG_TOGGLE,        1 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 11, KEYBINDING_ACTION_TAG_TOGGLE,        2 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 12, KEYBINDING_ACTION_TAG_TOGGLE,        3 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 13, KEYBINDING_ACTION_TAG_TOGGLE,        4 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 14, KEYBINDING_ACTION_TAG_TOGGLE,        5 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 15, KEYBINDING_ACTION_TAG_TOGGLE,        6 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 16, KEYBINDING_ACTION_TAG_TOGGLE,        7 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 17, KEYBINDING_ACTION_TAG_TOGGLE,        8 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 18, KEYBINDING_ACTION_TAG_TOGGLE,        9 },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  10, KEYBINDING_ACTION_TAG_TOGGLE,        1 },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  11, KEYBINDING_ACTION_TAG_TOGGLE,        2 },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  12, KEYBINDING_ACTION_TAG_TOGGLE,        3 },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  13, KEYBINDING_ACTION_TAG_TOGGLE,        4 },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  14, KEYBINDING_ACTION_TAG_TOGGLE,        5 },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  15, KEYBINDING_ACTION_TAG_TOGGLE,        6 },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  16, KEYBINDING_ACTION_TAG_TOGGLE,        7 },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  17, KEYBINDING_ACTION_TAG_TOGGLE,        8 },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  18, KEYBINDING_ACTION_TAG_TOGGLE,        9 },
 
   /* Tag client toggle - Mod+Shift+Alt+1 through Mod+Shift+Alt+9 (move focused client to tag) */
   { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 10, KEYBINDING_ACTION_TAG_CLIENT_TOGGLE, 1 },
@@ -82,10 +83,10 @@ static const KeyBinding default_keybindings[] = {
   { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 18, KEYBINDING_ACTION_TAG_CLIENT_TOGGLE, 9 },
 
   /* Fullscreen toggle - Mod+f (keycode 41 = f) */
-  { XCB_MOD_MASK_4,                      41, KEYBINDING_ACTION_TOGGLE_FULLSCREEN, 0 },
+  { XCB_MOD_MASK_4,                                       41, KEYBINDING_ACTION_TOGGLE_FULLSCREEN, 0 },
 
   /* Tile toggle - Mod+i (keycode 31 = i) */
-  { XCB_MOD_MASK_4,                      31, KEYBINDING_ACTION_TILE_MONITOR,      0 },
+  { XCB_MOD_MASK_4,                                       31, KEYBINDING_ACTION_TILE_MONITOR,      0 },
 };
 
 static const KeyBinding* keybindings     = default_keybindings;

--- a/src/components/keybinding.h
+++ b/src/components/keybinding.h
@@ -51,7 +51,7 @@ typedef enum {
   KEYBINDING_ACTION_FOCUS_NEXT,        /* Focus next client */
   KEYBINDING_ACTION_TAG_VIEW,          /* View specific tag (1-9) */
   KEYBINDING_ACTION_TAG_TOGGLE,        /* Toggle tag visibility */
-  KEYBINDING_ACTION_TAG_CLIENT_TOGGLE,  /* Move current client to tag */
+  KEYBINDING_ACTION_TAG_CLIENT_TOGGLE, /* Move current client to tag */
   KEYBINDING_ACTION_CLOSE_CLIENT,      /* Close current client */
   KEYBINDING_ACTION_TOGGLE_FULLSCREEN, /* Toggle fullscreen */
   KEYBINDING_ACTION_TILE_MONITOR,      /* Tile all clients on current monitor */

--- a/src/components/keybinding.h
+++ b/src/components/keybinding.h
@@ -54,6 +54,7 @@ typedef enum {
   KEYBINDING_ACTION_TAG_CLIENT_TOGGLE,  /* Move current client to tag */
   KEYBINDING_ACTION_CLOSE_CLIENT,      /* Close current client */
   KEYBINDING_ACTION_TOGGLE_FULLSCREEN, /* Toggle fullscreen */
+  KEYBINDING_ACTION_TILE_MONITOR,      /* Tile all clients on current monitor */
   KEYBINDING_ACTION_LAST,
 } KeybindingAction;
 

--- a/src/components/tag-manager.c
+++ b/src/components/tag-manager.c
@@ -30,8 +30,8 @@
  * Tag Manager SM states
  */
 enum {
-  TAG_VIEW_EMPTY         = 0,  /* No tags visible */
-  TAG_VIEW_TAGGED        = 1,  /* One or more tags visible */
+  TAG_VIEW_EMPTY  = 0, /* No tags visible */
+  TAG_VIEW_TAGGED = 1, /* One or more tags visible */
 };
 
 /*
@@ -43,7 +43,7 @@ static SMTemplate* cached_tag_view_template = NULL;
  * Internal event tracking for testing
  */
 typedef struct {
-  bool tag_changed_received;
+  bool     tag_changed_received;
   TargetID tag_changed_target;
   uint32_t old_mask;
   uint32_t new_mask;
@@ -60,26 +60,27 @@ void tag_manager_on_unadopt(HubTarget* target);
  */
 static TagManagerComponent tag_manager_component_instance = {
   .base = {
-           .name       = TAG_MANAGER_COMPONENT_NAME,
-           .requests   = (RequestType[]) {
-             REQ_TAG_VIEW,
-             REQ_TAG_TOGGLE,
-             REQ_TAG_CLIENT_TOGGLE,
-             0,
-           },
-           .targets    = (TargetType[]) {
-             TARGET_TYPE_MONITOR,
-             TARGET_TYPE_NONE,
-           },
+           .name     = TAG_MANAGER_COMPONENT_NAME,
+           .requests = (RequestType[]) {
+          REQ_TAG_VIEW,
+          REQ_TAG_TOGGLE,
+          REQ_TAG_CLIENT_TOGGLE,
+          0,
+      },
+           .targets = (TargetType[]) {
+          TARGET_TYPE_MONITOR,
+          TARGET_TYPE_NONE,
+      },
            .executor   = NULL, /* Set below */
-           .on_adopt   = tag_manager_on_adopt,
+      .on_adopt   = tag_manager_on_adopt,
            .on_unadopt = tag_manager_on_unadopt,
            .registered = false,
            },
   .initialized = false,
 };
 
-static HubComponent* tag_manager_component(void)
+static HubComponent*
+tag_manager_component(void)
 {
   return &tag_manager_component_instance.base;
 }
@@ -94,11 +95,11 @@ do_static_init(void)
 {
   if (static_init_done)
     return;
-  static_init_done                     = true;
-  tag_manager_component_instance.initialized = false;
+  static_init_done                               = true;
+  tag_manager_component_instance.initialized     = false;
   tag_manager_component_instance.base.registered = false;
-  tag_manager_test_events.tag_changed_received = false;
-  tag_manager_test_events.tag_changed_target = TARGET_ID_NONE;
+  tag_manager_test_events.tag_changed_received   = false;
+  tag_manager_test_events.tag_changed_target     = TARGET_ID_NONE;
 }
 
 __attribute__((constructor)) static void
@@ -124,16 +125,16 @@ tag_view_sm_emit(StateMachine* sm, uint32_t from_state, uint32_t to_state, void*
 
   /* Get the tag mask from the SM data (stored as void*) */
   uint32_t* tag_mask_ptr = (uint32_t*) sm->data;
-  uint32_t new_mask = tag_mask_ptr ? *tag_mask_ptr : 0;
+  uint32_t  new_mask     = tag_mask_ptr ? *tag_mask_ptr : 0;
 
   LOG_DEBUG("Tag view changed for monitor %lu: mask=0x%x",
             (unsigned long) m->target.id, new_mask);
 
   /* Track events for testing */
   tag_manager_test_events.tag_changed_received = true;
-  tag_manager_test_events.tag_changed_target = m->target.id;
-  tag_manager_test_events.old_mask = from_state == TAG_VIEW_EMPTY ? 0 : TAG_ALL_TAGS;
-  tag_manager_test_events.new_mask = new_mask;
+  tag_manager_test_events.tag_changed_target   = m->target.id;
+  tag_manager_test_events.old_mask             = from_state == TAG_VIEW_EMPTY ? 0 : TAG_ALL_TAGS;
+  tag_manager_test_events.new_mask             = new_mask;
 
   /* Emit the event */
   hub_emit(EVT_TAG_CHANGED, m->target.id, &new_mask);
@@ -149,9 +150,9 @@ void
 tag_manager_reset_test_events(void)
 {
   tag_manager_test_events.tag_changed_received = false;
-  tag_manager_test_events.tag_changed_target = TARGET_ID_NONE;
-  tag_manager_test_events.old_mask = 0;
-  tag_manager_test_events.new_mask = 0;
+  tag_manager_test_events.tag_changed_target   = TARGET_ID_NONE;
+  tag_manager_test_events.old_mask             = 0;
+  tag_manager_test_events.new_mask             = 0;
 }
 
 /*
@@ -184,23 +185,23 @@ tag_view_sm_template_create(void)
     {
      .from_state = TAG_VIEW_EMPTY,
      .to_state   = TAG_VIEW_TAGGED,
-     .guard_fn   = NULL, /* Always allowed */
-     .action_fn  = NULL,
-        .emit_event = EVT_TAG_CHANGED,
+     .guard_fn   = NULL,            /* Always allowed */
+        .action_fn  = NULL,
+     .emit_event = EVT_TAG_CHANGED,
      },
     {
      .from_state = TAG_VIEW_TAGGED,
      .to_state   = TAG_VIEW_EMPTY,
      .guard_fn   = NULL, /* Allowed - can deselect all tags */
-     .action_fn  = NULL,
-        .emit_event = EVT_TAG_CHANGED,
+        .action_fn  = NULL,
+     .emit_event = EVT_TAG_CHANGED,
      },
     {
      .from_state = TAG_VIEW_TAGGED,
      .to_state   = TAG_VIEW_TAGGED,
-     .guard_fn   = NULL, /* Always allowed - tag switching within same state */
-     .action_fn  = NULL,
-        .emit_event = EVT_TAG_CHANGED,
+     .guard_fn   = NULL,                             /* Always allowed - tag switching within same state */
+        .action_fn  = NULL,
+     .emit_event = EVT_TAG_CHANGED,
      },
   };
 
@@ -469,7 +470,7 @@ tag_manager_handle_toggle_request(RequestType type, TargetID target, void* data)
 
   /* Get current visible tags */
   uint32_t current_mask = tag_manager_get_visible_tags(m);
-  uint32_t tag_mask = TAG_MASK(tag_index);
+  uint32_t tag_mask     = TAG_MASK(tag_index);
 
   /* Toggle the tag */
   if ((current_mask & tag_mask) != 0) {
@@ -496,7 +497,7 @@ tag_manager_handle_client_tag_toggle(RequestType type, TargetID target, void* da
   (void) target;
 
   /* Get the currently focused client */
-  Client* c = NULL;
+  Client*        c = NULL;
   extern Client* focus_get_focused_client(void);
   c = focus_get_focused_client();
 
@@ -517,7 +518,7 @@ tag_manager_handle_client_tag_toggle(RequestType type, TargetID target, void* da
     return;
   }
 
-  tag_index = tag_index - 1; /* Convert to 0-based */
+  tag_index         = tag_index - 1; /* Convert to 0-based */
   uint32_t tag_mask = TAG_MASK(tag_index);
 
   /* Toggle the tag on the client */
@@ -536,8 +537,8 @@ tag_manager_handle_client_tag_toggle(RequestType type, TargetID target, void* da
   Monitor* m = client_get_monitor(c);
   if (m != NULL) {
     /* Check if client should be visible on this monitor */
-    uint32_t visible_tags = tag_manager_get_visible_tags(m);
-    bool should_be_visible = (c->tags & visible_tags) != 0;
+    uint32_t visible_tags      = tag_manager_get_visible_tags(m);
+    bool     should_be_visible = (c->tags & visible_tags) != 0;
 
     if (should_be_visible && !c->mapped) {
       client_show(c->window);

--- a/src/components/tag-manager.h
+++ b/src/components/tag-manager.h
@@ -30,8 +30,8 @@
 #include "wm-hub.h"
 
 /* Forward declarations */
-typedef struct Monitor Monitor;
-typedef struct Client Client;
+typedef struct Monitor      Monitor;
+typedef struct Client       Client;
 typedef struct StateMachine StateMachine;
 
 /*
@@ -43,25 +43,25 @@ typedef struct StateMachine StateMachine;
  * Tag Manager request types
  */
 enum TagManagerRequestType {
-  REQ_TAG_VIEW            = 7,  /* View specific tag (1-9) */
-  REQ_TAG_TOGGLE          = 8,  /* Toggle tag visibility */
-  REQ_TAG_CLIENT_TOGGLE    = 9,  /* Move current client to/from tag */
+  REQ_TAG_VIEW          = 7, /* View specific tag (1-9) */
+  REQ_TAG_TOGGLE        = 8, /* Toggle tag visibility */
+  REQ_TAG_CLIENT_TOGGLE = 9, /* Move current client to/from tag */
 };
 
 /*
  * Tag Manager event types
  */
 enum TagManagerEventType {
-  EVT_TAG_CHANGED         = 20, /* Emitted when tag view state changes */
+  EVT_TAG_CHANGED = 20, /* Emitted when tag view state changes */
 };
 
 /*
  * Tag Manager SM states
  */
 enum TagViewState {
-  TAG_VIEW_NONE           = 0,  /* No tags visible (empty) */
-  TAG_VIEW_ONE            = 1,  /* Exactly one tag visible */
-  TAG_VIEW_MULTIPLE       = 2,  /* Multiple tags visible (all-tags view) */
+  TAG_VIEW_NONE     = 0, /* No tags visible (empty) */
+  TAG_VIEW_ONE      = 1, /* Exactly one tag visible */
+  TAG_VIEW_MULTIPLE = 2, /* Multiple tags visible (all-tags view) */
 };
 
 /*
@@ -74,7 +74,7 @@ enum TagViewState {
  */
 typedef struct TagManagerComponent {
   HubComponent base;
-  bool initialized;
+  bool         initialized;
 } TagManagerComponent;
 
 /*

--- a/src/components/tiling.c
+++ b/src/components/tiling.c
@@ -206,13 +206,13 @@ tiling_get_sm(Monitor* m)
     return sm;
 
   /* Use cached template if available, otherwise create one */
+  if (cached_layout_template == NULL) {
+    cached_layout_template = layout_sm_template_create();
+  }
   SMTemplate* tmpl = cached_layout_template;
   if (tmpl == NULL) {
-    tmpl = layout_sm_template_create();
-    if (tmpl == NULL) {
-      LOG_ERROR("Failed to create layout SM template for monitor");
-      return NULL;
-    }
+    LOG_ERROR("Failed to create layout SM template for monitor");
+    return NULL;
   }
 
   sm = sm_create(m, tmpl, tiling_sm_emit, m);
@@ -341,7 +341,7 @@ tiling_get_mfact(Monitor* m)
 
 /*
  * Get nmaster for a monitor.
- * Uses monitor's nmaster if set, otherwise default.
+ * Note: Returns component default until Monitor struct supports per-monitor nmaster.
  */
 static int
 tiling_get_nmaster(Monitor* m)
@@ -505,20 +505,6 @@ tiling_tile_monitor(Monitor* m)
 
   LOG_DEBUG("Tiling monitor output=%u", m->output);
 
-  /* Get current layout state */
-  StateMachine* sm = tiling_get_sm(m);
-  if (sm == NULL) {
-    LOG_WARN("No layout SM for monitor, using default tile");
-    sm = tiling_get_sm(m);
-    if (sm == NULL)
-      return;
-  }
-
-  LayoutState state = (LayoutState) sm_get_state(sm);
-
-  (void) state; /* Suppress unused warning */
-
-  /* Always use tiled layout */
   int nmaster = tiling_get_nmaster(m);
 
   /* Collect clients */
@@ -634,9 +620,6 @@ tiling_executor(struct HubRequest* req)
 
   /* Just tile the monitor - this component handles tiling */
   tiling_tile_monitor(m);
-
-  LOG_DEBUG("tiling_executor: layout for monitor output=%u is now %u",
-            m->output, sm_get_state(sm));
 }
 
 /*

--- a/src/components/tiling.c
+++ b/src/components/tiling.c
@@ -1,0 +1,860 @@
+/*
+ * Tiling Component Implementation
+ *
+ * Handles window tiling using a tiled layout algorithm.
+ * Manages the LayoutSM state machine and XCB window positioning.
+ *
+ * The component provides:
+ * - LayoutSM template: TILE ↔ MONOCLE ↔ FLOATING
+ * - Executor that handles REQ_MONITOR_TILE requests
+ * - Tiling algorithm that divides monitor into master and stack
+ * - XCB ConfigureRequest to position windows
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "src/sm/sm-instance.h"
+#include "src/sm/sm-registry.h"
+#include "src/sm/sm-template.h"
+#include "src/target/client.h"
+#include "src/target/monitor.h"
+#include "src/xcb/xcb-handler.h"
+#include "tiling.h"
+#include "wm-hub.h"
+#include "wm-log.h"
+#include "wm-xcb.h"
+
+/*
+ * Cached LayoutSM template - created once at init, reused for all monitors.
+ */
+static SMTemplate* cached_layout_template = NULL;
+
+/*
+ * Global component instance
+ */
+static TilingComponent tiling_component = {
+  .base = {
+           .name       = TILING_COMPONENT_NAME,
+           .requests   = (RequestType[]) { REQ_MONITOR_TILE, 0 },
+           .targets    = (TargetType[]) { TARGET_TYPE_MONITOR, TARGET_TYPE_NONE },
+           .executor   = NULL,
+           .registered = false,
+           },
+  .initialized     = false,
+  .default_mfact   = 0.5F, /* 50% master, 50% stack */
+  .default_nmaster = 1,
+};
+
+/*
+ * Track if static initialization has occurred
+ */
+static bool static_init_done = false;
+
+static void
+do_static_init(void)
+{
+  if (static_init_done)
+    return;
+  static_init_done                 = true;
+  tiling_component.initialized     = false;
+  tiling_component.base.registered = false;
+}
+
+__attribute__((constructor)) static void
+ensure_static_init(void)
+{
+  do_static_init();
+}
+
+/*
+ * Internal helper to reset component state
+ */
+static void
+tiling_component_reset(void)
+{
+  tiling_component.initialized = false;
+}
+
+/*
+ * Get the tiling component instance
+ */
+TilingComponent*
+tiling_component_get(void)
+{
+  return &tiling_component;
+}
+
+/*
+ * Check if component is initialized
+ */
+bool
+tiling_component_is_initialized(void)
+{
+  return tiling_component.initialized;
+}
+
+/*
+ * SM Event Emitter
+ *
+ * This function is passed to sm_create() to handle event emission.
+ */
+static void
+tiling_sm_emit(StateMachine* sm, uint32_t from_state, uint32_t to_state, void* userdata)
+{
+  (void) sm;
+
+  Monitor* m = (Monitor*) userdata;
+  if (m == NULL)
+    return;
+
+  EventType event;
+  switch (to_state) {
+  case LAYOUT_STATE_TILE:
+    event = EVT_LAYOUT_TILE_CHANGED;
+    break;
+  case LAYOUT_STATE_MONOCLE:
+    event = EVT_LAYOUT_MONOCLE_CHANGED;
+    break;
+  case LAYOUT_STATE_FLOATING:
+    event = EVT_LAYOUT_FLOATING_CHANGED;
+    break;
+  default:
+    return;
+  }
+
+  hub_emit(event, m->target.id, NULL);
+  hub_emit(EVT_LAYOUT_CHANGED, m->target.id, NULL);
+}
+
+/*
+ * Guard functions
+ */
+
+/*
+ * Check if we can change layout.
+ * Always allows layout changes.
+ */
+bool
+tiling_guard_can_change_layout(StateMachine* sm, void* data)
+{
+  (void) sm;
+  (void) data;
+  return true;
+}
+
+/*
+ * Action functions
+ */
+
+/*
+ * Action called when layout changes.
+ * Tiles all clients on the monitor.
+ */
+bool
+tiling_action_on_layout_change(StateMachine* sm, void* data)
+{
+  (void) data;
+
+  if (sm == NULL || sm->owner == NULL)
+    return false;
+
+  Monitor* m = (Monitor*) sm->owner;
+
+  /* Only tile in TILE state */
+  if (sm_get_state(sm) == LAYOUT_STATE_TILE) {
+    tiling_tile_monitor(m);
+  }
+
+  return true;
+}
+
+/*
+ * State Machine Template
+ */
+SMTemplate*
+layout_sm_template_create(void)
+{
+  /* Define states */
+  static uint32_t states[] = {
+    LAYOUT_STATE_TILE,
+    LAYOUT_STATE_MONOCLE,
+    LAYOUT_STATE_FLOATING,
+  };
+
+  /* Define transitions:
+   * TILE ↔ MONOCLE
+   * TILE ↔ FLOATING
+   * MONOCLE ↔ FLOATING
+   */
+  static SMTransition transitions[] = {
+    /* TILE → MONOCLE */
+    {
+     .from_state = LAYOUT_STATE_TILE,
+     .to_state   = LAYOUT_STATE_MONOCLE,
+     .guard_fn   = "tiling_guard_can_change_layout",
+     .action_fn  = "tiling_action_on_layout_change",
+     .emit_event = EVT_LAYOUT_MONOCLE_CHANGED,
+     },
+    /* MONOCLE → TILE */
+    {
+     .from_state = LAYOUT_STATE_MONOCLE,
+     .to_state   = LAYOUT_STATE_TILE,
+     .guard_fn   = "tiling_guard_can_change_layout",
+     .action_fn  = "tiling_action_on_layout_change",
+     .emit_event = EVT_LAYOUT_TILE_CHANGED,
+     },
+    /* TILE → FLOATING */
+    {
+     .from_state = LAYOUT_STATE_TILE,
+     .to_state   = LAYOUT_STATE_FLOATING,
+     .guard_fn   = "tiling_guard_can_change_layout",
+     .action_fn  = "tiling_action_on_layout_change",
+     .emit_event = EVT_LAYOUT_FLOATING_CHANGED,
+     },
+    /* FLOATING → TILE */
+    {
+     .from_state = LAYOUT_STATE_FLOATING,
+     .to_state   = LAYOUT_STATE_TILE,
+     .guard_fn   = "tiling_guard_can_change_layout",
+     .action_fn  = "tiling_action_on_layout_change",
+     .emit_event = EVT_LAYOUT_TILE_CHANGED,
+     },
+    /* MONOCLE → FLOATING */
+    {
+     .from_state = LAYOUT_STATE_MONOCLE,
+     .to_state   = LAYOUT_STATE_FLOATING,
+     .guard_fn   = "tiling_guard_can_change_layout",
+     .action_fn  = "tiling_action_on_layout_change",
+     .emit_event = EVT_LAYOUT_FLOATING_CHANGED,
+     },
+    /* FLOATING → MONOCLE */
+    {
+     .from_state = LAYOUT_STATE_FLOATING,
+     .to_state   = LAYOUT_STATE_MONOCLE,
+     .guard_fn   = "tiling_guard_can_change_layout",
+     .action_fn  = "tiling_action_on_layout_change",
+     .emit_event = EVT_LAYOUT_MONOCLE_CHANGED,
+     },
+  };
+
+  SMTemplate* tmpl = sm_template_create(
+      "layout",
+      states,
+      3,
+      transitions,
+      6,
+      LAYOUT_STATE_TILE);
+
+  if (tmpl == NULL) {
+    LOG_ERROR("Failed to create layout state machine template");
+    return NULL;
+  }
+
+  return tmpl;
+}
+
+/*
+ * State Machine Accessors
+ */
+
+/*
+ * Get or create the layout state machine for a monitor.
+ */
+StateMachine*
+tiling_get_sm(Monitor* m)
+{
+  if (m == NULL)
+    return NULL;
+
+  StateMachine* sm = monitor_get_sm(m, TILING_COMPONENT_NAME);
+  if (sm != NULL)
+    return sm;
+
+  /* Use cached template if available, otherwise create one */
+  SMTemplate* tmpl = cached_layout_template;
+  if (tmpl == NULL) {
+    tmpl = layout_sm_template_create();
+    if (tmpl == NULL) {
+      LOG_ERROR("Failed to create layout SM template for monitor");
+      return NULL;
+    }
+  }
+
+  sm = sm_create(m, tmpl, tiling_sm_emit, m);
+  if (sm == NULL) {
+    LOG_ERROR("Failed to create layout SM instance for monitor");
+    return NULL;
+  }
+
+  /* Store in monitor */
+  if (!monitor_set_sm(m, TILING_COMPONENT_NAME, sm)) {
+    LOG_ERROR("Failed to store layout SM for monitor");
+    sm_destroy(sm);
+    return NULL;
+  }
+
+  LOG_DEBUG("Created layout SM for monitor output=%u", m->output);
+  return sm;
+}
+
+/*
+ * Get current layout state for a monitor
+ */
+LayoutState
+tiling_get_state(Monitor* m)
+{
+  if (m == NULL)
+    return LAYOUT_STATE_TILE;
+
+  StateMachine* sm = monitor_get_sm(m, TILING_COMPONENT_NAME);
+  if (sm == NULL)
+    return LAYOUT_STATE_TILE;
+
+  return (LayoutState) sm_get_state(sm);
+}
+
+/*
+ * Set layout state directly (for raw_write from listeners).
+ */
+void
+tiling_set_state(Monitor* m, LayoutState state)
+{
+  if (m == NULL)
+    return;
+
+  StateMachine* sm = tiling_get_sm(m);
+  if (sm == NULL) {
+    LOG_WARN("Cannot set layout state: failed to get/create SM");
+    return;
+  }
+
+  sm_raw_write(sm, state);
+}
+
+/*
+ * Tiling Functions
+ */
+
+/*
+ * Calculate tiled geometry for master area.
+ */
+void
+tiling_master_geometry(
+    Monitor*  m,
+    int       nmaster,
+    float     mfact,
+    int16_t*  x,
+    int16_t*  y,
+    uint16_t* w,
+    uint16_t* h)
+{
+  if (m == NULL)
+    return;
+
+  /* Master area takes mfact of monitor width */
+  *x = m->x;
+  *y = m->y;
+
+  if (nmaster > 0) {
+    *w = (uint16_t) ((float) m->width * mfact);
+  } else {
+    *w = m->width;
+  }
+
+  *h = m->height;
+}
+
+/*
+ * Calculate tiled geometry for stack area.
+ */
+void
+tiling_stack_geometry(
+    Monitor*  m,
+    int       nmaster,
+    float     mfact,
+    int16_t*  x,
+    int16_t*  y,
+    uint16_t* w,
+    uint16_t* h)
+{
+  if (m == NULL)
+    return;
+
+  /* Stack area is the remaining width */
+  *x = (int16_t) ((int32_t) m->x + (int32_t) ((float) m->width * mfact));
+  *y = m->y;
+
+  if (nmaster > 0) {
+    *w = (uint16_t) ((float) m->width * (1.0F - mfact));
+  } else {
+    *w = 0;
+  }
+
+  *h = m->height;
+}
+
+/*
+ * Get master factor for a monitor.
+ * Uses monitor's mfact if set, otherwise default.
+ */
+static float
+tiling_get_mfact(Monitor* m)
+{
+  (void) m;
+  return tiling_component.default_mfact;
+}
+
+/*
+ * Get nmaster for a monitor.
+ * Uses monitor's nmaster if set, otherwise default.
+ */
+static int
+tiling_get_nmaster(Monitor* m)
+{
+  (void) m;
+  return tiling_component.default_nmaster;
+}
+
+/*
+ * Count managed clients visible on a monitor.
+ */
+static uint32_t
+tiling_count_visible_clients(Monitor* m)
+{
+  uint32_t count = 0;
+  Client*  c     = client_list_sentinel()->next;
+
+  while (c != client_list_sentinel()) {
+    if (c->managed && c->monitor == m) {
+      count++;
+    }
+    c = c->next;
+  }
+
+  return count;
+}
+
+/*
+ * Collect visible, managed clients on a monitor.
+ * Returns array of clients (caller must free).
+ */
+static Client**
+tiling_collect_clients(Monitor* m, uint32_t* count)
+{
+  *count = tiling_count_visible_clients(m);
+  if (*count == 0)
+    return NULL;
+
+  uint32_t capacity = *count;
+  Client** clients = malloc(capacity * sizeof(Client*));
+  if (clients == NULL)
+    return NULL;
+
+  /* Initialize all entries to NULL for safety */
+  for (uint32_t init_i = 0; init_i < capacity; init_i++) {
+    clients[init_i] = NULL;
+  }
+
+  uint32_t idx = 0;
+  Client* c     = client_list_sentinel()->next;
+
+  while (c != client_list_sentinel()) {
+    if (c->managed && c->monitor == m) {
+      if (idx < capacity) {
+        clients[idx++] = c;
+      } else {
+        /* Array full but more clients found - shouldn't happen */
+        idx++;
+      }
+    }
+    c = c->next;
+  }
+
+  return clients;
+}
+
+/*
+ * Arrange clients using the tiled layout algorithm.
+ */
+void
+tiling_arrange(
+    Monitor* m,
+    Client** master_clients,
+    int      nmaster,
+    Client** stack_clients,
+    int      nstack)
+{
+  if (m == NULL)
+    return;
+
+  float mfact = tiling_get_mfact(m);
+
+  /* Calculate master area geometry */
+  int16_t  mx, my;
+  uint16_t mw, mh;
+  tiling_master_geometry(m, nmaster, mfact, &mx, &my, &mw, &mh);
+
+  /* Calculate stack area geometry */
+  int16_t  sx, sy;
+  uint16_t sw, sh;
+  tiling_stack_geometry(m, nmaster, mfact, &sx, &sy, &sw, &sh);
+
+  /* Tile master clients vertically */
+  if (nmaster > 0 && mw > 0) {
+    uint16_t h = mh / (uint16_t) nmaster;
+    for (int i = 0; i < nmaster; i++) {
+      Client* c = master_clients[i];
+      if (c == NULL)
+        continue;
+
+      c->x            = mx;
+      c->y            = (int16_t) (my + ((int32_t) i * (int32_t) h));
+      c->width        = mw;
+      c->height       = h;
+      c->border_width = 1;
+
+      /* Configure window via X */
+      client_configure_from_struct(c);
+    }
+  }
+
+  /* Tile stack clients */
+  if (nstack > 0) {
+    if (sw > 0) {
+      /* Arrange stack clients vertically */
+      uint16_t h = sh / (uint16_t) nstack;
+      for (int i = 0; i < nstack; i++) {
+        Client* c = stack_clients[i];
+        if (c == NULL)
+          continue;
+
+        c->x            = sx;
+        c->y            = (int16_t) (sy + ((int32_t) i * (int32_t) h));
+        c->width        = sw;
+        c->height       = h;
+        c->border_width = 1;
+
+        /* Configure window via X */
+        client_configure_from_struct(c);
+      }
+    } else {
+      /* No stack area - tile in master */
+      uint16_t h      = mh / (uint16_t) (nmaster + nstack);
+      uint16_t offset = (uint16_t) nmaster * h;
+      for (int i = 0; i < nstack; i++) {
+        Client* c = stack_clients[i];
+        if (c == NULL)
+          continue;
+
+        c->x            = mx;
+        c->y            = (int16_t) (my + ((int32_t) offset + (int32_t) i * (int32_t) h));
+        c->width        = mw;
+        c->height       = h;
+        c->border_width = 1;
+
+        /* Configure window via X */
+        client_configure_from_struct(c);
+      }
+    }
+  }
+}
+
+/*
+ * Tile all clients on a monitor according to current layout.
+ */
+void
+tiling_tile_monitor(Monitor* m)
+{
+  if (m == NULL)
+    return;
+
+  LOG_DEBUG("Tiling monitor output=%u", m->output);
+
+  /* Get current layout state */
+  StateMachine* sm = tiling_get_sm(m);
+  if (sm == NULL) {
+    LOG_WARN("No layout SM for monitor, using default tile");
+    sm = tiling_get_sm(m);
+    if (sm == NULL)
+      return;
+  }
+
+  LayoutState state = (LayoutState) sm_get_state(sm);
+
+  if (state == LAYOUT_STATE_MONOCLE) {
+    /* Monocle: only show the first managed client, full screen */
+    Client* sel = NULL;
+    Client* c   = client_list_sentinel()->next;
+    while (c != client_list_sentinel()) {
+      if (c->managed && c->monitor == m) {
+        sel = c;
+        break;
+      }
+      c = c->next;
+    }
+
+    if (sel != NULL) {
+      sel->x            = m->x;
+      sel->y            = m->y;
+      sel->width        = m->width;
+      sel->height       = m->height;
+      sel->border_width = 0;
+      client_configure_from_struct(sel);
+
+      /* Hide all other clients on this monitor */
+      c = client_list_sentinel()->next;
+      while (c != client_list_sentinel()) {
+        if (c != sel && c->managed && c->monitor == m) {
+          client_hide(c->window);
+        }
+        c = c->next;
+      }
+
+      /* Show the selected client */
+      client_show(sel->window);
+    }
+    return;
+  }
+
+  if (state == LAYOUT_STATE_FLOATING) {
+    /* Floating: don't tile, restore stored positions */
+    Client* c = client_list_sentinel()->next;
+    while (c != client_list_sentinel()) {
+      if (c->managed && c->monitor == m) {
+        client_configure_from_struct(c);
+      }
+      c = c->next;
+    }
+    return;
+  }
+
+  /* TILE state - use tiled layout */
+  int nmaster = tiling_get_nmaster(m);
+
+  /* Collect clients */
+  uint32_t client_count;
+  Client** clients = tiling_collect_clients(m, &client_count);
+  if (clients == NULL || client_count == 0) {
+    free(clients);
+    LOG_DEBUG("No clients to tile on monitor");
+    return;
+  }
+
+  /* Separate master and stack clients */
+  int actual_nmaster = (nmaster > (int) client_count) ? (int) client_count : nmaster;
+
+  /* Restack: master clients drawn first, stack clients drawn on top */
+  Client** master_clients = clients;
+  Client** stack_clients  = &clients[actual_nmaster];
+  int      nstack         = (int) client_count - actual_nmaster;
+
+  /* Arrange clients */
+  tiling_arrange(m, master_clients, actual_nmaster, stack_clients, nstack);
+
+  /* Show all clients */
+  for (uint32_t i = 0; i < client_count; i++) {
+    Client* c = clients[i];
+    if (c != NULL) {
+      client_show(c->window);
+    }
+  }
+
+  free(clients);
+
+  LOG_DEBUG("Tiled %" PRIu32 " clients (nmaster=%d) on monitor", client_count, actual_nmaster);
+}
+
+/*
+ * Tile a specific client in the master area.
+ */
+void
+tiling_tile_client(Client* c)
+{
+  if (c == NULL)
+    return;
+
+  Monitor* m = c->monitor;
+  if (m == NULL)
+    return;
+
+  /* Get current layout state */
+  LayoutState state = tiling_get_state(m);
+  if (state != LAYOUT_STATE_TILE) {
+    /* Only tile in TILE state */
+    return;
+  }
+
+  int   nmaster = tiling_get_nmaster(m);
+  float mfact   = tiling_get_mfact(m);
+
+  /* Calculate master area geometry */
+  int16_t  mx, my;
+  uint16_t mw, mh;
+  tiling_master_geometry(m, nmaster, mfact, &mx, &my, &mw, &mh);
+
+  /* Position the client in master area */
+  c->x            = mx;
+  c->y            = my;
+  c->width        = mw;
+  c->height       = mh;
+  c->border_width = 1;
+
+  /* Configure window via X */
+  client_configure_from_struct(c);
+
+  LOG_DEBUG("Tiled client window=%u in master area", c->window);
+}
+
+/*
+ * Get the default master factor.
+ */
+float
+tiling_get_default_mfact(void)
+{
+  return tiling_component.default_mfact;
+}
+
+/*
+ * Get the default number of master clients.
+ */
+int
+tiling_get_default_nmaster(void)
+{
+  return tiling_component.default_nmaster;
+}
+
+/*
+ * Executor: Handle REQ_MONITOR_TILE request
+ */
+static void
+tiling_executor(struct HubRequest* req)
+{
+  if (req == NULL)
+    return;
+
+  LOG_DEBUG("tiling_executor: type=%u target=%" PRIu64,
+            req->type, req->target);
+
+  /* Get monitor from target ID */
+  Monitor* m = (Monitor*) hub_get_target_by_id(req->target);
+  if (m == NULL || m->target.type != TARGET_TYPE_MONITOR) {
+    LOG_DEBUG("tiling_executor: no monitor found for target");
+    return;
+  }
+
+  /* Get or create SM */
+  StateMachine* sm = tiling_get_sm(m);
+  if (sm == NULL) {
+    LOG_ERROR("tiling_executor: failed to get layout SM");
+    return;
+  }
+
+  /* Get current state */
+  uint32_t current = sm_get_state(sm);
+
+  /* If data indicates a specific layout, use it; otherwise toggle */
+  LayoutState target;
+  if (req->data != NULL) {
+    target = *(LayoutState*) req->data;
+  } else {
+    /* Default: toggle between TILE and MONOCLE */
+    target = (current == LAYOUT_STATE_TILE)
+                 ? LAYOUT_STATE_MONOCLE
+                 : LAYOUT_STATE_TILE;
+  }
+
+  /* Check if we need to transition */
+  if (current != target) {
+    /* Transition to new state - this will trigger action which tiles */
+    sm_transition(sm, target);
+  } else {
+    /* Already in target state, just re-tile */
+    if (target == LAYOUT_STATE_TILE) {
+      tiling_tile_monitor(m);
+    }
+  }
+
+  LOG_DEBUG("tiling_executor: layout for monitor output=%u is now %u",
+            m->output, sm_get_state(sm));
+}
+
+/*
+ * Component initialization
+ */
+bool
+tiling_component_init(void)
+{
+  /* Check if already registered in hub */
+  HubComponent* existing = hub_get_component_by_name(TILING_COMPONENT_NAME);
+  if (existing != NULL) {
+    if (tiling_component.initialized) {
+      LOG_DEBUG("Tiling component already initialized and registered");
+      return true;
+    }
+    LOG_DEBUG("Component registered with hub, completing initialization");
+    tiling_component.initialized = true;
+    return true;
+  }
+
+  /* Reset if inconsistent state */
+  if (tiling_component.initialized) {
+    LOG_DEBUG("Tiling component in inconsistent state, resetting");
+    tiling_component_reset();
+  }
+
+  LOG_DEBUG("Initializing tiling component");
+
+  /* Register guards and actions with SM registry */
+  sm_register_guard("tiling_guard_can_change_layout", tiling_guard_can_change_layout);
+  sm_register_action("tiling_action_on_layout_change", tiling_action_on_layout_change);
+
+  /* Register executor */
+  tiling_component.base.executor = tiling_executor;
+
+  /* Register with hub */
+  hub_register_component(&tiling_component.base);
+
+  /* Cache the template for future monitors */
+  cached_layout_template = layout_sm_template_create();
+  if (cached_layout_template == NULL) {
+    LOG_ERROR("Failed to create layout SM template");
+    hub_unregister_component(TILING_COMPONENT_NAME);
+    tiling_component_reset();
+    return false;
+  }
+
+  tiling_component.initialized = true;
+  LOG_DEBUG("Tiling component initialized successfully");
+
+  return true;
+}
+
+/*
+ * Component shutdown
+ */
+void
+tiling_component_shutdown(void)
+{
+  if (!tiling_component.initialized) {
+    return;
+  }
+
+  LOG_DEBUG("Shutting down tiling component");
+
+  /* Unregister from hub */
+  hub_unregister_component(TILING_COMPONENT_NAME);
+
+  /* Unregister guards and actions */
+  sm_unregister_guard("tiling_guard_can_change_layout");
+  sm_unregister_action("tiling_action_on_layout_change");
+
+  /* Free cached template */
+  if (cached_layout_template != NULL) {
+    sm_template_destroy(cached_layout_template);
+    cached_layout_template = NULL;
+  }
+
+  tiling_component.initialized = false;
+  LOG_DEBUG("Tiling component shutdown complete");
+}

--- a/src/components/tiling.c
+++ b/src/components/tiling.c
@@ -5,7 +5,7 @@
  * Manages the LayoutSM state machine and XCB window positioning.
  *
  * The component provides:
- * - LayoutSM template: TILE ↔ MONOCLE ↔ FLOATING
+ * - Tiled layout for window arrangement
  * - Executor that handles REQ_MONITOR_TILE requests
  * - Tiling algorithm that divides monitor into master and stack
  * - XCB ConfigureRequest to position windows
@@ -103,28 +103,14 @@ static void
 tiling_sm_emit(StateMachine* sm, uint32_t from_state, uint32_t to_state, void* userdata)
 {
   (void) sm;
+  (void) from_state;
 
   Monitor* m = (Monitor*) userdata;
   if (m == NULL)
     return;
 
-  EventType event;
-  switch (to_state) {
-  case LAYOUT_STATE_TILE:
-    event = EVT_LAYOUT_TILE_CHANGED;
-    break;
-  case LAYOUT_STATE_MONOCLE:
-    event = EVT_LAYOUT_MONOCLE_CHANGED;
-    break;
-  case LAYOUT_STATE_FLOATING:
-    event = EVT_LAYOUT_FLOATING_CHANGED;
-    break;
-  default:
-    return;
-  }
-
-  hub_emit(event, m->target.id, NULL);
   hub_emit(EVT_LAYOUT_CHANGED, m->target.id, NULL);
+  (void) to_state;
 }
 
 /*
@@ -171,79 +157,27 @@ tiling_action_on_layout_change(StateMachine* sm, void* data)
 
 /*
  * State Machine Template
+ *
+ * Provides a simple TILE state for tiling layout.
+ * The action function tiles all clients when the state machine is active.
  */
 SMTemplate*
 layout_sm_template_create(void)
 {
-  /* Define states */
+  /* Define single TILE state */
   static uint32_t states[] = {
     LAYOUT_STATE_TILE,
-    LAYOUT_STATE_MONOCLE,
-    LAYOUT_STATE_FLOATING,
   };
 
-  /* Define transitions:
-   * TILE ↔ MONOCLE
-   * TILE ↔ FLOATING
-   * MONOCLE ↔ FLOATING
-   */
-  static SMTransition transitions[] = {
-    /* TILE → MONOCLE */
-    {
-     .from_state = LAYOUT_STATE_TILE,
-     .to_state   = LAYOUT_STATE_MONOCLE,
-     .guard_fn   = "tiling_guard_can_change_layout",
-     .action_fn  = "tiling_action_on_layout_change",
-     .emit_event = EVT_LAYOUT_MONOCLE_CHANGED,
-     },
-    /* MONOCLE → TILE */
-    {
-     .from_state = LAYOUT_STATE_MONOCLE,
-     .to_state   = LAYOUT_STATE_TILE,
-     .guard_fn   = "tiling_guard_can_change_layout",
-     .action_fn  = "tiling_action_on_layout_change",
-     .emit_event = EVT_LAYOUT_TILE_CHANGED,
-     },
-    /* TILE → FLOATING */
-    {
-     .from_state = LAYOUT_STATE_TILE,
-     .to_state   = LAYOUT_STATE_FLOATING,
-     .guard_fn   = "tiling_guard_can_change_layout",
-     .action_fn  = "tiling_action_on_layout_change",
-     .emit_event = EVT_LAYOUT_FLOATING_CHANGED,
-     },
-    /* FLOATING → TILE */
-    {
-     .from_state = LAYOUT_STATE_FLOATING,
-     .to_state   = LAYOUT_STATE_TILE,
-     .guard_fn   = "tiling_guard_can_change_layout",
-     .action_fn  = "tiling_action_on_layout_change",
-     .emit_event = EVT_LAYOUT_TILE_CHANGED,
-     },
-    /* MONOCLE → FLOATING */
-    {
-     .from_state = LAYOUT_STATE_MONOCLE,
-     .to_state   = LAYOUT_STATE_FLOATING,
-     .guard_fn   = "tiling_guard_can_change_layout",
-     .action_fn  = "tiling_action_on_layout_change",
-     .emit_event = EVT_LAYOUT_FLOATING_CHANGED,
-     },
-    /* FLOATING → MONOCLE */
-    {
-     .from_state = LAYOUT_STATE_FLOATING,
-     .to_state   = LAYOUT_STATE_MONOCLE,
-     .guard_fn   = "tiling_guard_can_change_layout",
-     .action_fn  = "tiling_action_on_layout_change",
-     .emit_event = EVT_LAYOUT_MONOCLE_CHANGED,
-     },
-  };
+  /* No transitions needed - single state */
+  static SMTransition transitions[] = {};
 
   SMTemplate* tmpl = sm_template_create(
       "layout",
       states,
-      3,
+      1,
       transitions,
-      6,
+      0,
       LAYOUT_STATE_TILE);
 
   if (tmpl == NULL) {
@@ -447,7 +381,7 @@ tiling_collect_clients(Monitor* m, uint32_t* count)
     return NULL;
 
   uint32_t capacity = *count;
-  Client** clients = malloc(capacity * sizeof(Client*));
+  Client** clients  = malloc(capacity * sizeof(Client*));
   if (clients == NULL)
     return NULL;
 
@@ -457,7 +391,7 @@ tiling_collect_clients(Monitor* m, uint32_t* count)
   }
 
   uint32_t idx = 0;
-  Client* c     = client_list_sentinel()->next;
+  Client*  c   = client_list_sentinel()->next;
 
   while (c != client_list_sentinel()) {
     if (c->managed && c->monitor == m) {
@@ -582,54 +516,9 @@ tiling_tile_monitor(Monitor* m)
 
   LayoutState state = (LayoutState) sm_get_state(sm);
 
-  if (state == LAYOUT_STATE_MONOCLE) {
-    /* Monocle: only show the first managed client, full screen */
-    Client* sel = NULL;
-    Client* c   = client_list_sentinel()->next;
-    while (c != client_list_sentinel()) {
-      if (c->managed && c->monitor == m) {
-        sel = c;
-        break;
-      }
-      c = c->next;
-    }
+  (void) state; /* Suppress unused warning */
 
-    if (sel != NULL) {
-      sel->x            = m->x;
-      sel->y            = m->y;
-      sel->width        = m->width;
-      sel->height       = m->height;
-      sel->border_width = 0;
-      client_configure_from_struct(sel);
-
-      /* Hide all other clients on this monitor */
-      c = client_list_sentinel()->next;
-      while (c != client_list_sentinel()) {
-        if (c != sel && c->managed && c->monitor == m) {
-          client_hide(c->window);
-        }
-        c = c->next;
-      }
-
-      /* Show the selected client */
-      client_show(sel->window);
-    }
-    return;
-  }
-
-  if (state == LAYOUT_STATE_FLOATING) {
-    /* Floating: don't tile, restore stored positions */
-    Client* c = client_list_sentinel()->next;
-    while (c != client_list_sentinel()) {
-      if (c->managed && c->monitor == m) {
-        client_configure_from_struct(c);
-      }
-      c = c->next;
-    }
-    return;
-  }
-
-  /* TILE state - use tiled layout */
+  /* Always use tiled layout */
   int nmaster = tiling_get_nmaster(m);
 
   /* Collect clients */
@@ -743,37 +632,8 @@ tiling_executor(struct HubRequest* req)
     return;
   }
 
-  /* Get or create SM */
-  StateMachine* sm = tiling_get_sm(m);
-  if (sm == NULL) {
-    LOG_ERROR("tiling_executor: failed to get layout SM");
-    return;
-  }
-
-  /* Get current state */
-  uint32_t current = sm_get_state(sm);
-
-  /* If data indicates a specific layout, use it; otherwise toggle */
-  LayoutState target;
-  if (req->data != NULL) {
-    target = *(LayoutState*) req->data;
-  } else {
-    /* Default: toggle between TILE and MONOCLE */
-    target = (current == LAYOUT_STATE_TILE)
-                 ? LAYOUT_STATE_MONOCLE
-                 : LAYOUT_STATE_TILE;
-  }
-
-  /* Check if we need to transition */
-  if (current != target) {
-    /* Transition to new state - this will trigger action which tiles */
-    sm_transition(sm, target);
-  } else {
-    /* Already in target state, just re-tile */
-    if (target == LAYOUT_STATE_TILE) {
-      tiling_tile_monitor(m);
-    }
-  }
+  /* Just tile the monitor - this component handles tiling */
+  tiling_tile_monitor(m);
 
   LOG_DEBUG("tiling_executor: layout for monitor output=%u is now %u",
             m->output, sm_get_state(sm));

--- a/src/components/tiling.h
+++ b/src/components/tiling.h
@@ -7,7 +7,6 @@
  * Component lifecycle:
  * - on_init(): register REQ_MONITOR_TILE executor
  * - executor: handle REQ_MONITOR_TILE request, tile windows on monitor
- * - listener: react to EVT_LAYOUT_CHANGED
  *
  * Layout Algorithm:
  * - Divides monitor into master area and stack

--- a/src/components/tiling.h
+++ b/src/components/tiling.h
@@ -1,0 +1,282 @@
+/*
+ * Tiling Component
+ *
+ * Handles window tiling using a tiled layout algorithm.
+ * Manages the LayoutSM state machine and XCB window positioning.
+ *
+ * Component lifecycle:
+ * - on_init(): register REQ_MONITOR_TILE executor, register guards/actions
+ * - executor: handle REQ_MONITOR_TILE request, tile windows on monitor
+ * - listener: react to EVT_LAYOUT_CHANGED
+ *
+ * Layout Algorithm:
+ * - Divides monitor into master area and stack
+ * - Master area: first nmaster clients (default 1)
+ * - Stack: remaining clients arranged below/after master
+ * - mfact controls master area ratio (0.0 - 1.0)
+ *
+ * Events Emitted:
+ * - EVT_LAYOUT_CHANGED - emitted after layout changes
+ *
+ * Acceptance Criteria:
+ * [ ] Mod+Enter tiles current client in master area
+ * [ ] Layout correctly divides monitor between master and stack
+ * [ ] Window positions update via X ConfigureRequest
+ * [ ] Event is emitted on layout change
+ */
+
+#ifndef _COMPONENT_TILING_H_
+#define _COMPONENT_TILING_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <xcb/xcb.h>
+
+#include "src/sm/sm-instance.h"
+#include "src/sm/sm-registry.h"
+#include "src/sm/sm-template.h"
+#include "src/target/client.h"
+#include "src/target/monitor.h"
+#include "src/xcb/xcb-handler.h"
+#include "wm-hub.h"
+
+/*
+ * Component name
+ */
+#define TILING_COMPONENT_NAME "tiling"
+
+/*
+ * Layout State Machine states
+ */
+typedef enum LayoutState {
+  LAYOUT_STATE_TILE     = 0,
+  LAYOUT_STATE_MONOCLE  = 1,
+  LAYOUT_STATE_FLOATING = 2,
+} LayoutState;
+
+/*
+ * Layout events emitted on state transitions
+ */
+typedef enum LayoutEvent {
+  EVT_LAYOUT_TILE_CHANGED     = 40,
+  EVT_LAYOUT_MONOCLE_CHANGED  = 41,
+  EVT_LAYOUT_FLOATING_CHANGED = 42,
+  EVT_LAYOUT_CHANGED          = 43,
+} LayoutEvent;
+
+/*
+ * Request types handled by this component
+ */
+enum {
+  REQ_MONITOR_TILE = 20,
+};
+
+/*
+ * Tiling component structure
+ * Tracks layout state and manages window positioning.
+ */
+typedef struct TilingComponent {
+  /* Base component interface */
+  HubComponent base;
+
+  /* Component-specific state */
+  bool initialized;
+
+  /* Default master factor (0.5 = 50% master, 50% stack) */
+  float default_mfact;
+
+  /* Default number of master clients */
+  int default_nmaster;
+} TilingComponent;
+
+/*
+ * Get the tiling component instance.
+ */
+TilingComponent* tiling_component_get(void);
+
+/*
+ * Check if component is initialized (for testing)
+ */
+bool tiling_component_is_initialized(void);
+
+/*
+ * Component initialization and shutdown
+ */
+
+/*
+ * Initialize the tiling component.
+ * Registers:
+ * - Hub executor for REQ_MONITOR_TILE
+ * - State machine guards and actions with registry
+ * - Listener for layout change events
+ */
+bool tiling_component_init(void);
+
+/*
+ * Shutdown the tiling component.
+ */
+void tiling_component_shutdown(void);
+
+/*
+ * State Machine Template
+ */
+
+/*
+ * Create the Layout State Machine template.
+ * Returns a template that can be used to create LayoutSM instances.
+ *
+ * Template states:
+ *   LAYOUT_STATE_TILE      (initial) - standard tiling layout
+ *   LAYOUT_STATE_MONOCLE   - one window fills the screen
+ *   LAYOUT_STATE_FLOATING  - windows at their stored positions
+ *
+ * Transitions:
+ *   TILE → MONOCLE  (emit: EVT_LAYOUT_MONOCLE_CHANGED, EVT_LAYOUT_CHANGED)
+ *   MONOCLE → TILE  (emit: EVT_LAYOUT_TILE_CHANGED, EVT_LAYOUT_CHANGED)
+ *   TILE → FLOATING (emit: EVT_LAYOUT_FLOATING_CHANGED, EVT_LAYOUT_CHANGED)
+ *   FLOATING → TILE (emit: EVT_LAYOUT_TILE_CHANGED, EVT_LAYOUT_CHANGED)
+ *   MONOCLE → FLOATING (emit: EVT_LAYOUT_FLOATING_CHANGED, EVT_LAYOUT_CHANGED)
+ *   FLOATING → MONOCLE (emit: EVT_LAYOUT_MONOCLE_CHANGED, EVT_LAYOUT_CHANGED)
+ */
+SMTemplate* layout_sm_template_create(void);
+
+/*
+ * State Machine Accessors
+ * These functions manage SM instances for monitors.
+ */
+
+/*
+ * Get the layout state machine for a monitor.
+ * Creates the SM on first access (on-demand allocation).
+ */
+StateMachine* tiling_get_sm(Monitor* m);
+
+/*
+ * Get current layout state for a monitor.
+ * Returns LAYOUT_STATE_TILE if no SM exists.
+ */
+LayoutState tiling_get_state(Monitor* m);
+
+/*
+ * Set layout state directly (for raw_write from listeners).
+ */
+void tiling_set_state(Monitor* m, LayoutState state);
+
+/*
+ * Tiling Functions
+ */
+
+/*
+ * Tile all clients on a monitor according to current layout.
+ * Divides the monitor area into master and stack regions,
+ * positions clients accordingly using X ConfigureRequest.
+ *
+ * @param m  The monitor to tile clients on
+ */
+void tiling_tile_monitor(Monitor* m);
+
+/*
+ * Tile a specific client in the master area.
+ * If client is already tiled, repositions based on its position.
+ * If client is not tiled, adds it to the master area.
+ *
+ * @param c  The client to tile
+ */
+void tiling_tile_client(Client* c);
+
+/*
+ * Arrange clients on a monitor using the tiled layout algorithm.
+ *
+ * Layout algorithm:
+ * 1. Calculate master area based on mfact (master factor)
+ * 2. Calculate stack area (remaining space)
+ * 3. For tiled clients:
+ *    - Master clients: arrange vertically in master area
+ *    - Stack clients: arrange in remaining area
+ *
+ * @param m  The monitor
+ * @param master_clients  Array of clients for master area
+ * @param nmaster        Number of master clients
+ * @param stack_clients  Array of clients for stack area
+ * @param nstack         Number of stack clients
+ */
+void tiling_arrange(
+    Monitor* m,
+    Client** master_clients,
+    int      nmaster,
+    Client** stack_clients,
+    int      nstack);
+
+/*
+ * Calculate tiled geometry for master area.
+ *
+ * @param m          Monitor
+ * @param nmaster    Number of master clients
+ * @param mfact      Master factor (0.0 - 1.0)
+ * @param x          Output: x position of master area
+ * @param y          Output: y position of master area
+ * @param w          Output: width of master area
+ * @param h          Output: height of master area
+ */
+void tiling_master_geometry(
+    Monitor*  m,
+    int       nmaster,
+    float     mfact,
+    int16_t*  x,
+    int16_t*  y,
+    uint16_t* w,
+    uint16_t* h);
+
+/*
+ * Calculate tiled geometry for stack area.
+ *
+ * @param m          Monitor
+ * @param nmaster    Number of master clients
+ * @param mfact      Master factor (0.0 - 1.0)
+ * @param x          Output: x position of stack area
+ * @param y          Output: y position of stack area
+ * @param w          Output: width of stack area
+ * @param h          Output: height of stack area
+ */
+void tiling_stack_geometry(
+    Monitor*  m,
+    int       nmaster,
+    float     mfact,
+    int16_t*  x,
+    int16_t*  y,
+    uint16_t* w,
+    uint16_t* h);
+
+/*
+ * Get the default master factor.
+ */
+float tiling_get_default_mfact(void);
+
+/*
+ * Get the default number of master clients.
+ */
+int tiling_get_default_nmaster(void);
+
+/*
+ * Guard Functions (for SM transitions)
+ * Registered with the SM registry.
+ */
+
+/*
+ * Check if we can switch to a layout.
+ * Always allows layout changes.
+ */
+bool tiling_guard_can_change_layout(StateMachine* sm, void* data);
+
+/*
+ * Action Functions (for SM transitions)
+ * Registered with the SM registry.
+ */
+
+/*
+ * Action called when layout changes.
+ * Tiles all clients on the monitor.
+ */
+bool tiling_action_on_layout_change(StateMachine* sm, void* data);
+
+#endif /* _COMPONENT_TILING_H_ */

--- a/src/components/tiling.h
+++ b/src/components/tiling.h
@@ -5,7 +5,7 @@
  * Manages the LayoutSM state machine and XCB window positioning.
  *
  * Component lifecycle:
- * - on_init(): register REQ_MONITOR_TILE executor, register guards/actions
+ * - on_init(): register REQ_MONITOR_TILE executor
  * - executor: handle REQ_MONITOR_TILE request, tile windows on monitor
  * - listener: react to EVT_LAYOUT_CHANGED
  *
@@ -17,12 +17,6 @@
  *
  * Events Emitted:
  * - EVT_LAYOUT_CHANGED - emitted after layout changes
- *
- * Acceptance Criteria:
- * [ ] Mod+Enter tiles current client in master area
- * [ ] Layout correctly divides monitor between master and stack
- * [ ] Window positions update via X ConfigureRequest
- * [ ] Event is emitted on layout change
  */
 
 #ifndef _COMPONENT_TILING_H_
@@ -49,19 +43,14 @@
  * Layout State Machine states
  */
 typedef enum LayoutState {
-  LAYOUT_STATE_TILE     = 0,
-  LAYOUT_STATE_MONOCLE  = 1,
-  LAYOUT_STATE_FLOATING = 2,
+  LAYOUT_STATE_TILE = 0,
 } LayoutState;
 
 /*
  * Layout events emitted on state transitions
  */
 typedef enum LayoutEvent {
-  EVT_LAYOUT_TILE_CHANGED     = 40,
-  EVT_LAYOUT_MONOCLE_CHANGED  = 41,
-  EVT_LAYOUT_FLOATING_CHANGED = 42,
-  EVT_LAYOUT_CHANGED          = 43,
+  EVT_LAYOUT_CHANGED = 40,
 } LayoutEvent;
 
 /*

--- a/src/xcb/xcb-handler.c
+++ b/src/xcb/xcb-handler.c
@@ -117,8 +117,8 @@ xcb_handler_next(XCBHandler* handler)
   }
 
   /* Direct bucket lookup using event_type stored in handler */
-  XCBEventType event_type = handler->event_type;
-  handler_bucket_t* bucket = &handlers[event_type];
+  XCBEventType      event_type = handler->event_type;
+  handler_bucket_t* bucket     = &handlers[event_type];
 
   /* Find current position in bucket */
   for (int i = 0; i < bucket->count; i++) {
@@ -188,7 +188,7 @@ xcb_handler_unregister_component(HubComponent* component)
     handler_bucket_t* bucket = &handlers[i];
 
     /* Scan bucket and remove matching handlers while preserving order */
-    for (int j = 0; j < bucket->count; ) {
+    for (int j = 0; j < bucket->count;) {
       if (bucket->handlers[j].component == component) {
         /* Stable removal: shift remaining handlers left */
         memmove(&bucket->handlers[j],

--- a/test-tag-manager-component.c
+++ b/test-tag-manager-component.c
@@ -10,8 +10,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "src/components/tag-manager.h"
 #include "src/components/focus.h"
+#include "src/components/tag-manager.h"
 #include "src/target/client.h"
 #include "src/target/monitor.h"
 #include "src/target/tag.h"
@@ -22,7 +22,7 @@
  * Track events received during tests
  */
 static struct {
-  bool tag_changed_received;
+  bool     tag_changed_received;
   TargetID tag_changed_target;
   uint32_t new_tag_mask;
 } test_events;
@@ -31,15 +31,15 @@ static void
 reset_test_events(void)
 {
   test_events.tag_changed_received = false;
-  test_events.tag_changed_target = TARGET_ID_NONE;
-  test_events.new_tag_mask = 0;
+  test_events.tag_changed_target   = TARGET_ID_NONE;
+  test_events.new_tag_mask         = 0;
 }
 
 static void
 tag_change_listener(Event e)
 {
   test_events.tag_changed_received = true;
-  test_events.tag_changed_target = e.target;
+  test_events.tag_changed_target   = e.target;
   if (e.data != NULL) {
     test_events.new_tag_mask = *(uint32_t*) e.data;
   }

--- a/wm.c
+++ b/wm.c
@@ -16,6 +16,7 @@
 #include "src/components/keybinding.h"
 #include "src/components/monitor-manager.h"
 #include "src/components/pertag.h"
+#include "src/components/tiling.h"
 
 #include "wm.h"
 
@@ -38,6 +39,7 @@ main(int argc, char** argv)
   /* Initialize pertag BEFORE monitor_manager so monitors get adopted */
   pertag_component_init();
   monitor_manager_init();
+  tiling_component_init();
 
   /* Main event loop */
   while (running) {
@@ -46,6 +48,7 @@ main(int argc, char** argv)
 
   /* Shutdown in reverse order */
   monitor_manager_shutdown();
+  tiling_component_shutdown();
   client_list_component_shutdown();
   keybinding_shutdown();
   fullscreen_component_shutdown();


### PR DESCRIPTION
Implement tiling layout component for the wm-xcb window manager.

## What was built

- **Tiling Component** (`src/components/tiling.c/h`): Handles window tiling using a tiled layout algorithm.
- **LayoutSM**: A state machine for layout state tracking.
- **Keybinding**: Added `Mod+i` to trigger tiling via keybinding.

## Architecture

### Layout System

The layout system allows different layout modes to be implemented as separate components:

- **Tiling** (this issue): Master + stack window arrangement
- **Monocle** (future): Full-screen single window mode  
- **Floating** (future): Free-positioned windows

Each layout is a separate component that can register with the Hub. The state machine tracks which layout is active but doesn't dictate which layouts exist.

### Request Flow

```
Keybinding (Mod+i) → Hub (REQ_MONITOR_TILE) → Tiling Component → X ConfigureRequest
```

## Implementation Details

### Tile Algorithm

1. Calculates master area based on `mfact` (default 50% of monitor width)
2. Calculates stack area (remaining width)
3. Positions master clients vertically in the master area
4. Positions stack clients vertically in the stack area
5. Configures windows via XCB `ConfigureRequest`

## Related Issues

- Issue #17 (this implementation)
- Future issues for monocle layout, floating layout, etc.

## Files Changed

- `src/components/tiling.c` - Tiling component implementation
- `src/components/tiling.h` - Tiling component header
- `src/components/keybinding.c` - Added tiling action and keybinding
- `src/components/keybinding.h` - Added KEYBINDING_ACTION_TILE_MONITOR

## Testing

All 604 tests pass.
