### PR TITLE
fix(scripts): address review comments from PRs #101/#102

### DIFF
--- a/scripts/review-agent.sh
+++ b/scripts/review-agent.sh
@@ -26,6 +26,7 @@ MODE="review"  # "review" or "fix"
 GITHUB_REPO="kesor/wm-xcb"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SUCKLESS_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 usage() {
     echo "Usage: $0 <PR_number> [--fix]"
@@ -66,13 +67,14 @@ get_pr_info() {
     }' 2>/dev/null
 }
 
-# Get diff between PR branch and master
+# Get diff between PR branch and base branch
 get_diff() {
     local branch="$1"
     local base="$2"
     
-    # Get commits on this branch that differ from master
-    git fetch origin "${base}:refs/remotes/origin/master" 2>/dev/null || true
+    # Fetch the base branch and PR branch to compare
+    git fetch origin "${base}:refs/remotes/origin/${base}" 2>/dev/null || true
+    git fetch origin "${branch}" 2>/dev/null || true
     git diff "origin/${base}...origin/${branch}" -- '*.c' '*.h' 2>/dev/null
 }
 
@@ -81,6 +83,8 @@ get_changed_files() {
     local branch="$1"
     local base="$2"
     
+    git fetch origin "${base}" 2>/dev/null || true
+    git fetch origin "${branch}" 2>/dev/null || true
     git diff "origin/${base}...origin/${branch}" --name-only 2>/dev/null | grep -E '\.(c|h)$' || true
 }
 
@@ -248,8 +252,8 @@ echo "Branch: ${BRANCH} → ${BASE}"
 
 # Fetch branches
 echo "Fetching branches..."
-git fetch origin "${BRANCH}:origin/${BRANCH}" 2>/dev/null || true
-git fetch origin "${BASE}:origin/master" 2>/dev/null || true
+git fetch origin "${BRANCH}" 2>/dev/null || true
+git fetch origin "${BASE}" 2>/dev/null || true
 
 # Get changed files
 CHANGED_FILES=$(get_changed_files "$BRANCH" "$BASE")
@@ -295,27 +299,31 @@ fi
 # Copy task file
 cp "${REPO_DIR}/review-task-${PR_NUM}.txt" "../${WORKTREE_NAME}/review-task-${PR_NUM}.txt" 2>/dev/null || true
 
-# Send commands to run the review
-NIX_CMD="cd /home/evgeny/src/suckless && nix develop --command sh -c 'cd ${WORKTREE_NAME} && pi @review-task-${PR_NUM}.txt Review PR #${PR_NUM} architectural violations'"
+# Create worktree path
+WORKTREE_PATH="${SUCKLESS_ROOT}/${WORKTREE_NAME}"
 
+# Send commands to run the review
+NIX_CMD="cd ${SUCKLESS_ROOT} && nix develop --command sh -c 'cd ${WORKTREE_NAME} && pi @review-task-${PR_NUM}.txt Review PR #${PR_NUM} architectural violations'"
+
+# Create or reuse review tmux session
 SESSION_NAME="wm-issues"
 WINDOW_NAME="review-${PR_NUM}"
 
 # Ensure session exists with correct window
 if ! tmux has-session -t ${SESSION_NAME} 2>/dev/null; then
-    tmux new-session -d -s ${SESSION_NAME} -n "main" -c "/home/evgeny/src/suckless/${WORKTREE_NAME}"
+    tmux new-session -d -s ${SESSION_NAME} -n "main" -c "${WORKTREE_PATH}"
 fi
 
 # Kill old review window if exists and create new one
 tmux kill-window -t "${SESSION_NAME}:${WINDOW_NAME}" 2>/dev/null || true
-tmux new-window -t ${SESSION_NAME} -n "${WINDOW_NAME}" -c "/home/evgeny/src/suckless/${WORKTREE_NAME}"
+tmux new-window -t ${SESSION_NAME} -n "${WINDOW_NAME}" -c "${WORKTREE_PATH}"
 
 tmux send-keys -t "${SESSION_NAME}:${WINDOW_NAME}" "git fetch origin" Enter
 tmux send-keys -t "${SESSION_NAME}:${WINDOW_NAME}" "${NIX_CMD}" Enter
 
 echo ""
 echo "Architectural review agent spawned for PR #${PR_NUM}"
