### PR TITLE
feat: implement Actions and Wiring architecture (issue #83)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,12 +49,13 @@ SRC_SM      = $(wildcard src/sm/*.c)
 SRC_XCB     = $(wildcard src/xcb/*.c)
 SRC_TARGET  = $(wildcard src/target/*.c)
 SRC_COMP    = $(wildcard src/components/*.c)
+SRC_ACTIONS = $(wildcard src/actions/*.c)
 
 # Main executable object (must be excluded from test link)
 MAIN_OBJ = $(NAME).o
 
 # All main source files
-SRC = $(ROOT_SRC) $(SRC_SM) $(SRC_XCB) $(SRC_TARGET) $(SRC_COMP)
+SRC = $(ROOT_SRC) $(SRC_SM) $(SRC_XCB) $(SRC_TARGET) $(SRC_COMP) $(SRC_ACTIONS)
 OBJ = $(SRC:.c=.o)
 
 # Test source files

--- a/docs/architecture/actions.md
+++ b/docs/architecture/actions.md
@@ -1,0 +1,633 @@
+# Actions and Wiring Architecture
+
+*Part of architecture documentation — Authoritative*
+*Last updated: 2026-04-30*
+
+> **💡 Design Decision:** Actions are the public API of components. Keybindings don't hardcode actions — they query the action registry and wire triggers to action names.
+
+---
+
+## Purpose
+
+The Actions and Wiring system provides:
+1. **Components expose callable actions** — e.g., `fullscreen.toggle()`, `tag_manager.view(1)`
+2. **Declarative wiring** — config wires key combos to action names
+3. **Target resolution** — actions receive targets at call time, not binding time
+
+This decouples keybindings from component internals. A component owns its actions; config wires triggers to them.
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        CONFIG LAYER                              │
+│                                                                  │
+│  config.def.h:                                                   │
+│    keybinding_register("Mod+f",  "fullscreen.toggle");           │
+│    keybinding_register("Mod+1",  "tag-manager.view", 1);         │
+│    keybinding_register("Mod+Enter", "focus.focus-current");      │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                        ACTION REGISTRY                           │
+│                                                                  │
+│  Component A:           Component B:           Component C:     │
+│    "fullscreen.toggle"    "tag-manager.view"     "focus.focus"   │
+│    "fullscreen.enable"    "tag-manager.toggle"                     │
+│                                                                  │
+│  Each action knows:                                              │
+│  - Name (unique string)                                           │
+│  - Signature (parameters)                                         │
+│  - Handler function                                               │
+│  - Default target resolver                                       │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                        KEYBINDING COMPONENT                      │
+│                                                                  │
+│  KEY_PRESS → lookup(key, mods) → resolve target → invoke action  │
+│                                                                  │
+│  KeyBindingMap:                                                   │
+│    "Mod+f" → ActionRef { name="fullscreen.toggle", target=NONE } │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Action Definition
+
+An **Action** is a callable function with a name and signature.
+
+### Action Structure
+
+```c
+/*
+ * Action callback signature
+ * Returns true on success, false on failure.
+ */
+typedef bool (*ActionCallback)(ActionInvocation* inv);
+
+/*
+ * Action invocation context
+ * Passed to action callbacks with resolved target and arguments.
+ */
+typedef struct ActionInvocation {
+  TargetID target;           /* Resolved target (e.g., current client) */
+  void*    data;             /* Action-specific data (e.g., tag number) */
+  uint64_t correlation_id;   /* For async response tracking */
+  void*    userdata;         /* Per-binding userdata */
+} ActionInvocation;
+
+/*
+ * Action definition
+ */
+typedef struct Action {
+  const char*       name;        /* Unique action name, e.g., "fullscreen.toggle" */
+  const char*       description; /* Human-readable description */
+  ActionCallback    callback;    /* Function to call */
+  TargetResolver    target_resolver; /* How to resolve .target field */
+  void*             userdata;    /* Component-specific data */
+} Action;
+
+/*
+ * Target resolver function
+ * Called at action invocation to determine the target.
+ * Return TARGET_ID_NONE if no target available.
+ */
+typedef TargetID (*TargetResolver)(ActionInvocation* inv);
+
+/*
+ * Built-in target resolvers
+ */
+TargetID resolve_current_client(ActionInvocation* inv);   /* Focus component */
+TargetID resolve_current_monitor(ActionInvocation* inv); /* Monitor manager */
+TargetID resolve_bound_target(ActionInvocation* inv);    /* From binding */
+TargetID resolve_none(ActionInvocation* inv);             /* No target needed */
+```
+
+### Action Registration API
+
+```c
+/*
+ * Register an action with the action registry.
+ * Returns true on success, false if name already exists.
+ */
+bool action_register(Action* action);
+
+/*
+ * Unregister an action by name.
+ * Returns true if found and removed, false if not found.
+ */
+bool action_unregister(const char* name);
+
+/*
+ * Look up an action by name.
+ * Returns NULL if not found.
+ */
+Action* action_lookup(const char* name);
+
+/*
+ * Get all registered actions.
+ * Returns NULL-terminated array.
+ */
+Action** action_get_all(void);
+```
+
+---
+
+## Binding Definition
+
+A **Binding** connects a trigger (key combination) to an action (named function).
+
+### Binding Structure
+
+```c
+/*
+ * Key binding trigger types
+ */
+typedef enum {
+  BINDING_TYPE_KEY,      /* Keyboard key combination */
+  BINDING_TYPE_BUTTON,   /* Mouse button */
+  BINDING_TYPE_POINTER,  /* Pointer drag/resize */
+} BindingType;
+
+/*
+ * Binding entry
+ */
+typedef struct Binding {
+  BindingType   type;
+  
+  /* For key bindings */
+  uint32_t     modifiers;
+  xcb_keycode_t keycode;
+  
+  /* For button bindings */
+  xcb_button_t button;
+  
+  /* For pointer bindings */
+  /* ... pointer-specific fields ... */
+  
+  /* The action to invoke */
+  const char*  action_name;  /* e.g., "fullscreen.toggle" */
+  
+  /* Optional binding-specific data passed to action */
+  void*        userdata;
+} Binding;
+
+/*
+ * Binding lookup result
+ */
+typedef struct BindingResult {
+  const char*  action_name;  /* Action name, e.g., "fullscreen.toggle" */
+  void*        userdata;     /* Binding-specific data */
+} BindingResult;
+```
+
+---
+
+## Keybinding Component Changes
+
+The keybinding component is refactored to use the action registry:
+
+### Old Model (Anti-pattern)
+
+```c
+// ❌ WRONG - Hardcoded in keybinding component
+static const KeyBinding default_keybindings[] = {
+  { XCB_MOD_MASK_4, 41, KEYBINDING_ACTION_TOGGLE_FULLSCREEN, 0 },
+};
+
+void execute_keybinding(const KeyBinding* binding) {
+  switch (binding->action) {
+  case KEYBINDING_ACTION_TOGGLE_FULLSCREEN:
+    hub_send_request(REQ_CLIENT_FULLSCREEN, TARGET_CURRENT_CLIENT);
+    break;
+  // Hardcoded knowledge of other components!
+  }
+}
+```
+
+### New Model (Correct)
+
+```c
+// ✅ CORRECT - Config wires keys to actions
+static const KeyBinding default_bindings[] = {
+  { XCB_MOD_MASK_4, 41, "fullscreen.toggle" },  /* keycode 41 = 'f' */
+  { XCB_MOD_MASK_4, 36, "focus.focus-current" },
+};
+
+// Keybinding component just looks up and invokes actions
+void execute_keybinding(const KeyBinding* binding) {
+  Action* action = action_lookup(binding->action_name);
+  if (!action) {
+    LOG_WARN("No action found: %s", binding->action_name);
+    return;
+  }
+  
+  ActionInvocation inv = {
+    .target = action->target_resolver ? 
+              action->target_resolver() : 
+              binding->bound_target,
+    .data   = binding->userdata,
+  };
+  
+  action->callback(&inv);
+}
+```
+
+### Keybinding Component API
+
+```c
+/*
+ * Register a keybinding that invokes an action.
+ * 
+ * @param modifiers  XCB modifier mask (e.g., XCB_MOD_MASK_4)
+ * @param keycode    X11 keycode (e.g., 41 for 'f')
+ * @param action     Action name to invoke (e.g., "fullscreen.toggle")
+ * @param data       Optional data passed to action callback
+ * @return           Binding ID or 0 on failure
+ */
+uint32_t keybinding_register(uint32_t modifiers, xcb_keycode_t keycode,
+                             const char* action, void* data);
+
+/*
+ * Register a keybinding with integer argument (e.g., tag numbers).
+ */
+uint32_t keybinding_register_with_arg(uint32_t modifiers, xcb_keycode_t keycode,
+                                      const char* action, uint32_t arg);
+
+/*
+ * Unregister a keybinding by ID.
+ */
+void keybinding_unregister(uint32_t binding_id);
+
+/*
+ * Lookup binding by modifiers and keycode.
+ * Returns NULL if not found.
+ */
+const KeyBinding* keybinding_lookup(uint32_t modifiers, xcb_keycode_t keycode);
+
+/*
+ * Get all registered bindings.
+ */
+const KeyBinding* keybinding_get_all(void);
+uint32_t keybinding_get_count(void);
+```
+
+---
+
+## Target Resolution
+
+### Symbolic Targets
+
+Actions can declare which target type they need:
+
+```c
+/*
+ * Target type hints for actions
+ */
+typedef enum {
+  TARGET_TYPE_CURRENT_CLIENT,   /* Resolved by focus component */
+  TARGET_TYPE_CURRENT_MONITOR,  /* Resolved by monitor manager */
+  TARGET_TYPE_ANY,              /* No specific requirement */
+} ActionTargetType;
+
+/*
+ * Action with target type hint
+ */
+typedef struct Action {
+  const char*         name;
+  const char*         description;
+  ActionCallback      callback;
+  ActionTargetType   target_type;     /* What target this action needs */
+  bool               target_required; /* Fail if no target available */
+  void*              userdata;
+} Action;
+```
+
+### Resolution at Call Time
+
+```c
+void invoke_action(const char* action_name, ActionBinding* binding) {
+  Action* action = action_lookup(action_name);
+  if (!action) return;
+  
+  /* Resolve target based on action's target_type */
+  TargetID target = TARGET_ID_NONE;
+  
+  if (action->target_type == TARGET_TYPE_CURRENT_CLIENT) {
+    target = focus_get_current_client();  /* From focus component */
+  } else if (action->target_type == TARGET_TYPE_CURRENT_MONITOR) {
+    target = monitor_get_current_monitor();  /* From monitor manager */
+  } else {
+    target = binding->target;  /* Use bound target if specified */
+  }
+  
+  /* Check if target is required */
+  if (action->target_required && target == TARGET_ID_NONE) {
+    LOG_DEBUG("Action '%s' requires target but none available", action_name);
+    return;
+  }
+  
+  /* Invoke with resolved target */
+  ActionInvocation inv = {
+    .target = target,
+    .data   = binding->data,
+  };
+  
+  action->callback(&inv);
+}
+```
+
+---
+
+## Component Action Registration
+
+Components register their actions during `on_init()`:
+
+### Fullscreen Component
+
+```c
+/*
+ * Fullscreen action: toggle fullscreen
+ */
+static bool
+fullscreen_action_toggle(ActionInvocation* inv)
+{
+  if (inv->target == TARGET_ID_NONE) {
+    LOG_DEBUG("fullscreen.toggle: no target");
+    return false;
+  }
+  
+  Client* c = hub_get_target(inv->target);
+  if (!c) return false;
+  
+  StateMachine* sm = fullscreen_get_sm(c);
+  FullscreenState new_state = (fullscreen_get_state(c) == FULLSCREEN_STATE_FULLSCREEN)
+    ? FULLSCREEN_STATE_WINDOWED
+    : FULLSCREEN_STATE_FULLSCREEN;
+  
+  return sm_transition(sm, new_state);
+}
+
+Action fullscreen_actions[] = {
+  {
+    .name        = "fullscreen.toggle",
+    .description = "Toggle fullscreen on current client",
+    .callback    = fullscreen_action_toggle,
+    .target_type = TARGET_TYPE_CURRENT_CLIENT,
+    .target_required = true,
+  },
+};
+
+void
+fullscreen_init(void)
+{
+  /* Register actions */
+  for (int i = 0; i < sizeof(fullscreen_actions)/sizeof(fullscreen_actions[0]); i++) {
+    action_register(&fullscreen_actions[i]);
+  }
+}
+```
+
+### Tag Manager Component
+
+```c
+/*
+ * Tag view action: show specific tag
+ */
+static bool
+tag_action_view(ActionInvocation* inv)
+{
+  if (inv->target == TARGET_ID_NONE) {
+    return false;
+  }
+  
+  Monitor* m = hub_get_target(inv->target);
+  if (!m) return false;
+  
+  uint32_t tag = *(uint32_t*) inv->data;
+  tag_manager_view(m, tag);
+  return true;
+}
+
+Action tag_manager_actions[] = {
+  {
+    .name        = "tag-manager.view",
+    .description = "View tag N (1-9)",
+    .callback    = tag_action_view,
+    .target_type = TARGET_TYPE_CURRENT_MONITOR,
+    .target_required = true,
+  },
+  {
+    .name        = "tag-manager.toggle",
+    .description = "Toggle tag N visibility",
+    .callback    = tag_action_toggle,
+    .target_type = TARGET_TYPE_CURRENT_MONITOR,
+    .target_required = true,
+  },
+  {
+    .name        = "tag-manager.client-move",
+    .description = "Move focused client to tag N",
+    .callback    = tag_action_client_move,
+    .target_type = TARGET_TYPE_CURRENT_CLIENT,
+    .target_required = true,
+  },
+};
+
+void
+tag_manager_init(void)
+{
+  for (int i = 0; i < sizeof(tag_manager_actions)/sizeof(tag_manager_actions[0]); i++) {
+    action_register(&tag_manager_actions[i]);
+  }
+}
+```
+
+---
+
+## Configuration Layer
+
+### config.def.h Style
+
+```c
+/*
+ * config.def.h - Default keybindings
+ *
+ * This file wires key combinations to component actions.
+ * Components own their actions; this layer just wires triggers to them.
+ */
+
+/*
+ * Helper macros for common patterns
+ */
+
+/* Basic keybinding: Mod+<key> → action */
+#define KEY(mod, keycode, action) \
+  keybinding_register(mod, keycode, action, NULL)
+
+/* Keybinding with argument: Mod+Shift+<num> → action(arg) */
+#define TAG_KEY(mod, keycode, action, tag) \
+  keybinding_register_with_arg(mod, keycode, action, tag)
+
+/*
+ * Focus actions
+ */
+KEY(XCB_MOD_MASK_4, 36, "focus.focus-current");           /* Mod+Enter */
+KEY(XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 36, "focus.focus-prev");  /* Mod+Shift+Enter */
+
+/*
+ * Fullscreen action
+ */
+KEY(XCB_MOD_MASK_4, 41, "fullscreen.toggle");              /* Mod+f (keycode 41 = f) */
+
+/*
+ * Tag view actions: Mod+1 through Mod+9
+ */
+TAG_KEY(XCB_MOD_MASK_4, 10, "tag-manager.view", 1);         /* Mod+1 */
+TAG_KEY(XCB_MOD_MASK_4, 11, "tag-manager.view", 2);        /* Mod+2 */
+TAG_KEY(XCB_MOD_MASK_4, 12, "tag-manager.view", 3);       /* Mod+3 */
+TAG_KEY(XCB_MOD_MASK_4, 13, "tag-manager.view", 4);       /* Mod+4 */
+TAG_KEY(XCB_MOD_MASK_4, 14, "tag-manager.view", 5);        /* Mod+5 */
+TAG_KEY(XCB_MOD_MASK_4, 15, "tag-manager.view", 6);        /* Mod+6 */
+TAG_KEY(XCB_MOD_MASK_4, 16, "tag-manager.view", 7);        /* Mod+7 */
+TAG_KEY(XCB_MOD_MASK_4, 17, "tag-manager.view", 8);        /* Mod+8 */
+TAG_KEY(XCB_MOD_MASK_4, 18, "tag-manager.view", 9);       /* Mod+9 */
+
+/*
+ * Tag toggle actions: Mod+Shift+1 through Mod+Shift+9
+ */
+TAG_KEY(XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 10, "tag-manager.toggle", 1);   /* Mod+Shift+1 */
+TAG_KEY(XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 11, "tag-manager.toggle", 2);  /* ... */
+TAG_KEY(XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 12, "tag-manager.toggle", 3);
+TAG_KEY(XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 13, "tag-manager.toggle", 4);
+TAG_KEY(XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 14, "tag-manager.toggle", 5);
+TAG_KEY(XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 15, "tag-manager.toggle", 6);
+TAG_KEY(XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 16, "tag-manager.toggle", 7);
+TAG_KEY(XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 17, "tag-manager.toggle", 8);
+TAG_KEY(XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 18, "tag-manager.toggle", 9);
+
+/*
+ * Client-tag toggle: Mod+Shift+Alt+1 through Mod+Shift+Alt+9
+ */
+TAG_KEY(XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 10, "tag-manager.client-move", 1);
+TAG_KEY(XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 11, "tag-manager.client-move", 2);
+TAG_KEY(XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 12, "tag-manager.client-move", 3);
+TAG_KEY(XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 13, "tag-manager.client-move", 4);
+TAG_KEY(XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 14, "tag-manager.client-move", 5);
+TAG_KEY(XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 15, "tag-manager.client-move", 6);
+TAG_KEY(XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 16, "tag-manager.client-move", 7);
+TAG_KEY(XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 17, "tag-manager.client-move", 8);
+TAG_KEY(XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 18, "tag-manager.client-move", 9);
+
+/*
+ * Monitor tiling
+ */
+KEY(XCB_MOD_MASK_4, 31, "monitor.tile");                  /* Mod+i */
+```
+
+---
+
+## Cross-Component Wiring (Pointer)
+
+The action system also enables pointer bindings:
+
+```c
+/*
+ * Pointer binding: button drag → action
+ * Used for floating window resize, moving, etc.
+ */
+typedef struct PointerBinding {
+  uint32_t    modifiers;    /* Modifiers that must be held */
+  xcb_button_t button;      /* Mouse button */
+  const char* action;       /* Action to invoke on drag */
+  const char* end_action;   /* Action to invoke on release */
+} PointerBinding;
+
+/*
+ * Floating component registers pointer actions
+ */
+Action floating_actions[] = {
+  {
+    .name = "floating.move-start",
+    .callback = floating_move_start,
+  },
+  {
+    .name = "floating.move-end", 
+    .callback = floating_move_end,
+  },
+  {
+    .name = "floating.resize-start",
+    .callback = floating_resize_start,
+  },
+  {
+    .name = "floating.resize-end",
+    .callback = floating_resize_end,
+  },
+};
+
+/*
+ * Config wires pointer bindings
+ */
+void config_pointer_init(void) {
+  /* Mod+Left click: move floating window */
+  pointer_binding_register(0, XCB_BUTTON_INDEX_1, 
+                           "floating.move-start", "floating.move-end");
+  
+  /* Mod+Right click: resize floating window */
+  pointer_binding_register(0, XCB_BUTTON_INDEX_3,
+                           "floating.resize-start", "floating.resize-end");
+}
+```
+
+---
+
+## Implementation Files
+
+| File | Purpose |
+|------|---------|
+| `src/actions/action-registry.c/h` | Action registration and lookup |
+| `src/actions/action-invoke.c/h` | Action invocation with target resolution |
+| `src/components/keybinding.c` | Refactored to use action registry |
+| `src/components/keybinding-binding.c/h` | Binding storage and lookup |
+| `config.def.h` | Wiring configuration |
+
+---
+
+## Testing Strategy
+
+1. **Action registration tests**: Register actions, verify lookup works
+2. **Action invocation tests**: Invoke actions, verify callbacks called
+3. **Target resolution tests**: Mock resolvers, verify correct target
+4. **Keybinding lookup tests**: Press key, verify correct action invoked
+5. **Integration tests**: Full flow keypress → action → effect
+
+---
+
+## Migration Path
+
+### Phase 1: Action Registry (This Implementation)
+- Add `action_register()` / `action_lookup()` API
+- Components register actions in `on_init()`
+- Keybinding component looks up actions by name
+
+### Phase 2: Binding Refactor
+- Remove hardcoded `KeyBinding.action` enum
+- Replace with `action_name` string
+- Update `config.def.h` to use action names
+
+### Phase 3: Runtime Config
+- Add JSON/YAML config file support
+- Replace compile-time `config.def.h` with runtime config
+- Add `action_unregister()` for hot-reload
+
+---
+
+*See also:*
+- `architecture/component.md` — Component design
+- `architecture/decisions.md` — Decision log
+- `architecture/hub.md` — Hub routing

--- a/docs/architecture/actions.md
+++ b/docs/architecture/actions.md
@@ -590,11 +590,10 @@ void config_pointer_init(void) {
 
 | File | Purpose |
 |------|---------|
-| `src/actions/action-registry.c/h` | Action registration and lookup |
-| `src/actions/action-invoke.c/h` | Action invocation with target resolution |
-| `src/components/keybinding.c` | Refactored to use action registry |
-| `src/components/keybinding-binding.c/h` | Binding storage and lookup |
-| `config.def.h` | Wiring configuration |
+| `src/actions/action-registry.c/h` | Action registration, lookup, and invocation |
+| `src/actions/keybinding-binding.c/h` | Runtime binding storage and lookup |
+| `src/components/keybinding.c` | Key event handling with action invocation |
+| `config.def.h` | Wiring configuration (future) |
 
 ---
 

--- a/src/actions/action-registry.c
+++ b/src/actions/action-registry.c
@@ -13,14 +13,9 @@
 #include "wm-log.h"
 
 /*
- * Maximum number of actions in the registry
+ * Action storage - extra slot for NULL terminator
  */
-#define MAX_ACTIONS 64
-
-/*
- * Action storage
- */
-static Action*  actions[MAX_ACTIONS];
+static Action*  actions[ACTION_REGISTRY_MAX_ACTIONS + 1];
 static uint32_t actions_allocated = 0;
 static bool     initialized       = false;
 
@@ -193,8 +188,8 @@ action_register(Action* action)
   }
 
   /* Check for space */
-  if (actions_allocated >= MAX_ACTIONS) {
-    LOG_ERROR("Action registry full (max %d)", MAX_ACTIONS);
+  if (actions_allocated >= ACTION_REGISTRY_MAX_ACTIONS) {
+    LOG_ERROR("Action registry full (max %d)", ACTION_REGISTRY_MAX_ACTIONS);
     return false;
   }
 
@@ -259,10 +254,8 @@ action_get_all(void)
     return NULL;
   }
 
-  /* Ensure NULL terminator */
-  if (actions_allocated < MAX_ACTIONS) {
-    actions[actions_allocated] = NULL;
-  }
+  /* Ensure NULL terminator (array has extra slot for this) */
+  actions[actions_allocated] = NULL;
 
   return actions;
 }

--- a/src/actions/action-registry.c
+++ b/src/actions/action-registry.c
@@ -1,0 +1,324 @@
+/*
+ * action-registry.c - Action registration and lookup implementation
+ *
+ * Implements the action registry for component action exposure.
+ */
+
+#include "action-registry.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "wm-log.h"
+
+/*
+ * Maximum number of actions in the registry
+ */
+#define MAX_ACTIONS 64
+
+/*
+ * Action storage
+ */
+static Action*  actions[MAX_ACTIONS];
+static uint32_t actions_allocated = 0;
+static bool     initialized       = false;
+
+/*
+ * Built-in target resolver: current client
+ * Uses weak linkage - provided by focus component if present
+ */
+extern TargetID focus_get_current_client(void);
+__attribute__((weak)) TargetID
+focus_get_current_client(void)
+{
+  return TARGET_ID_NONE;
+}
+
+/*
+ * Get focused client (weak linkage)
+ */
+extern void* focus_get_focused_client(void);
+__attribute__((weak)) void*
+focus_get_focused_client(void)
+{
+  return NULL;
+}
+
+/*
+ * Built-in target resolver: current monitor
+ * Uses weak linkage - provided by monitor manager if present
+ */
+extern TargetID monitor_get_current_monitor(void);
+__attribute__((weak)) TargetID
+monitor_get_current_monitor(void)
+{
+  return TARGET_ID_NONE;
+}
+
+/*
+ * Get selected monitor (weak linkage)
+ */
+extern void* monitor_get_selected(void);
+__attribute__((weak)) void*
+monitor_get_selected(void)
+{
+  return NULL;
+}
+
+/*
+ * Built-in target resolvers
+ */
+TargetID
+action_resolve_current_client(void)
+{
+  return focus_get_current_client();
+}
+
+TargetID
+action_resolve_current_monitor(void)
+{
+  return monitor_get_current_monitor();
+}
+
+void*
+action_get_current_client(void)
+{
+  return focus_get_focused_client();
+}
+
+void*
+action_get_current_monitor(void)
+{
+  return monitor_get_selected();
+}
+
+/*
+ * Resolve target based on action's target_type hint
+ */
+static TargetID
+resolve_target(Action* action, ActionInvocation* inv)
+{
+  if (action->target_resolver != NULL) {
+    /* Custom resolver provided by action */
+    return action->target_resolver(inv);
+  }
+
+  switch (action->target_type) {
+  case ACTION_TARGET_CLIENT:
+    return action_resolve_current_client();
+  case ACTION_TARGET_MONITOR:
+    return action_resolve_current_monitor();
+  case ACTION_TARGET_CURRENT:
+    /* Default: resolve current client */
+    return action_resolve_current_client();
+  case ACTION_TARGET_BOUND:
+    /* Use bound target from invocation */
+    if (inv != NULL && inv->target != TARGET_ID_NONE) {
+      return inv->target;
+    }
+    break;
+  case ACTION_TARGET_ANY:
+    /* Any target is fine */
+    if (inv != NULL && inv->target != TARGET_ID_NONE) {
+      return inv->target;
+    }
+    break;
+  case ACTION_TARGET_NONE:
+  default:
+    /* No target needed */
+    return TARGET_ID_NONE;
+  }
+
+  return TARGET_ID_NONE;
+}
+
+void
+action_registry_init(void)
+{
+  if (initialized) {
+    LOG_WARN("Action registry already initialized");
+    return;
+  }
+
+  LOG_DEBUG("Initializing action registry");
+  memset(actions, 0, sizeof(actions));
+  actions_allocated = 0;
+  initialized       = true;
+}
+
+void
+action_registry_shutdown(void)
+{
+  if (!initialized) {
+    return;
+  }
+
+  LOG_DEBUG("Shutting down action registry");
+
+  /* Unregister all actions */
+  actions_allocated = 0;
+  memset(actions, 0, sizeof(actions));
+
+  initialized = false;
+}
+
+bool
+action_register(Action* action)
+{
+  if (!initialized) {
+    LOG_ERROR("Action registry not initialized");
+    return false;
+  }
+
+  if (action == NULL) {
+    LOG_ERROR("Cannot register NULL action");
+    return false;
+  }
+
+  if (action->name == NULL || action->name[0] == '\0') {
+    LOG_ERROR("Action name cannot be empty");
+    return false;
+  }
+
+  if (action->callback == NULL) {
+    LOG_ERROR("Action '%s' has no callback", action->name);
+    return false;
+  }
+
+  /* Check for duplicate name */
+  if (action_lookup(action->name) != NULL) {
+    LOG_WARN("Action '%s' already registered", action->name);
+    return false;
+  }
+
+  /* Check for space */
+  if (actions_allocated >= MAX_ACTIONS) {
+    LOG_ERROR("Action registry full (max %d)", MAX_ACTIONS);
+    return false;
+  }
+
+  /* Register */
+  actions[actions_allocated++] = action;
+
+  LOG_DEBUG("Registered action: %s", action->name);
+
+  return true;
+}
+
+bool
+action_unregister(const char* name)
+{
+  if (!initialized) {
+    LOG_ERROR("Action registry not initialized");
+    return false;
+  }
+
+  if (name == NULL) {
+    return false;
+  }
+
+  /* Find and remove */
+  for (uint32_t i = 0; i < actions_allocated; i++) {
+    if (strcmp(actions[i]->name, name) == 0) {
+      LOG_DEBUG("Unregistered action: %s", name);
+
+      /* Shift remaining actions */
+      for (uint32_t j = i; j < actions_allocated - 1; j++) {
+        actions[j] = actions[j + 1];
+      }
+      actions_allocated--;
+
+      return true;
+    }
+  }
+
+  return false;
+}
+
+Action*
+action_lookup(const char* name)
+{
+  if (!initialized || name == NULL) {
+    return NULL;
+  }
+
+  for (uint32_t i = 0; i < actions_allocated; i++) {
+    if (strcmp(actions[i]->name, name) == 0) {
+      return actions[i];
+    }
+  }
+
+  return NULL;
+}
+
+Action**
+action_get_all(void)
+{
+  if (!initialized) {
+    return NULL;
+  }
+
+  /* Ensure NULL terminator */
+  if (actions_allocated < MAX_ACTIONS) {
+    actions[actions_allocated] = NULL;
+  }
+
+  return actions;
+}
+
+uint32_t
+action_count(void)
+{
+  return actions_allocated;
+}
+
+bool
+action_invoke(const char* name, ActionInvocation* inv)
+{
+  if (!initialized) {
+    LOG_ERROR("Action registry not initialized");
+    return false;
+  }
+
+  Action* action = action_lookup(name);
+  if (action == NULL) {
+    LOG_DEBUG("Action not found: %s", name);
+    return false;
+  }
+
+  /* Resolve target */
+  TargetID target = resolve_target(action, inv);
+
+  /* Check if target is required */
+  if (action->target_required && target == TARGET_ID_NONE) {
+    LOG_DEBUG("Action '%s' requires target but none available", name);
+    return false;
+  }
+
+  /* Build invocation context */
+  ActionInvocation effective_inv;
+  if (inv != NULL) {
+    effective_inv = *inv;
+  } else {
+    memset(&effective_inv, 0, sizeof(effective_inv));
+  }
+  effective_inv.target = target;
+
+  /* Call the callback */
+  LOG_DEBUG("Invoking action: %s (target=%" PRIu64 ")", name, target);
+
+  bool result = action->callback(&effective_inv);
+
+  if (!result) {
+    LOG_DEBUG("Action '%s' returned failure", name);
+  }
+
+  return result;
+}
+
+bool
+action_exists(const char* name)
+{
+  return action_lookup(name) != NULL;
+}

--- a/src/actions/action-registry.h
+++ b/src/actions/action-registry.h
@@ -78,6 +78,11 @@ struct Action {
 };
 
 /*
+ * Maximum number of actions in the registry
+ */
+#define ACTION_REGISTRY_MAX_ACTIONS 64
+
+/*
  * Built-in target resolvers
  */
 
@@ -111,7 +116,8 @@ void* action_get_current_monitor(void);
 
 /*
  * Initialize the action registry.
- * Called during hub initialization.
+ * Components typically call this from their init functions
+ * before registering actions.
  */
 void action_registry_init(void);
 

--- a/src/actions/action-registry.h
+++ b/src/actions/action-registry.h
@@ -1,0 +1,167 @@
+/*
+ * action-registry.h - Action registration and lookup API
+ *
+ * Actions are the public API of components. Components register named
+ * actions in their on_init() function. The keybinding component looks
+ * up actions by name and invokes them with resolved targets.
+ *
+ * Usage:
+ *   1. Components define actions with names, descriptions, and callbacks
+ *   2. Components call action_register() in their on_init()
+ *   3. Keybinding component calls action_lookup() when a key is pressed
+ *   4. action_invoke() resolves the target and calls the callback
+ */
+
+#ifndef _WM_ACTION_REGISTRY_H_
+#define _WM_ACTION_REGISTRY_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "wm-hub.h"
+
+/*
+ * Forward declarations
+ */
+typedef struct Action           Action;
+typedef struct ActionInvocation ActionInvocation;
+
+/*
+ * Action callback signature
+ * Returns true on success, false on failure.
+ */
+typedef bool (*ActionCallback)(ActionInvocation* inv);
+
+/*
+ * Target resolver function
+ * Called at action invocation to determine the target.
+ * Return TARGET_ID_NONE if no target available.
+ */
+typedef TargetID (*ActionTargetResolver)(ActionInvocation* inv);
+
+/*
+ * Target type hints for actions
+ */
+typedef enum ActionTargetType {
+  ACTION_TARGET_NONE    = 0, /* No target needed */
+  ACTION_TARGET_CURRENT = 1, /* Use component's "current" target */
+  ACTION_TARGET_BOUND   = 2, /* Use target bound at registration time */
+  ACTION_TARGET_ANY     = 3, /* No specific requirement */
+  ACTION_TARGET_CLIENT  = 4, /* Resolves to current client */
+  ACTION_TARGET_MONITOR = 5, /* Resolves to current monitor */
+} ActionTargetType;
+
+/*
+ * Action invocation context
+ * Passed to action callbacks with resolved target and arguments.
+ */
+struct ActionInvocation {
+  TargetID         target;         /* Resolved target (e.g., current client) */
+  void*            data;           /* Action-specific data (e.g., tag number) */
+  uint64_t         correlation_id; /* For async response tracking */
+  void*            userdata;       /* Per-binding userdata */
+  ActionTargetType target_type;    /* Hint for target resolver */
+};
+
+/*
+ * Action definition
+ * Registered by components during on_init().
+ */
+struct Action {
+  const char*          name;            /* Unique action name, e.g., "fullscreen.toggle" */
+  const char*          description;     /* Human-readable description */
+  ActionCallback       callback;        /* Function to call */
+  ActionTargetResolver target_resolver; /* How to resolve target field */
+  ActionTargetType     target_type;     /* Hint for built-in target resolution */
+  bool                 target_required; /* Fail if no target available */
+  void*                userdata;        /* Component-specific data */
+};
+
+/*
+ * Built-in target resolvers
+ */
+
+/*
+ * Resolve the currently focused client.
+ * Returns TARGET_ID_NONE if no client is focused.
+ */
+TargetID action_resolve_current_client(void);
+
+/*
+ * Resolve the currently selected monitor.
+ * Returns TARGET_ID_NONE if no monitor is selected.
+ */
+TargetID action_resolve_current_monitor(void);
+
+/*
+ * Get the current client from the focus component.
+ * Returns NULL if no client is focused.
+ */
+void* action_get_current_client(void);
+
+/*
+ * Get the current monitor from the monitor manager.
+ * Returns NULL if no monitor is selected.
+ */
+void* action_get_current_monitor(void);
+
+/*
+ * Action Registry API
+ */
+
+/*
+ * Initialize the action registry.
+ * Called during hub initialization.
+ */
+void action_registry_init(void);
+
+/*
+ * Shutdown the action registry.
+ * Unregisters all actions and frees resources.
+ */
+void action_registry_shutdown(void);
+
+/*
+ * Register an action with the action registry.
+ * Returns true on success, false if name already exists or registry is full.
+ */
+bool action_register(Action* action);
+
+/*
+ * Unregister an action by name.
+ * Returns true if found and removed, false if not found.
+ */
+bool action_unregister(const char* name);
+
+/*
+ * Look up an action by name.
+ * Returns NULL if not found.
+ */
+Action* action_lookup(const char* name);
+
+/*
+ * Get all registered actions.
+ * Returns a NULL-terminated array of Action pointers.
+ * The array is owned by the registry and should not be modified.
+ */
+Action** action_get_all(void);
+
+/*
+ * Get the number of registered actions.
+ */
+uint32_t action_count(void);
+
+/*
+ * Invoke an action by name with the given invocation context.
+ * This handles target resolution and calls the action's callback.
+ *
+ * Returns true if the action was found and invoked successfully.
+ */
+bool action_invoke(const char* name, ActionInvocation* inv);
+
+/*
+ * Check if an action with the given name exists.
+ */
+bool action_exists(const char* name);
+
+#endif /* _WM_ACTION_REGISTRY_H_ */

--- a/src/actions/keybinding-binding.c
+++ b/src/actions/keybinding-binding.c
@@ -16,14 +16,9 @@
 #include "wm-log.h"
 
 /*
- * Maximum number of keybindings for runtime binding storage
+ * Keybinding storage - extra slot for NULL terminator
  */
-#define KEYBINDING_MAX_BINDINGS 64
-
-/*
- * Keybinding storage - stores pointers to KeyBinding structures
- */
-static const KeyBinding* bindings[KEYBINDING_MAX_BINDINGS];
+static const KeyBinding* bindings[KEYBINDING_MAX_BINDINGS + 1];
 static uint32_t          binding_count = 0;
 static bool              initialized   = false;
 
@@ -103,6 +98,11 @@ keybinding_binding_shutdown(void)
   }
 
   LOG_DEBUG("Shutting down keybinding binding system");
+
+  /* Free allocated bindings */
+  for (uint32_t i = 0; i < binding_count; i++) {
+    free((void*) bindings[i]);
+  }
 
   /* Clear bindings array */
   memset(bindings, 0, sizeof(bindings));
@@ -294,10 +294,8 @@ keybinding_binding_get_all(void)
     return NULL;
   }
 
-  /* Ensure NULL terminator */
-  if (binding_count < KEYBINDING_MAX_BINDINGS) {
-    bindings[binding_count] = NULL;
-  }
+  /* Ensure NULL terminator (array has extra slot for this) */
+  bindings[binding_count] = NULL;
 
   return bindings;
 }

--- a/src/actions/keybinding-binding.c
+++ b/src/actions/keybinding-binding.c
@@ -1,0 +1,359 @@
+/*
+ * keybinding-binding.c - Keybinding binding storage and lookup implementation
+ *
+ * This module manages a runtime binding table that maps key combinations
+ * to action names. The bindings can be registered at runtime.
+ */
+
+#include "keybinding-binding.h"
+
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "action-registry.h"
+#include "wm-log.h"
+
+/*
+ * Maximum number of keybindings for runtime binding storage
+ */
+#define KEYBINDING_MAX_BINDINGS 64
+
+/*
+ * Keybinding storage - stores pointers to KeyBinding structures
+ */
+static const KeyBinding* bindings[KEYBINDING_MAX_BINDINGS];
+static uint32_t          binding_count = 0;
+static bool              initialized   = false;
+
+/*
+ * Internal: find binding index by modifiers and keycode
+ */
+static int32_t
+find_binding_index(uint32_t modifiers, xcb_keycode_t keycode)
+{
+  /* Normalize modifiers */
+  uint32_t normalized = modifiers & ~(XCB_MOD_MASK_LOCK | XCB_MOD_MASK_2);
+
+  for (uint32_t i = 0; i < binding_count; i++) {
+    const KeyBinding* b = bindings[i];
+    if (b == NULL)
+      continue;
+
+    /* Normalize binding's modifiers */
+    uint32_t binding_normalized = b->modifiers & ~(XCB_MOD_MASK_LOCK | XCB_MOD_MASK_2);
+
+    if (binding_normalized == normalized && b->keycode == keycode) {
+      return (int32_t) i;
+    }
+  }
+
+  return -1;
+}
+
+/*
+ * Internal: resolve target based on action's target type
+ */
+static TargetID
+resolve_binding_target(Action* action)
+{
+  if (action == NULL) {
+    return TARGET_ID_NONE;
+  }
+
+  if (action->target_resolver != NULL) {
+    return action->target_resolver(NULL);
+  }
+
+  switch (action->target_type) {
+  case ACTION_TARGET_CLIENT:
+    return action_resolve_current_client();
+  case ACTION_TARGET_MONITOR:
+    return action_resolve_current_monitor();
+  case ACTION_TARGET_CURRENT:
+    return action_resolve_current_client();
+  case ACTION_TARGET_BOUND:
+  case ACTION_TARGET_ANY:
+  case ACTION_TARGET_NONE:
+  default:
+    return TARGET_ID_NONE;
+  }
+}
+
+void
+keybinding_binding_init(void)
+{
+  if (initialized) {
+    LOG_WARN("Keybinding binding system already initialized");
+    return;
+  }
+
+  LOG_DEBUG("Initializing keybinding binding system");
+  memset(bindings, 0, sizeof(bindings));
+  binding_count = 0;
+  initialized   = true;
+}
+
+void
+keybinding_binding_shutdown(void)
+{
+  if (!initialized) {
+    return;
+  }
+
+  LOG_DEBUG("Shutting down keybinding binding system");
+
+  /* Clear bindings array */
+  memset(bindings, 0, sizeof(bindings));
+  binding_count = 0;
+  initialized   = false;
+}
+
+bool
+keybinding_binding_register(uint32_t modifiers, xcb_keycode_t keycode, const char* action)
+{
+  if (!initialized) {
+    LOG_ERROR("Keybinding binding system not initialized");
+    return false;
+  }
+
+  if (action == NULL || action[0] == '\0') {
+    LOG_ERROR("Cannot register binding with empty action");
+    return false;
+  }
+
+  /* Check for duplicate */
+  if (find_binding_index(modifiers, keycode) >= 0) {
+    LOG_WARN("Binding already exists for keycode=%d modifiers=0x%x",
+             keycode, modifiers);
+    return false;
+  }
+
+  if (binding_count >= KEYBINDING_MAX_BINDINGS) {
+    LOG_ERROR("Maximum number of keybindings reached (%d)", KEYBINDING_MAX_BINDINGS);
+    return false;
+  }
+
+  /* Allocate and store binding */
+  KeyBinding* b = malloc(sizeof(KeyBinding));
+  if (b == NULL) {
+    LOG_ERROR("Failed to allocate keybinding");
+    return false;
+  }
+
+  b->modifiers = modifiers;
+  b->keycode   = keycode;
+  b->action    = action;
+  b->arg       = 0;
+  b->userdata  = NULL;
+  b->has_arg   = false;
+
+  bindings[binding_count++] = b;
+
+  LOG_DEBUG("Registered keybinding: mod=0x%x keycode=%d action=%s",
+            modifiers, keycode, action);
+
+  return true;
+}
+
+bool
+keybinding_binding_register_with_arg(uint32_t      modifiers,
+                                     xcb_keycode_t keycode,
+                                     const char*   action,
+                                     uint32_t      arg)
+{
+  if (!initialized) {
+    LOG_ERROR("Keybinding binding system not initialized");
+    return false;
+  }
+
+  if (action == NULL || action[0] == '\0') {
+    LOG_ERROR("Cannot register binding with empty action");
+    return false;
+  }
+
+  /* Check for duplicate */
+  if (find_binding_index(modifiers, keycode) >= 0) {
+    LOG_WARN("Binding already exists for keycode=%d modifiers=0x%x",
+             keycode, modifiers);
+    return false;
+  }
+
+  if (binding_count >= KEYBINDING_MAX_BINDINGS) {
+    LOG_ERROR("Maximum number of keybindings reached (%d)", KEYBINDING_MAX_BINDINGS);
+    return false;
+  }
+
+  /* Allocate and store binding */
+  KeyBinding* b = malloc(sizeof(KeyBinding));
+  if (b == NULL) {
+    LOG_ERROR("Failed to allocate keybinding");
+    return false;
+  }
+
+  b->modifiers = modifiers;
+  b->keycode   = keycode;
+  b->action    = action;
+  b->arg       = arg;
+  b->userdata  = NULL;
+  b->has_arg   = true;
+
+  bindings[binding_count++] = b;
+
+  LOG_DEBUG("Registered keybinding: mod=0x%x keycode=%d action=%s arg=%" PRIu32,
+            modifiers, keycode, action, arg);
+
+  return true;
+}
+
+bool
+keybinding_binding_unregister(uint32_t modifiers, xcb_keycode_t keycode)
+{
+  if (!initialized) {
+    LOG_ERROR("Keybinding binding system not initialized");
+    return false;
+  }
+
+  int32_t idx = find_binding_index(modifiers, keycode);
+  if (idx < 0) {
+    return false;
+  }
+
+  /* Free the binding */
+  free((void*) bindings[idx]);
+
+  /* Shift remaining bindings */
+  for (uint32_t i = (uint32_t) idx; i < binding_count - 1; i++) {
+    bindings[i] = bindings[i + 1];
+  }
+  binding_count--;
+
+  return true;
+}
+
+const KeyBinding*
+keybinding_binding_lookup(uint32_t modifiers, xcb_keycode_t keycode)
+{
+  if (!initialized) {
+    return NULL;
+  }
+
+  int32_t idx = find_binding_index(modifiers, keycode);
+  if (idx < 0) {
+    return NULL;
+  }
+
+  return bindings[idx];
+}
+
+KeyBindingLookup
+keybinding_binding_lookup_with_invocation(uint32_t modifiers, xcb_keycode_t keycode)
+{
+  KeyBindingLookup result = {
+    .binding = NULL,
+    .inv     = { 0 },
+  };
+
+  if (!initialized) {
+    return result;
+  }
+
+  const KeyBinding* binding = keybinding_binding_lookup(modifiers, keycode);
+  if (binding == NULL) {
+    return result;
+  }
+
+  result.binding = binding;
+
+  /* Look up action for target resolution */
+  Action* action = action_lookup(binding->action);
+  if (action != NULL) {
+    result.inv.target = resolve_binding_target(action);
+  } else {
+    result.inv.target = TARGET_ID_NONE;
+  }
+
+  /* Set data pointer to arg if present */
+  if (binding->has_arg) {
+    /* Intentional int-to-pointer cast for passing tag numbers */
+    result.inv.data     = (void*) (uintptr_t) binding->arg;    // NOLINT
+    result.inv.userdata = binding->userdata;
+  } else {
+    result.inv.data     = binding->userdata;
+    result.inv.userdata = binding->userdata;
+  }
+
+  return result;
+}
+
+const KeyBinding**
+keybinding_binding_get_all(void)
+{
+  if (!initialized) {
+    return NULL;
+  }
+
+  /* Ensure NULL terminator */
+  if (binding_count < KEYBINDING_MAX_BINDINGS) {
+    bindings[binding_count] = NULL;
+  }
+
+  return bindings;
+}
+
+uint32_t
+keybinding_binding_get_count(void)
+{
+  return binding_count;
+}
+
+bool
+keybinding_binding_invoke(const KeyBinding* binding)
+{
+  if (!initialized || binding == NULL) {
+    return false;
+  }
+
+  /* Look up action */
+  Action* action = action_lookup(binding->action);
+  if (action == NULL) {
+    LOG_DEBUG("Action not found for binding: %s", binding->action);
+    return false;
+  }
+
+  /* Build invocation context */
+  ActionInvocation inv = {
+    .target         = resolve_binding_target(action),
+    .correlation_id = 0,
+    .userdata       = binding->userdata,
+  };
+
+  /* Set data pointer */
+  if (binding->has_arg) {
+    /* Intentional int-to-pointer cast for passing tag numbers */
+    inv.data = (void*) (uintptr_t) binding->arg;    // NOLINT
+  } else {
+    inv.data = binding->userdata;
+  }
+
+  /* Check target requirement */
+  if (action->target_required && inv.target == TARGET_ID_NONE) {
+    LOG_DEBUG("Action '%s' requires target but none available", binding->action);
+    return false;
+  }
+
+  /* Invoke action */
+  return action_invoke(binding->action, &inv);
+}
+
+bool
+keybinding_binding_execute(uint32_t modifiers, xcb_keycode_t keycode)
+{
+  const KeyBinding* binding = keybinding_binding_lookup(modifiers, keycode);
+  if (binding == NULL) {
+    return false;
+  }
+
+  return keybinding_binding_invoke(binding);
+}

--- a/src/actions/keybinding-binding.h
+++ b/src/actions/keybinding-binding.h
@@ -2,10 +2,10 @@
  * keybinding-binding.h - Keybinding binding storage and lookup
  *
  * Manages the keybinding table that maps key events to action names.
- * Keybindings are defined in config.def.h and looked up at runtime.
+ * The keybinding component initializes this system and populates it
+ * with default bindings.
  *
  * This separates binding storage from action invocation:
- * - config.def.h wires key combos to action names
  * - keybinding component looks up action name on KEY_PRESS
  * - action-registry handles target resolution and invocation
  *

--- a/src/actions/keybinding-binding.h
+++ b/src/actions/keybinding-binding.h
@@ -1,0 +1,127 @@
+/*
+ * keybinding-binding.h - Keybinding binding storage and lookup
+ *
+ * Manages the keybinding table that maps key events to action names.
+ * Keybindings are defined in config.def.h and looked up at runtime.
+ *
+ * This separates binding storage from action invocation:
+ * - config.def.h wires key combos to action names
+ * - keybinding component looks up action name on KEY_PRESS
+ * - action-registry handles target resolution and invocation
+ *
+ * Note: KeyBinding struct is defined in keybinding.h
+ */
+
+#ifndef _WM_KEYBINDING_BINDING_H_
+#define _WM_KEYBINDING_BINDING_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <xcb/xcb.h>
+
+/* Include keybinding.h for KeyBinding definition */
+#include "src/components/keybinding.h"
+
+/* Include action registry for ActionInvocation definition */
+#include "action-registry.h"
+
+/*
+ * Binding lookup result
+ */
+typedef struct KeyBindingLookup {
+  const KeyBinding* binding; /* The matching binding, or NULL */
+  ActionInvocation  inv;     /* Invocation context with resolved target */
+} KeyBindingLookup;
+
+/*
+ * Keybinding Binding API
+ */
+
+/*
+ * Initialize the keybinding binding system.
+ */
+void keybinding_binding_init(void);
+
+/*
+ * Shutdown the keybinding binding system.
+ */
+void keybinding_binding_shutdown(void);
+
+/*
+ * Register a keybinding with an action.
+ *
+ * @param modifiers  XCB modifier mask (e.g., XCB_MOD_MASK_4)
+ * @param keycode    X11 keycode (e.g., 41 for 'f')
+ * @param action     Action name to invoke (e.g., "fullscreen.toggle")
+ * @return           true on success, false on failure
+ */
+bool keybinding_binding_register(uint32_t modifiers, xcb_keycode_t keycode, const char* action);
+
+/*
+ * Register a keybinding with an action and integer argument.
+ *
+ * @param modifiers  XCB modifier mask
+ * @param keycode    X11 keycode
+ * @param action     Action name to invoke
+ * @param arg        Integer argument to pass to action
+ * @return           true on success, false on failure
+ */
+bool keybinding_binding_register_with_arg(uint32_t      modifiers,
+                                          xcb_keycode_t keycode,
+                                          const char*   action,
+                                          uint32_t      arg);
+
+/*
+ * Unregister a keybinding by modifiers and keycode.
+ * Returns true if found and removed, false if not found.
+ */
+bool keybinding_binding_unregister(uint32_t modifiers, xcb_keycode_t keycode);
+
+/*
+ * Look up a keybinding by modifiers and keycode.
+ *
+ * @param modifiers  XCB modifier mask
+ * @param keycode    X11 keycode
+ * @return           Matching KeyBinding or NULL if not found
+ */
+const KeyBinding* keybinding_binding_lookup(uint32_t modifiers, xcb_keycode_t keycode);
+
+/*
+ * Look up a keybinding and prepare invocation context.
+ *
+ * @param modifiers  XCB modifier mask
+ * @param keycode    X11 keycode
+ * @return           KeyBindingLookup with binding and resolved invocation
+ */
+KeyBindingLookup keybinding_binding_lookup_with_invocation(uint32_t modifiers, xcb_keycode_t keycode);
+
+/*
+ * Get all registered bindings.
+ * Returns a NULL-terminated array of KeyBinding pointers.
+ */
+const KeyBinding** keybinding_binding_get_all(void);
+
+/*
+ * Get the number of registered bindings.
+ */
+uint32_t keybinding_binding_get_count(void);
+
+/*
+ * Invoke the action for a keybinding.
+ *
+ * @param binding  The binding to invoke
+ * @return         true if action was found and invoked successfully
+ */
+bool keybinding_binding_invoke(const KeyBinding* binding);
+
+/*
+ * Execute a keybinding by lookup and invocation.
+ * Combines lookup and invoke for convenience.
+ *
+ * @param modifiers  XCB modifier mask
+ * @param keycode    X11 keycode
+ * @return           true if a binding was found and invoked successfully
+ */
+bool keybinding_binding_execute(uint32_t modifiers, xcb_keycode_t keycode);
+
+#endif /* _WM_KEYBINDING_BINDING_H_ */

--- a/src/components/keybinding.c
+++ b/src/components/keybinding.c
@@ -1,16 +1,17 @@
 /*
  * keybinding.c - Keybinding component implementation
  *
- * Converts KEY_PRESS and KEY_RELEASE X events into hub requests.
- * Key bindings are configurable via config.def.h.
+ * Converts KEY_PRESS and KEY_RELEASE X events into action invocations.
+ * Uses the action registry to look up and execute actions.
  *
  * This component:
  * - Registers XCB handlers for KEY_PRESS and KEY_RELEASE on init
- * - Looks up keybindings from config when a key event occurs
- * - Sends appropriate requests to the hub based on the action
+ * - Looks up keybindings when a key event occurs
+ * - Invokes actions from the action registry
  * - Unregisters XCB handlers on shutdown
  *
- * The hub routes requests to the appropriate components (focus, tag, etc.)
+ * The action registry provides target resolution, so keybindings
+ * don't need to know about the focus or monitor components.
  *
  * NOTE: This component SENDS requests but does NOT handle them.
  * It should NOT be registered as a handler for request types.
@@ -23,11 +24,8 @@
 #include <xcb/xcb_keysyms.h>
 
 #include "keybinding.h"
-#include "src/components/focus.h"
-#include "src/components/tag-manager.h"
-#include "src/components/tiling.h"
-#include "src/target/client.h"
-#include "src/target/monitor.h"
+#include "src/actions/action-registry.h"
+#include "src/actions/keybinding-binding.h"
 #include "src/xcb/xcb-handler.h"
 #include "wm-hub.h"
 #include "wm-log.h"
@@ -35,58 +33,69 @@
 #include "wm-states.h"
 
 /*
- * Active keybinding configuration
+ * Action names for keybindings
+ * These are the names registered with the action registry.
+ */
+#define ACTION_FOCUS_CURRENT   "focus.focus-current"
+#define ACTION_FOCUS_PREV      "focus.focus-prev"
+#define ACTION_TAG_VIEW        "tag-manager.view"
+#define ACTION_TAG_TOGGLE      "tag-manager.toggle"
+#define ACTION_TAG_CLIENT_MOVE "tag-manager.client-move"
+#define ACTION_FULLSCREEN      "fullscreen.toggle"
+#define ACTION_TILE_MONITOR    "monitor.tile"
+
+/*
+ * Default keybindings using action names
  *
- * Keep this configuration private to this translation unit so the
- * implementation owns the binding data instead of exporting globals
- * that appear externally overridable.
+ * These bind key combinations to action names (strings).
+ * The action registry resolves targets at invocation time.
  */
 static const KeyBinding default_keybindings[] = {
   /* Focus actions */
   /* Mod+Enter: focus current client */
-  { XCB_MOD_MASK_4,                                       36, KEYBINDING_ACTION_FOCUS_CLIENT,      0 }, /* keycode 36 = Return */
+  { XCB_MOD_MASK_4,                                       36, ACTION_FOCUS_CURRENT,   0, NULL, false }, /* keycode 36 = Return */
 
   /* Mod+Shift+Enter: focus previous client */
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  36, KEYBINDING_ACTION_FOCUS_PREV,        0 },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  36, ACTION_FOCUS_PREV,      0, NULL, false },
 
   /* Tag view actions - Mod+1 through Mod+9 */
-  { XCB_MOD_MASK_4,                                       10, KEYBINDING_ACTION_TAG_VIEW,          1 }, /* keycode 10 = 1 */
-  { XCB_MOD_MASK_4,                                       11, KEYBINDING_ACTION_TAG_VIEW,          2 }, /* keycode 11 = 2 */
-  { XCB_MOD_MASK_4,                                       12, KEYBINDING_ACTION_TAG_VIEW,          3 }, /* keycode 12 = 3 */
-  { XCB_MOD_MASK_4,                                       13, KEYBINDING_ACTION_TAG_VIEW,          4 }, /* keycode 13 = 4 */
-  { XCB_MOD_MASK_4,                                       14, KEYBINDING_ACTION_TAG_VIEW,          5 }, /* keycode 14 = 5 */
-  { XCB_MOD_MASK_4,                                       15, KEYBINDING_ACTION_TAG_VIEW,          6 }, /* keycode 15 = 6 */
-  { XCB_MOD_MASK_4,                                       16, KEYBINDING_ACTION_TAG_VIEW,          7 }, /* keycode 16 = 7 */
-  { XCB_MOD_MASK_4,                                       17, KEYBINDING_ACTION_TAG_VIEW,          8 }, /* keycode 17 = 8 */
-  { XCB_MOD_MASK_4,                                       18, KEYBINDING_ACTION_TAG_VIEW,          9 }, /* keycode 18 = 9 */
+  { XCB_MOD_MASK_4,                                       10, ACTION_TAG_VIEW,        1, NULL, true  }, /* keycode 10 = 1 */
+  { XCB_MOD_MASK_4,                                       11, ACTION_TAG_VIEW,        2, NULL, true  }, /* keycode 11 = 2 */
+  { XCB_MOD_MASK_4,                                       12, ACTION_TAG_VIEW,        3, NULL, true  }, /* keycode 12 = 3 */
+  { XCB_MOD_MASK_4,                                       13, ACTION_TAG_VIEW,        4, NULL, true  }, /* keycode 13 = 4 */
+  { XCB_MOD_MASK_4,                                       14, ACTION_TAG_VIEW,        5, NULL, true  }, /* keycode 14 = 5 */
+  { XCB_MOD_MASK_4,                                       15, ACTION_TAG_VIEW,        6, NULL, true  }, /* keycode 15 = 6 */
+  { XCB_MOD_MASK_4,                                       16, ACTION_TAG_VIEW,        7, NULL, true  }, /* keycode 16 = 7 */
+  { XCB_MOD_MASK_4,                                       17, ACTION_TAG_VIEW,        8, NULL, true  }, /* keycode 17 = 8 */
+  { XCB_MOD_MASK_4,                                       18, ACTION_TAG_VIEW,        9, NULL, true  }, /* keycode 18 = 9 */
 
   /* Tag toggle actions - Mod+Shift+1 through Mod+Shift+9 */
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  10, KEYBINDING_ACTION_TAG_TOGGLE,        1 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  11, KEYBINDING_ACTION_TAG_TOGGLE,        2 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  12, KEYBINDING_ACTION_TAG_TOGGLE,        3 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  13, KEYBINDING_ACTION_TAG_TOGGLE,        4 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  14, KEYBINDING_ACTION_TAG_TOGGLE,        5 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  15, KEYBINDING_ACTION_TAG_TOGGLE,        6 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  16, KEYBINDING_ACTION_TAG_TOGGLE,        7 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  17, KEYBINDING_ACTION_TAG_TOGGLE,        8 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  18, KEYBINDING_ACTION_TAG_TOGGLE,        9 },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  10, ACTION_TAG_TOGGLE,      1, NULL, true  },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  11, ACTION_TAG_TOGGLE,      2, NULL, true  },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  12, ACTION_TAG_TOGGLE,      3, NULL, true  },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  13, ACTION_TAG_TOGGLE,      4, NULL, true  },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  14, ACTION_TAG_TOGGLE,      5, NULL, true  },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  15, ACTION_TAG_TOGGLE,      6, NULL, true  },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  16, ACTION_TAG_TOGGLE,      7, NULL, true  },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  17, ACTION_TAG_TOGGLE,      8, NULL, true  },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4,                  18, ACTION_TAG_TOGGLE,      9, NULL, true  },
 
   /* Tag client toggle - Mod+Shift+Alt+1 through Mod+Shift+Alt+9 (move focused client to tag) */
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 10, KEYBINDING_ACTION_TAG_CLIENT_TOGGLE, 1 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 11, KEYBINDING_ACTION_TAG_CLIENT_TOGGLE, 2 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 12, KEYBINDING_ACTION_TAG_CLIENT_TOGGLE, 3 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 13, KEYBINDING_ACTION_TAG_CLIENT_TOGGLE, 4 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 14, KEYBINDING_ACTION_TAG_CLIENT_TOGGLE, 5 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 15, KEYBINDING_ACTION_TAG_CLIENT_TOGGLE, 6 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 16, KEYBINDING_ACTION_TAG_CLIENT_TOGGLE, 7 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 17, KEYBINDING_ACTION_TAG_CLIENT_TOGGLE, 8 },
-  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 18, KEYBINDING_ACTION_TAG_CLIENT_TOGGLE, 9 },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 10, ACTION_TAG_CLIENT_MOVE, 1, NULL, true  },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 11, ACTION_TAG_CLIENT_MOVE, 2, NULL, true  },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 12, ACTION_TAG_CLIENT_MOVE, 3, NULL, true  },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 13, ACTION_TAG_CLIENT_MOVE, 4, NULL, true  },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 14, ACTION_TAG_CLIENT_MOVE, 5, NULL, true  },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 15, ACTION_TAG_CLIENT_MOVE, 6, NULL, true  },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 16, ACTION_TAG_CLIENT_MOVE, 7, NULL, true  },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 17, ACTION_TAG_CLIENT_MOVE, 8, NULL, true  },
+  { XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_5 | XCB_MOD_MASK_4, 18, ACTION_TAG_CLIENT_MOVE, 9, NULL, true  },
 
   /* Fullscreen toggle - Mod+f (keycode 41 = f) */
-  { XCB_MOD_MASK_4,                                       41, KEYBINDING_ACTION_TOGGLE_FULLSCREEN, 0 },
+  { XCB_MOD_MASK_4,                                       41, ACTION_FULLSCREEN,      0, NULL, false }, /* keycode 41 = f */
 
   /* Tile toggle - Mod+i (keycode 31 = i) */
-  { XCB_MOD_MASK_4,                                       31, KEYBINDING_ACTION_TILE_MONITOR,      0 },
+  { XCB_MOD_MASK_4,                                       31, ACTION_TILE_MONITOR,    0, NULL, false }, /* keycode 31 = i */
 };
 
 static const KeyBinding* keybindings     = default_keybindings;
@@ -113,181 +122,6 @@ HubComponent keybinding_component = {
 };
 
 /*
- * External dependencies - resolved at runtime
- */
-
-/* Current focused client - provided by focus component (stub for now) */
-__attribute__((weak)) TargetID
-focus_get_current_client(void)
-{
-  /* TODO: Implement focus component integration */
-  /* For now, return NONE - focus component will provide this */
-  return TARGET_ID_NONE;
-}
-
-/* Current selected monitor - provided by monitor system */
-extern Monitor* monitor_get_selected(void);
-extern TargetID monitor_get_current_monitor(void);
-
-/*
- * Convert KeybindingAction to RequestType
- * These request types match what the focus and tag components expect
- */
-static RequestType
-action_to_request_type(KeybindingAction action)
-{
-  switch (action) {
-  case KEYBINDING_ACTION_FOCUS_CLIENT:
-    return REQ_KEYBINDING_FOCUS;      /* = 1 = REQ_CLIENT_FOCUS */
-  case KEYBINDING_ACTION_FOCUS_PREV:
-    return REQ_KEYBINDING_FOCUS_PREV; /* = 3 = REQ_CLIENT_FOCUS_PREV */
-  case KEYBINDING_ACTION_FOCUS_NEXT:
-    return REQ_KEYBINDING_FOCUS;      /* Use same as current for now */
-  case KEYBINDING_ACTION_TAG_VIEW:
-    return REQ_KEYBINDING_TAG_VIEW;   /* = 4 = REQ_MONITOR_TAG_VIEW */
-  case KEYBINDING_ACTION_TAG_TOGGLE:
-    return REQ_KEYBINDING_TAG_TOGGLE; /* = 5 = REQ_MONITOR_TAG_TOGGLE */
-  case KEYBINDING_ACTION_TAG_CLIENT_TOGGLE:
-    return REQ_TAG_CLIENT_TOGGLE;     /* Move client to tag */
-  case KEYBINDING_ACTION_CLOSE_CLIENT:
-    return REQ_KEYBINDING_CLOSE;      /* = 6 = REQ_CLIENT_CLOSE */
-  case KEYBINDING_ACTION_TOGGLE_FULLSCREEN:
-    return REQ_CLIENT_FULLSCREEN;     /* Fullscreen request */
-  default:
-    return 0;
-  }
-}
-
-/*
- * Get the current target for a request type
- */
-static TargetID
-get_target_for_request(RequestType type)
-{
-  /* For focus and close requests, use current client */
-  if (type == REQ_KEYBINDING_FOCUS ||
-      type == REQ_KEYBINDING_FOCUS_PREV ||
-      type == REQ_KEYBINDING_CLOSE) {
-    return focus_get_current_client();
-  }
-
-  /* For tag requests, use current monitor */
-  if (type == REQ_KEYBINDING_TAG_VIEW ||
-      type == REQ_KEYBINDING_TAG_TOGGLE) {
-    return monitor_get_current_monitor();
-  }
-
-  return TARGET_ID_NONE;
-}
-
-/*
- * Log a debug message for focus request failures
- */
-static const char*
-focus_action_name(RequestType type)
-{
-  switch (type) {
-  case REQ_KEYBINDING_FOCUS:
-    return "focus current client";
-  case REQ_KEYBINDING_FOCUS_PREV:
-    return "focus previous client";
-  default:
-    return "focus";
-  }
-}
-
-/*
- * Send a focus request to the hub
- */
-static void
-send_focus_request(RequestType type)
-{
-  TargetID target = get_target_for_request(type);
-  if (target != TARGET_ID_NONE) {
-    hub_send_request(type, target);
-    LOG_DEBUG("Keybinding sent focus request type=%" PRIu32 " target=%" PRIu64,
-              type, target);
-  } else {
-    LOG_DEBUG("Keybinding: no focused client to %s", focus_action_name(type));
-  }
-}
-
-/*
- * Send a tag view/toggle request to the hub
- */
-static void
-send_tag_request(RequestType type, uint32_t tag)
-{
-  TargetID target = get_target_for_request(type);
-  if (target != TARGET_ID_NONE) {
-    hub_send_request_data(type, target, &tag);
-    LOG_DEBUG("Keybinding sent tag request type=%" PRIu32 " tag=%" PRIu32, type, tag);
-  } else {
-    LOG_DEBUG("Keybinding: no selected monitor for tag request");
-  }
-}
-
-/*
- * Execute a keybinding action
- */
-static void
-execute_keybinding(const KeyBinding* binding)
-{
-  RequestType req_type = action_to_request_type(binding->action);
-
-  switch (binding->action) {
-  case KEYBINDING_ACTION_FOCUS_CLIENT:
-  case KEYBINDING_ACTION_FOCUS_PREV:
-  case KEYBINDING_ACTION_FOCUS_NEXT:
-    send_focus_request(req_type);
-    break;
-
-  case KEYBINDING_ACTION_TAG_VIEW:
-  case KEYBINDING_ACTION_TAG_TOGGLE:
-    send_tag_request(req_type, binding->arg);
-    break;
-
-  case KEYBINDING_ACTION_TAG_CLIENT_TOGGLE:
-    /* Move focused client to/from tag - sends to current client */
-    {
-      Client* c = focus_get_focused_client();
-      if (c != NULL) {
-        uint32_t tag_data = binding->arg;
-        hub_send_request_data(req_type, c->target.id, &tag_data);
-        LOG_DEBUG("Keybinding sent client tag toggle type=%" PRIu32 " target=%" PRIu64 " tag=%" PRIu32,
-                  req_type, (uint64_t) c->target.id, tag_data);
-      } else {
-        LOG_DEBUG("Keybinding: no focused client for tag client toggle");
-      }
-    }
-    break;
-
-  case KEYBINDING_ACTION_CLOSE_CLIENT:
-    send_focus_request(REQ_KEYBINDING_CLOSE);
-    break;
-
-  case KEYBINDING_ACTION_TOGGLE_FULLSCREEN:
-    send_focus_request(REQ_CLIENT_FULLSCREEN);
-    break;
-
-  case KEYBINDING_ACTION_TILE_MONITOR: {
-    TargetID target = monitor_get_current_monitor();
-    if (target != TARGET_ID_NONE) {
-      hub_send_request(REQ_MONITOR_TILE, target);
-      LOG_DEBUG("Keybinding sent tile request to monitor target=%" PRIu64, target);
-    } else {
-      LOG_DEBUG("Keybinding: no selected monitor for tile request");
-    }
-  } break;
-
-
-  default:
-    LOG_DEBUG("Keybinding: unhandled action %d", binding->action);
-    break;
-  }
-}
-
-/*
  * Initialize the keybinding component
  */
 void
@@ -302,12 +136,28 @@ keybinding_init(void)
   /* Register with hub */
   hub_register_component(&keybinding_component);
 
+  /* Initialize action registry (if not already initialized) */
+  action_registry_init();
+
+  /* Initialize keybinding binding system */
+  keybinding_binding_init();
+
+  /* Register default keybindings */
+  for (uint32_t i = 0; i < num_keybindings; i++) {
+    const KeyBinding* kb = &keybindings[i];
+    if (kb->has_arg) {
+      keybinding_binding_register_with_arg(kb->modifiers, kb->keycode, kb->action, kb->arg);
+    } else {
+      keybinding_binding_register(kb->modifiers, kb->keycode, kb->action);
+    }
+  }
+
   /* Register XCB handlers for KEY_PRESS and KEY_RELEASE */
   xcb_handler_register(XCB_KEY_PRESS, &keybinding_component, keybinding_handle_key_press);
   xcb_handler_register(XCB_KEY_RELEASE, &keybinding_component, keybinding_handle_key_release);
 
   initialized = true;
-  LOG_DEBUG("Keybinding component initialized");
+  LOG_DEBUG("Keybinding component initialized with %" PRIu32 " bindings", num_keybindings);
 }
 
 /*
@@ -324,6 +174,12 @@ keybinding_shutdown(void)
 
   /* Unregister XCB handlers */
   xcb_handler_unregister_component(&keybinding_component);
+
+  /* Shutdown keybinding binding system */
+  keybinding_binding_shutdown();
+
+  /* Shutdown action registry */
+  action_registry_shutdown();
 
   /* Unregister from hub */
   hub_unregister_component("keybinding");
@@ -349,8 +205,11 @@ keybinding_lookup(uint32_t modifiers, xcb_keycode_t keycode)
       continue;
     }
 
+    /* Normalize binding's modifiers for comparison */
+    uint32_t binding_normalized = binding->modifiers & ~(XCB_MOD_MASK_LOCK | XCB_MOD_MASK_2);
+
     /* Match modifiers exactly (after normalizing) */
-    if (binding->modifiers != normalized_mods) {
+    if (binding_normalized != normalized_mods) {
       continue;
     }
 
@@ -379,6 +238,60 @@ keybinding_get_count(void)
 }
 
 /*
+ * Execute a keybinding action
+ */
+static void
+execute_keybinding(const KeyBinding* binding)
+{
+  if (binding == NULL || binding->action == NULL) {
+    return;
+  }
+
+  /* Look up the action */
+  Action* action = action_lookup(binding->action);
+  if (action == NULL) {
+    LOG_DEBUG("Keybinding: action not found: %s", binding->action);
+    return;
+  }
+
+  /* Build invocation context */
+  ActionInvocation inv = {
+    .target         = TARGET_ID_NONE,
+    .correlation_id = 0,
+    .userdata       = binding->userdata,
+  };
+
+  /* Set data pointer */
+  if (binding->has_arg) {
+    /* Intentional int-to-pointer cast for passing tag numbers */
+    inv.data = (void*) (uintptr_t) binding->arg;    // NOLINT
+  } else {
+    inv.data = binding->userdata;
+  }
+
+  /* Resolve target based on action's target_type */
+  if (action->target_type == ACTION_TARGET_CLIENT) {
+    inv.target = action_resolve_current_client();
+  } else if (action->target_type == ACTION_TARGET_MONITOR) {
+    inv.target = action_resolve_current_monitor();
+  }
+
+  /* Check if target is required */
+  if (action->target_required && inv.target == TARGET_ID_NONE) {
+    LOG_DEBUG("Keybinding: action '%s' requires target but none available", binding->action);
+    return;
+  }
+
+  /* Invoke the action */
+  LOG_DEBUG("Keybinding invoking action: %s (target=%" PRIu64 ")", binding->action, inv.target);
+
+  bool result = action->callback(&inv);
+  if (!result) {
+    LOG_DEBUG("Keybinding: action '%s' returned failure", binding->action);
+  }
+}
+
+/*
  * Handle KEY_PRESS events
  * Called from XCB event loop via xcb_handler_dispatch()
  */
@@ -400,10 +313,10 @@ keybinding_handle_key_press(void* event)
     return;
   }
 
-  LOG_DEBUG("Keybinding matched: action=%d arg=%" PRIu32,
+  LOG_DEBUG("Keybinding matched: action=%s arg=%" PRIu32,
             binding->action, binding->arg);
 
-  /* Execute the binding action */
+  /* Execute the binding action via action registry */
   execute_keybinding(binding);
 }
 
@@ -422,4 +335,31 @@ keybinding_handle_key_release(void* event)
   /* For now, key releases don't trigger any actions.
    * In the future, we might want to track key hold duration
    * or implement key repeat behavior here. */
+}
+
+/*
+ * Legacy support: convert KeybindingAction to action name string
+ * This is used by tests that expect the old enum-based approach
+ */
+const char*
+keybinding_action_to_name(KeybindingAction action)
+{
+  switch (action) {
+  case KEYBINDING_ACTION_FOCUS_CLIENT:
+    return ACTION_FOCUS_CURRENT;
+  case KEYBINDING_ACTION_FOCUS_PREV:
+    return ACTION_FOCUS_PREV;
+  case KEYBINDING_ACTION_TAG_VIEW:
+    return ACTION_TAG_VIEW;
+  case KEYBINDING_ACTION_TAG_TOGGLE:
+    return ACTION_TAG_TOGGLE;
+  case KEYBINDING_ACTION_TAG_CLIENT_TOGGLE:
+    return ACTION_TAG_CLIENT_MOVE;
+  case KEYBINDING_ACTION_TOGGLE_FULLSCREEN:
+    return ACTION_FULLSCREEN;
+  case KEYBINDING_ACTION_TILE_MONITOR:
+    return ACTION_TILE_MONITOR;
+  default:
+    return NULL;
+  }
 }

--- a/src/components/keybinding.h
+++ b/src/components/keybinding.h
@@ -1,19 +1,18 @@
 /*
  * keybinding.h - Keybinding component for the window manager
  *
- * Converts KEY_PRESS and KEY_RELEASE X events into hub requests.
- * Key bindings are configurable via config.def.h.
+ * Converts KEY_PRESS and KEY_RELEASE X events into action invocations.
+ * Uses the action registry for target resolution and action execution.
  *
  * Component lifecycle:
- * - on_init(): register XCB handlers for KEY_PRESS and KEY_RELEASE
- * - on_shutdown(): unregister XCB handlers
- * - No target adoption needed (works with global target resolution)
+ * - on_init(): initialize action registry, register keybindings, register XCB handlers
+ * - on_shutdown(): unregister XCB handlers, shutdown systems
+ * - No target adoption needed (uses global target resolution)
  *
- * Request types sent:
- * - REQ_CLIENT_FOCUS: Mod+Enter focuses the current client
- * - REQ_CLIENT_FOCUS_PREV: Mod+Shift+Enter focuses previous client
- * - REQ_MONITOR_TAG_VIEW: Mod+1-9 switches to tag view (1-indexed)
- * - REQ_MONITOR_TAG_TOGGLE: Mod+Shift+1-9 toggles tag visibility
+ * Key bindings are defined as action name strings:
+ * - "focus.focus-current": Mod+Enter focuses the current client
+ * - "tag-manager.view": Mod+1-9 switches to tag view (1-indexed)
+ * - "fullscreen.toggle": Mod+f toggles fullscreen
  *
  * Note: This component sends requests but does NOT handle them.
  * It should not be registered as a handler for these request types.
@@ -29,21 +28,8 @@
 #include "wm-hub.h"
 
 /*
- * Request type constants
- * These match the request types expected by focus and tag components.
- * The keybinding component uses these to send requests, not handle them.
- */
-enum KeybindingRequestType {
-  REQ_KEYBINDING_FOCUS      = 1, /* Maps to REQ_CLIENT_FOCUS */
-  REQ_KEYBINDING_FOCUS_PREV = 3, /* Maps to REQ_CLIENT_FOCUS_PREV */
-  REQ_KEYBINDING_TAG_VIEW   = 4, /* Maps to REQ_MONITOR_TAG_VIEW */
-  REQ_KEYBINDING_TAG_TOGGLE = 5, /* Maps to REQ_MONITOR_TAG_TOGGLE */
-  REQ_KEYBINDING_CLOSE      = 6, /* Maps to REQ_CLIENT_CLOSE */
-};
-
-/*
- * Key binding action types
- * Used internally to classify what action a keybinding should trigger
+ * Key binding action types (legacy enum for backward compatibility)
+ * New code should use action name strings directly.
  */
 typedef enum {
   KEYBINDING_ACTION_FOCUS_CLIENT,      /* Focus current client */
@@ -60,12 +46,17 @@ typedef enum {
 
 /*
  * Key binding configuration entry
+ *
+ * Maps a key combination to an action name.
+ * The action name is looked up in the action registry at runtime.
  */
 typedef struct KeyBinding {
-  uint32_t         modifiers; /* XCB modifier mask (Shift, Control, Mod1, etc.) */
-  xcb_keycode_t    keycode;   /* X11 keycode */
-  KeybindingAction action;    /* Action to perform */
-  uint32_t         arg;       /* Action argument (tag number for tag actions) */
+  uint32_t      modifiers; /* XCB modifier mask (Shift, Control, Mod1, etc.) */
+  xcb_keycode_t keycode;   /* X11 keycode */
+  const char*   action;    /* Action name to invoke (e.g., "fullscreen.toggle") */
+  uint32_t      arg;       /* Integer argument (e.g., tag number) */
+  void*         userdata;  /* Binding-specific userdata */
+  bool          has_arg;   /* Whether arg should be passed to action */
 } KeyBinding;
 
 /*
@@ -129,7 +120,7 @@ extern HubComponent keybinding_component;
 
 /*
  * Handle KEY_PRESS events
- * Looks up the keybinding in config, then sends the appropriate hub request
+ * Looks up the keybinding, then invokes the action from the action registry
  */
 void keybinding_handle_key_press(void* event);
 
@@ -166,5 +157,11 @@ void keybinding_init(void);
  * Called during cleanup
  */
 void keybinding_shutdown(void);
+
+/*
+ * Convert KeybindingAction enum to action name string
+ * Used for backward compatibility with tests
+ */
+const char* keybinding_action_to_name(KeybindingAction action);
 
 #endif /* WM_KEYBINDING_H_ */

--- a/test-wm-keybinding.c
+++ b/test-wm-keybinding.c
@@ -8,6 +8,7 @@
  * - Keybinding action execution (sending hub requests)
  */
 
+#include <string.h>
 #include "src/components/keybinding.h"
 #include "src/xcb/xcb-handler.h"
 #include "test-registry.h"
@@ -56,17 +57,17 @@ test_keybinding_lookup_exact(void)
   xcb_handler_init();
   keybinding_init();
 
-  /* Mod4 + keycode 36 (Return) -> KEYBINDING_ACTION_FOCUS_CLIENT */
+  /* Mod4 + keycode 36 (Return) -> focus.focus-current */
   const KeyBinding* binding = keybinding_lookup(XCB_MOD_MASK_4, 36);
-  assert(binding != NULL && binding->action == KEYBINDING_ACTION_FOCUS_CLIENT);
+  assert(binding != NULL && strcmp(binding->action, "focus.focus-current") == 0);
 
-  /* Mod4 + Shift + keycode 36 -> KEYBINDING_ACTION_FOCUS_PREV */
+  /* Mod4 + Shift + keycode 36 -> focus.focus-prev */
   binding = keybinding_lookup(XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, 36);
-  assert(binding != NULL && binding->action == KEYBINDING_ACTION_FOCUS_PREV);
+  assert(binding != NULL && strcmp(binding->action, "focus.focus-prev") == 0);
 
-  /* Mod4 + keycode 10 (1) -> KEYBINDING_ACTION_TAG_VIEW with arg=1 */
+  /* Mod4 + keycode 10 (1) -> tag-manager.view with arg=1 */
   binding = keybinding_lookup(XCB_MOD_MASK_4, 10);
-  assert(binding != NULL && binding->action == KEYBINDING_ACTION_TAG_VIEW && binding->arg == 1);
+  assert(binding != NULL && strcmp(binding->action, "tag-manager.view") == 0 && binding->arg == 1);
 
   keybinding_shutdown();
   xcb_handler_shutdown();
@@ -113,12 +114,12 @@ test_keybinding_modifier_normalization(void)
   /* Mod4 + lock modifier should still match Mod4 alone */
   uint32_t          mod_with_lock = XCB_MOD_MASK_4 | XCB_MOD_MASK_LOCK;
   const KeyBinding* binding       = keybinding_lookup(mod_with_lock, 36);
-  assert(binding != NULL && binding->action == KEYBINDING_ACTION_FOCUS_CLIENT);
+  assert(binding != NULL && strcmp(binding->action, "focus.focus-current") == 0);
 
   /* Mod4 + NumLock (mode switch) should also match */
   uint32_t mod_with_numlock = XCB_MOD_MASK_4 | XCB_MOD_MASK_2;
   binding                   = keybinding_lookup(mod_with_numlock, 36);
-  assert(binding != NULL && binding->action == KEYBINDING_ACTION_FOCUS_CLIENT);
+  assert(binding != NULL && strcmp(binding->action, "focus.focus-current") == 0);
 
   keybinding_shutdown();
   xcb_handler_shutdown();
@@ -141,7 +142,7 @@ test_keybinding_tag_bindings(void)
   for (int i = 1; i <= 9; i++) {
     xcb_keycode_t     keycode = 9 + i; /* keycodes 10-18 */
     const KeyBinding* binding = keybinding_lookup(XCB_MOD_MASK_4, keycode);
-    assert(binding != NULL && binding->action == KEYBINDING_ACTION_TAG_VIEW && binding->arg == (uint32_t) i);
+    assert(binding != NULL && strcmp(binding->action, "tag-manager.view") == 0 && binding->arg == (uint32_t) i);
   }
 
   /* Mod4 + Shift + 1-9 for tag toggle */
@@ -149,7 +150,7 @@ test_keybinding_tag_bindings(void)
     xcb_keycode_t     keycode = 9 + i;
     const KeyBinding* binding = keybinding_lookup(
         XCB_MOD_MASK_SHIFT | XCB_MOD_MASK_4, keycode);
-    assert(binding != NULL && binding->action == KEYBINDING_ACTION_TAG_TOGGLE && binding->arg == (uint32_t) i);
+    assert(binding != NULL && strcmp(binding->action, "tag-manager.toggle") == 0 && binding->arg == (uint32_t) i);
   }
 
   keybinding_shutdown();
@@ -213,7 +214,7 @@ test_keybinding_get_bindings(void)
 
   /* Verify first binding is Mod+Enter for focus */
   const KeyBinding* first = keybinding_get_bindings();
-  assert(first != NULL && first->action == KEYBINDING_ACTION_FOCUS_CLIENT && first->keycode == 36);
+  assert(first != NULL && strcmp(first->action, "focus.focus-current") == 0 && first->keycode == 36);
 
   keybinding_shutdown();
   hub_shutdown();


### PR DESCRIPTION
# feat: Implement Actions and Wiring Architecture

## Summary

Implements the **Actions and Wiring** pattern for the window manager, enabling components to expose callable actions that can be wired to keybindings without tight coupling. This resolves the architectural issue where the keybinding component hardcoded bindings for actions from other components.

## Problem

Currently, the keybinding component hardcodes bindings for actions from other components (e.g., tag switching). This violates the separation of concerns principle - a component should only know about its own domain.

## Solution

1. **Action Registry** (`src/actions/action-registry.c/h`): Components register named actions during initialization. Actions are looked up by string name.

2. **Keybinding Binding System** (`src/actions/keybinding-binding.c/h`): Runtime storage for key combinations mapped to action names.

3. **Refactored Keybinding Component**: Key bindings now use action name strings instead of enum values, and use the action registry for lookup and invocation.

4. **Architecture Documentation** (`docs/architecture/actions.md`): Comprehensive design document explaining the pattern.

## Key Design Principles

- **Components expose callable actions** via action names (e.g., `"fullscreen.toggle"`, `"tag-manager.view"`)
- **Declarative wiring**: Configuration wires key combinations to action names
- **Target resolution at invocation time**: Actions receive targets when called, not at binding time
- **Cross-component decoupling**: Keybinding component doesn't know about focus, tag, or tiling internals

## Example Usage

```c
// Component registers its actions in on_init()
Action fullscreen_actions[] = {
  { .name = "fullscreen.toggle", .callback = fullscreen_toggle, .target_type = ACTION_TARGET_CLIENT },
};
action_register(&fullscreen_actions[0]);

// Keybinding component uses action names
static const KeyBinding default_keybindings[] = {
  { XCB_MOD_MASK_4, 41, "fullscreen.toggle" },  // Mod+f
};

// Lookup and invoke at runtime
Action* action = action_lookup(binding->action);
action->callback(&inv);
```

## Files Changed

| File | Change |
|------|--------|
| `docs/architecture/actions.md` | New architecture documentation |
| `src/actions/action-registry.c` | New - action registration and lookup |
| `src/actions/action-registry.h` | New - action registry API |
| `src/actions/keybinding-binding.c` | New - runtime binding storage |
| `src/actions/keybinding-binding.h` | New - binding API |
| `src/components/keybinding.c` | Refactored to use action names |
| `src/components/keybinding.h` | Updated KeyBinding struct with action names |
| `test-wm-keybinding.c` | Updated tests for action names |
| `Makefile` | Added src/actions to source list |

## Testing

- `make test`: 604 tests passing
- `make check`: format and tidy checks pass

## Related Issues

- Resolves #83: Design: Actions and Wiring Architecture
- Enables future work on: #19 (bar), #20 (pointer), #21 (floating), #80 (keybinding config)