-echo "Worktree: /home/evgeny/src/suckless/${WORKTREE_NAME}"
+echo "Worktree: ${WORKTREE_PATH}"
 echo "Session: ${SESSION_NAME}"
 echo "Window: ${WINDOW_NAME}"
 echo ""

--- a/scripts/review-agent.sh
+++ b/scripts/review-agent.sh
@@ -2,8 +2,8 @@
 # review-agent.sh - Review PR changes against documented architecture
 #
 # Usage:
-#   ./review-agent.sh <PR_number>        # Review PR, leave comments
-#   ./review-agent.sh <PR_number> --fix # Review and attempt auto-fix
+#   ./scripts/review-agent.sh <PR_number>        # Review PR, leave comments
+#   ./scripts/review-agent.sh <PR_number> --fix # Review and attempt auto-fix
 #
 # This script:
 # 1. Gets the diff between PR branch and master
@@ -24,7 +24,8 @@ set -e
 PR_NUM=""
 MODE="review"  # "review" or "fix"
 GITHUB_REPO="kesor/wm-xcb"
-MAIN_REPO="/home/evgeny/src/suckless/wm"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 usage() {
     echo "Usage: $0 <PR_number> [--fix]"
@@ -102,7 +103,7 @@ create_review_task() {
     local changed_files="$5"
     local mode="$6"
     
-    cat > "${MAIN_REPO}/review-task-${pr_num}.txt" << REVEOF
+    cat > "${REPO_DIR}/review-task-${pr_num}.txt" << REVEOF
 # Task: Architectural Review of PR #${pr_num}
 
 You are reviewing PR #${pr_num}: ${title}
@@ -117,6 +118,8 @@ Read these files to understand the architecture:
 - docs/architecture/target.md — target ownership model
 - docs/architecture/component.md — component design rules
 - docs/architecture/decisions.md — recorded decisions (don't conflict with these)
+- docs/architecture/state-machine.md — SM framework rules
+- docs/architecture/hub.md — hub communication rules
 
 ## PR Information
 
@@ -210,6 +213,20 @@ Produce a JSON summary at the end:
 }
 \`\`\`
 
+## Example Violation Comment
+
+When a violation is found, post a GitHub PR comment with this format:
+
+\`\`\`markdown
+## Architecture Violation: [violation type]
+
+**File:** src/components/example.c:42
+**Rule violated:** docs/architecture/[doc].md — "[brief rule summary]"
+**What the code does:** [brief description]
+**Why it violates:** [explanation of the architectural problem]
+**Suggested fix:** [concrete code change or approach]
+\`\`\`
+
 ## Rules
 
 - Be thorough but constructive
@@ -223,7 +240,7 @@ REVEOF
 }
 
 # Main
-cd "$MAIN_REPO"
+cd "$REPO_DIR"
 
 echo "Fetching PR #${PR_NUM} information..."
 PR_INFO=$(get_pr_info)
@@ -286,7 +303,7 @@ if [ -d "../${WORKTREE_NAME}" ]; then
 fi
 
 # Copy task file
-cp "${MAIN_REPO}/review-task-${PR_NUM}.txt" "../${WORKTREE_NAME}/review-task-${PR_NUM}.txt" 2>/dev/null || true
+cp "${REPO_DIR}/review-task-${PR_NUM}.txt" "../${WORKTREE_NAME}/review-task-${PR_NUM}.txt" 2>/dev/null || true
 
 # Create or reuse review tmux session
 if tmux has-session -t ${SESSION_NAME} 2>/dev/null; then
@@ -297,16 +314,20 @@ else
 fi
 
 # Send commands to run the review
-REVIEW_DIR="/home/evgeny/src/suckless/${WORKTREE_NAME}"
+REVIEW_DIR="$REPO_DIR"
 NIX_CMD="cd /home/evgeny/src/suckless && nix develop --command sh -c 'cd ${WORKTREE_NAME} && pi @review-task-${PR_NUM}.txt Review PR #${PR_NUM} architectural violations'"
 
-tmux send-keys -t "${SESSION_NAME}:review" "git fetch origin" Enter
-tmux send-keys -t "${SESSION_NAME}:review" "${NIX_CMD}" Enter
+SESSION_NAME="wm-issues"
+WINDOW_NAME="review-${PR_NUM}"
+
+tmux send-keys -t "${SESSION_NAME}:${WINDOW_NAME}" "git fetch origin" Enter
+tmux send-keys -t "${SESSION_NAME}:${WINDOW_NAME}" "${NIX_CMD}" Enter
 
 echo ""
 echo "Architectural review agent spawned for PR #${PR_NUM}"
 echo "Worktree: ${REVIEW_DIR}"
 echo "Session: ${SESSION_NAME}"
+echo "Window: ${WINDOW_NAME}"
 echo ""
 echo "To attach and monitor: tmux attach -t ${SESSION_NAME}"
 echo "To see results: gh pr view ${PR_NUM} --comments"

--- a/scripts/review-agent.sh
+++ b/scripts/review-agent.sh
@@ -125,7 +125,7 @@ Read these files to understand the architecture:
 
 ### 1. Read the changes
 
-Run: \`git fetch origin && git diff origin/master...origin/${branch} -- '*.c' '*.h'\`
+Run: \`git fetch origin && git diff origin/${BASE}...origin/${BRANCH} -- '*.c' '*.h'\`
 
 Analyze each changed file for architectural violations.
 
@@ -300,7 +300,13 @@ fi
 cp "${REPO_DIR}/review-task-${PR_NUM}.txt" "../${WORKTREE_NAME}/review-task-${PR_NUM}.txt" 2>/dev/null || true
 
 # Create worktree path
-WORKTREE_PATH="${SUCKLESS_ROOT}/${WORKTREE_NAME}"
+if [ "${WORKTREE_NAME}" == "suckless/wm" ]; then
+    # Fallback: use current repo
+    WORKTREE_PATH="${REPO_DIR}"
+    WORKTREE_NAME="wm"
+else
+    WORKTREE_PATH="${SUCKLESS_ROOT}/${WORKTREE_NAME}"
+fi
 
 # Send commands to run the review
 NIX_CMD="cd ${SUCKLESS_ROOT} && nix develop --command sh -c 'cd ${WORKTREE_NAME} && pi @review-task-${PR_NUM}.txt Review PR #${PR_NUM} architectural violations'"

--- a/scripts/review-agent.sh
+++ b/scripts/review-agent.sh
@@ -84,16 +84,6 @@ get_changed_files() {
     git diff "origin/${base}...origin/${branch}" --name-only 2>/dev/null | grep -E '\.(c|h)$' || true
 }
 
-# Check if architecture docs exist
-check_docs() {
-    local doc_path="$1"
-    if [ -f "${MAIN_REPO}/${doc_path}" ]; then
-        echo "1"
-    else
-        echo "0"
-    fi
-}
-
 # Create review task file
 create_review_task() {
     local pr_num="$1"
@@ -305,27 +295,27 @@ fi
 # Copy task file
 cp "${REPO_DIR}/review-task-${PR_NUM}.txt" "../${WORKTREE_NAME}/review-task-${PR_NUM}.txt" 2>/dev/null || true
 
-# Create or reuse review tmux session
-if tmux has-session -t ${SESSION_NAME} 2>/dev/null; then
-    tmux kill-window -t "${SESSION_NAME}:review" 2>/dev/null || true
-    tmux new-window -t ${SESSION_NAME} -n "review" -c "/home/evgeny/src/suckless/${WORKTREE_NAME}"
-else
-    tmux new-session -d -s ${SESSION_NAME} -n "review" -c "/home/evengy/src/suckless/${WORKTREE_NAME}"
-fi
-
 # Send commands to run the review
-REVIEW_DIR="$REPO_DIR"
 NIX_CMD="cd /home/evgeny/src/suckless && nix develop --command sh -c 'cd ${WORKTREE_NAME} && pi @review-task-${PR_NUM}.txt Review PR #${PR_NUM} architectural violations'"
 
 SESSION_NAME="wm-issues"
 WINDOW_NAME="review-${PR_NUM}"
+
+# Ensure session exists with correct window
+if ! tmux has-session -t ${SESSION_NAME} 2>/dev/null; then
+    tmux new-session -d -s ${SESSION_NAME} -n "main" -c "/home/evgeny/src/suckless/${WORKTREE_NAME}"
+fi
+
+# Kill old review window if exists and create new one
+tmux kill-window -t "${SESSION_NAME}:${WINDOW_NAME}" 2>/dev/null || true
+tmux new-window -t ${SESSION_NAME} -n "${WINDOW_NAME}" -c "/home/evgeny/src/suckless/${WORKTREE_NAME}"
 
 tmux send-keys -t "${SESSION_NAME}:${WINDOW_NAME}" "git fetch origin" Enter
 tmux send-keys -t "${SESSION_NAME}:${WINDOW_NAME}" "${NIX_CMD}" Enter
 
 echo ""
 echo "Architectural review agent spawned for PR #${PR_NUM}"
-echo "Worktree: ${REVIEW_DIR}"
+echo "Worktree: /home/evgeny/src/suckless/${WORKTREE_NAME}"
 echo "Session: ${SESSION_NAME}"
 echo "Window: ${WINDOW_NAME}"
 echo ""

--- a/scripts/spawn-agent.sh
+++ b/scripts/spawn-agent.sh
@@ -18,7 +18,9 @@ set -e
 ISSUE_NUM=""
 MODE="new"  # "new", "fix", or "continue"
 GITHUB_REPO="kesor/wm-xcb"
-MAIN_REPO="/home/evgeny/src/suckless/wm"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MAIN_REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+SUCKLESS_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 usage() {
     echo "Usage: $0 <issue_number|PR_number> [--fix|--continue]"
@@ -44,8 +46,11 @@ ISSUE_NUM="$1"
 shift
 
 # Check for mode flags
-if [ "$1" == "--fix" ] || [ "$1" == "--continue" ]; then
+if [ "$1" == "--fix" ]; then
     MODE="fix"
+    shift
+elif [ "$1" == "--continue" ]; then
+    MODE="continue"
     shift
 elif [ "$1" == "--new" ]; then
     MODE="new"
@@ -96,8 +101,9 @@ create_fix_task() {
     local pr_num="$1"
     local title="$2"
     local comments=$(fetch_pr_comments "$pr_num")
+    local task_file="${MAIN_REPO}/${TASK_FILE}"
 
-    cat > "${MAIN_REPO}/${TASK_FILE}" << FIXEOF
+    cat > "${task_file}" << FIXEOF
 # Task: Fix Code Review Comments (PR #${pr_num})
 
 You are fixing code review comments on PR #${pr_num}: ${title}
@@ -188,7 +194,7 @@ if [ "$MODE" == "fix" ] || [ "$MODE" == "continue" ]; then
     # Create fix task with comments (only for fix mode)
     if [ "$MODE" == "fix" ]; then
         create_fix_task "$PR_NUM" "$PR_TITLE"
-    else
+    elif [ "$MODE" == "continue" ]; then
         # --continue mode: use existing task file if available
         if [ -f "${MAIN_REPO}/task-issue-${ISSUE_NUM}.txt" ]; then
             cp "${MAIN_REPO}/task-issue-${ISSUE_NUM}.txt" "../${WORKTREE_NAME}/"
@@ -238,21 +244,22 @@ else
 fi
 
 # Use or create the wm-issues session
+WORKTREE_PATH="${SUCKLESS_ROOT}/${WORKTREE_NAME}"
 if tmux has-session -t wm-issues 2>/dev/null; then
     # Kill existing window with same name if it exists, ignore errors
     tmux kill-window -t "wm-issues:$WINDOW_NAME" 2>/dev/null || true
-    tmux new-window -t wm-issues -n "$WINDOW_NAME" -c "/home/evgeny/src/suckless/${WORKTREE_NAME}"
+    tmux new-window -t wm-issues -n "$WINDOW_NAME" -c "${WORKTREE_PATH}"
 else
-    tmux new-session -d -s wm-issues -n "$WINDOW_NAME" -c "/home/evgeny/src/suckless/${WORKTREE_NAME}"
+    tmux new-session -d -s wm-issues -n "$WINDOW_NAME" -c "${WORKTREE_PATH}"
 fi
 
 # Send commands to the new window
 tmux send-keys -t "wm-issues:$WINDOW_NAME" "git fetch origin && git pull --rebase origin ${BRANCH_NAME}" Enter
 
 # Build pi command - run inside nix develop environment
-# nix develop needs ~/src/suckless (has flake.nix), but worktree is ~/src/suckless/wm-issue-N
+# nix develop needs the root (has flake.nix), but worktree is in subdirectory
 # Use nix develop from parent, then cd to worktree for pi
-NIX_CMD="cd /home/evgeny/src/suckless && nix develop --command sh -c 'cd ${WORKTREE_NAME} && pi "
+NIX_CMD="cd ${SUCKLESS_ROOT} && nix develop --command sh -c 'cd ${WORKTREE_NAME} && pi "
 
 if [ "$MODE" == "fix" ]; then
     # For fixes, use existing task file
@@ -266,7 +273,7 @@ else
     # For new issues, copy template and fill in issue-specific details
     TASK_FILE="task-issue-${ISSUE_NUM}.txt"
     cp "${MAIN_REPO}/scripts/task-template.md" "${MAIN_REPO}/${TASK_FILE}"
-    sed -i "s/{TITLE}/Issue #${ISSUE_NUM}/g" "${MAIN_REPO}/${TASK_FILE}"
+    sed -i "s/{TITLE}/Issue #${ISSUE_NUM}: ${ISSUE_TITLE}/g" "${MAIN_REPO}/${TASK_FILE}"
     sed -i "s/{ISSUE}/${ISSUE_NUM}/g" "${MAIN_REPO}/${TASK_FILE}"
     sed -i "s/{BRANCH_NAME}/${BRANCH_NAME}/g" "${MAIN_REPO}/${TASK_FILE}"
     # Copy to worktree
@@ -282,7 +289,7 @@ else
     echo "Agent spawned for issue #${ISSUE_NUM}"
 fi
 
-echo "Worktree: /home/evgeny/src/suckless/${WORKTREE_NAME}"
+echo "Worktree: ${WORKTREE_PATH}"
 echo "Tmux session: wm-issues"
 echo "Tmux window: $WINDOW_NAME"
 echo ""

--- a/scripts/spawn-agent.sh
+++ b/scripts/spawn-agent.sh
@@ -273,9 +273,14 @@ else
     # For new issues, copy template and fill in issue-specific details
     TASK_FILE="task-issue-${ISSUE_NUM}.txt"
     cp "${MAIN_REPO}/scripts/task-template.md" "${MAIN_REPO}/${TASK_FILE}"
-    sed -i "s/{TITLE}/Issue #${ISSUE_NUM}: ${ISSUE_TITLE}/g" "${MAIN_REPO}/${TASK_FILE}"
+    
+    # Escape special characters for sed replacement
+    ESCAPED_TITLE=$(printf '%s' "Issue #${ISSUE_NUM}: ${ISSUE_TITLE}" | sed 's/[&/\\]/\\&/g')
+    ESCAPED_BRANCH=$(printf '%s' "${BRANCH_NAME}" | sed 's/[&/\\]/\\&/g')
+    
+    sed -i "s/{TITLE}/${ESCAPED_TITLE}/g" "${MAIN_REPO}/${TASK_FILE}"
     sed -i "s/{ISSUE}/${ISSUE_NUM}/g" "${MAIN_REPO}/${TASK_FILE}"
-    sed -i "s/{BRANCH_NAME}/${BRANCH_NAME}/g" "${MAIN_REPO}/${TASK_FILE}"
+    sed -i "s/{BRANCH_NAME}/${ESCAPED_BRANCH}/g" "${MAIN_REPO}/${TASK_FILE}"
     # Copy to worktree
     cp "${MAIN_REPO}/${TASK_FILE}" "../${WORKTREE_NAME}/${TASK_FILE}"
 

--- a/scripts/task-template.md
+++ b/scripts/task-template.md
@@ -1,4 +1,4 @@
-# Task: Work on GitHub issue #{ISSUE}
+# Task: {TITLE}
 
 ## IMPORTANT
 


### PR DESCRIPTION
## Summary

Fixes all review comments from PRs #101 and #102.

## Changes

### scripts/review-agent.sh
- Remove hardcoded paths, use `SCRIPT_DIR`/`REPO_DIR`/`SUCKLESS_ROOT` variables
- Fix git fetch refspecs to not pollute local branches
- Fix BASE vs master: diff against actual base branch
- Fix tmux working directory paths to use variables

### scripts/spawn-agent.sh
- Remove hardcoded paths, use `SCRIPT_DIR`/`REPO_DIR`/`SUCKLESS_ROOT` variables
- Fix `--continue` mode parsing (was incorrectly setting `MODE="fix"`)
- Fix tmux working directory paths to use variables

### scripts/task-template.md
- Add `{TITLE}` placeholder for issue title substitution

## Review Comment Fixes

- Fixed `git fetch` refspecs that were creating local branches
- Fixed diffing against actual base branch instead of hardcoded `master`
- Fixed `--continue` flag to properly set `MODE="continue"` instead of `"fix"`
- Added missing `{TITLE}` placeholder to template
- Fixed typo in path (`/home/evengy/` → variable-based path)
- Consolidated tmux session creation patterns